### PR TITLE
refactor(frontend): update mock and default services for esdc branch

### DIFF
--- a/frontend/app/.server/domain/services/branch-service-default.ts
+++ b/frontend/app/.server/domain/services/branch-service-default.ts
@@ -35,7 +35,7 @@ export function getDefaultBranchService(): BranchService {
         return Ok(data);
       } catch (error) {
         return Err(
-          new AppError(`Unexpected error occurred while fetching branches: ${String(error)}`, ErrorCodes.VACMAN_API_ERROR),
+          new AppError(`Unexpected error occurred while fetching ESDC Branches: ${String(error)}`, ErrorCodes.VACMAN_API_ERROR),
         );
       }
     },
@@ -44,8 +44,7 @@ export function getDefaultBranchService(): BranchService {
      * Retrieves a single branch by its ID.
      *
      * @param id The ID of the branch to retrieve.
-     * @returns The branch object if found.
-     * @throws {AppError} If the branch is not found or if the request fails or if the server responds with an error status.
+     * @returns The branch object if found or {AppError} If the branch is not found or if the request fails or if the server responds with an error status.
      */
 
     async getById(id: string): Promise<Result<Branch, AppError>> {
@@ -69,7 +68,10 @@ export function getDefaultBranchService(): BranchService {
         return Ok(data);
       } catch (error) {
         return Err(
-          new AppError(`Unexpected error occurred while fetching branch by ID: ${String(error)}`, ErrorCodes.VACMAN_API_ERROR),
+          new AppError(
+            `Unexpected error occurred while fetching ESDC Branch by ID: ${String(error)}`,
+            ErrorCodes.VACMAN_API_ERROR,
+          ),
         );
       }
     },

--- a/frontend/app/.server/domain/services/branch-service-default.ts
+++ b/frontend/app/.server/domain/services/branch-service-default.ts
@@ -101,7 +101,7 @@ export function getDefaultBranchService(): BranchService {
      * @throws AppError if the request fails or if the server responds with an error status.
      */
 
-    async getLocalized(language: Language): Promise<Result<readonly LocalizedBranch[], AppError>> {
+    async getAllLocalized(language: Language): Promise<Result<readonly LocalizedBranch[], AppError>> {
       const result = await getDefaultBranchService().getAll();
 
       return result.map((branches) =>

--- a/frontend/app/.server/domain/services/branch-service-default.ts
+++ b/frontend/app/.server/domain/services/branch-service-default.ts
@@ -1,3 +1,6 @@
+import type { Result, Option } from 'oxide.ts';
+import { Some, None, Ok, Err } from 'oxide.ts';
+
 import type { Branch, LocalizedBranch } from '~/.server/domain/models';
 import type { BranchService } from '~/.server/domain/services/branch-service';
 import { serverEnvironment } from '~/.server/environment';
@@ -14,15 +17,27 @@ export function getDefaultBranchService(): BranchService {
      * @returns An array of esdc branch objects.
      * @throws AppError if the request fails or if the server responds with an error status.
      */
-    async getBranches(): Promise<readonly Branch[]> {
-      const response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}/branches`);
 
-      if (!response.ok) {
-        const errorMessage = `Failed to retrieve all ESDC Branches. Server responded with status ${response.status}.`;
-        throw new AppError(errorMessage, ErrorCodes.VACMAN_API_ERROR);
+    async getAll(): Promise<Result<readonly Branch[], AppError>> {
+      try {
+        const response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}/branches`);
+
+        if (!response.ok) {
+          return Err(
+            new AppError(
+              `Failed to retrieve all ESDC Branches. Server responded with status ${response.status}.`,
+              ErrorCodes.VACMAN_API_ERROR,
+            ),
+          );
+        }
+
+        const data: Branch[] = await response.json();
+        return Ok(data);
+      } catch (error) {
+        return Err(
+          new AppError(`Unexpected error occurred while fetching branches: ${String(error)}`, ErrorCodes.VACMAN_API_ERROR),
+        );
       }
-
-      return await response.json();
     },
 
     /**
@@ -32,19 +47,50 @@ export function getDefaultBranchService(): BranchService {
      * @returns The branch object if found.
      * @throws {AppError} If the branch is not found or if the request fails or if the server responds with an error status.
      */
-    async getBranchById(id: string): Promise<Branch | undefined> {
-      const response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}/branches/${id}`);
 
-      if (response.status === HttpStatusCodes.NOT_FOUND) {
-        return undefined;
+    async getById(id: string): Promise<Result<Branch, AppError>> {
+      try {
+        const response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}/branches/${id}`);
+
+        if (response.status === HttpStatusCodes.NOT_FOUND) {
+          return Err(new AppError(`Branch with ID '${id}' not found.`, ErrorCodes.NO_BRANCH_FOUND));
+        }
+
+        if (!response.ok) {
+          return Err(
+            new AppError(
+              `Failed to find the ESDC Branch with ID '${id}'. Server responded with status ${response.status}.`,
+              ErrorCodes.VACMAN_API_ERROR,
+            ),
+          );
+        }
+
+        const data: Branch = await response.json();
+        return Ok(data);
+      } catch (error) {
+        return Err(
+          new AppError(`Unexpected error occurred while fetching branch by ID: ${String(error)}`, ErrorCodes.VACMAN_API_ERROR),
+        );
+      }
+    },
+
+    /**
+     * Retrieves a single branch by its ID.
+     *
+     * @param id The ID of the branch to retrieve.
+     * @returns The branch object if found or undefined if not found.
+     * @throws {AppError} If the request fails or if the server responds with an error status.
+     */
+
+    async findById(id: string): Promise<Option<Branch>> {
+      const result = await getDefaultBranchService().getAll();
+
+      if (result.isErr()) {
+        return None;
       }
 
-      if (!response.ok) {
-        const errorMessage = `Failed to find the ESDC Branch with ID '${id}'. Server responded with status ${response.status}.`;
-        throw new AppError(errorMessage, ErrorCodes.VACMAN_API_ERROR);
-      }
-
-      return await response.json();
+      const found = result.unwrap().find((branch) => branch.id === id);
+      return found ? Some(found) : None;
     },
 
     /**
@@ -54,12 +100,16 @@ export function getDefaultBranchService(): BranchService {
      * @returns An array of localized branch objects.
      * @throws AppError if the request fails or if the server responds with an error status.
      */
-    async getLocalizedBranches(language: Language): Promise<readonly LocalizedBranch[]> {
-      const response = await getDefaultBranchService().getBranches();
-      return response.map((option) => ({
-        id: option.id,
-        name: language === 'fr' ? option.nameFr : option.nameEn,
-      }));
+
+    async getLocalized(language: Language): Promise<Result<readonly LocalizedBranch[], AppError>> {
+      const result = await getDefaultBranchService().getAll();
+
+      return result.map((branches) =>
+        branches.map((branch) => ({
+          id: branch.id,
+          name: language === 'fr' ? branch.nameFr : branch.nameEn,
+        })),
+      );
     },
 
     /**
@@ -68,11 +118,16 @@ export function getDefaultBranchService(): BranchService {
      * @param id The ID of the branch to retrieve.
      * @param language The language to localize the branch name to.
      * @returns The localized branch object if found.
-     * @throws AppError if the request fails or if the server responds with an error status.
+     * @throws {AppError} If the branch is not found or if the request fails or if the server responds with an error status.
      */
-    async getLocalizedBranchById(id: string, language: Language): Promise<LocalizedBranch | undefined> {
-      const response = await getDefaultBranchService().getLocalizedBranches(language);
-      return response.find((l) => l.id === id);
+
+    async getLocalizedById(id: string, language: Language): Promise<Result<LocalizedBranch, AppError>> {
+      const result = await getDefaultBranchService().getById(id);
+
+      return result.map((branch) => ({
+        id: branch.id,
+        name: language === 'fr' ? branch.nameFr : branch.nameEn,
+      }));
     },
   };
 }

--- a/frontend/app/.server/domain/services/branch-service-mock.ts
+++ b/frontend/app/.server/domain/services/branch-service-mock.ts
@@ -36,8 +36,7 @@ function getAll(): Result<readonly Branch[], AppError> {
  * Retrieves a single branch by its ID.
  *
  * @param id The ID of the branch to retrieve.
- * @returns The branch object if found.
- * @throws {AppError} If the branch is not found.
+ * @returns The branch object if found or {AppError} If the branch is not found.
  */
 function getById(id: string): Result<Branch, AppError> {
   const result = getAll();
@@ -49,7 +48,7 @@ function getById(id: string): Result<Branch, AppError> {
   const branches = result.unwrap();
   const branch = branches.find((p) => p.id === id);
 
-  return branch ? Ok(branch) : Err(new AppError(`Localized branch with ID '${id}' not found.`, ErrorCodes.NO_BRANCH_FOUND));
+  return branch ? Ok(branch) : Err(new AppError(`Branch with ID '${id}' not found.`, ErrorCodes.NO_BRANCH_FOUND));
 }
 
 /**
@@ -92,8 +91,7 @@ function getAllLocalized(language: Language): Result<readonly LocalizedBranch[],
  *
  * @param id The ID of the branch to retrieve.
  * @param language The language to localize the branch name to.
- * @returns The localized branch object if found.
- * @throws {AppError} If the branch is not found.
+ * @returns The localized branch object if found or {AppError} If the branch is not found.
  */
 function getLocalizedById(id: string, language: Language): Result<LocalizedBranch, AppError> {
   return getAllLocalized(language).andThen((branches) => {

--- a/frontend/app/.server/domain/services/branch-service-mock.ts
+++ b/frontend/app/.server/domain/services/branch-service-mock.ts
@@ -12,7 +12,7 @@ export function getMockBranchService(): BranchService {
     getAll: () => Promise.resolve(getAll()),
     getById: (id: string) => Promise.resolve(getById(id)),
     findById: (id: string) => Promise.resolve(findById(id)),
-    getLocalized: (language: Language) => Promise.resolve(getLocalized(language)),
+    getAllLocalized: (language: Language) => Promise.resolve(getAllLocalized(language)),
     getLocalizedById: (id: string, language: Language) => Promise.resolve(getLocalizedById(id, language)),
   };
 }
@@ -76,7 +76,7 @@ function findById(id: string): Option<Branch> {
  * @param language The language to localize the branch names to.
  * @returns An array of localized branch objects.
  */
-function getLocalized(language: Language): Result<readonly LocalizedBranch[], AppError> {
+function getAllLocalized(language: Language): Result<readonly LocalizedBranch[], AppError> {
   return getAll().map((branches) =>
     branches
       .map((branch) => ({
@@ -96,7 +96,7 @@ function getLocalized(language: Language): Result<readonly LocalizedBranch[], Ap
  * @throws {AppError} If the branch is not found.
  */
 function getLocalizedById(id: string, language: Language): Result<LocalizedBranch, AppError> {
-  return getLocalized(language).andThen((branches) => {
+  return getAllLocalized(language).andThen((branches) => {
     const branch = branches.find((b) => b.id === id);
 
     return branch ? Ok(branch) : Err(new AppError(`Localized branch with ID '${id}' not found.`, ErrorCodes.NO_BRANCH_FOUND));

--- a/frontend/app/.server/domain/services/branch-service.ts
+++ b/frontend/app/.server/domain/services/branch-service.ts
@@ -10,7 +10,7 @@ export type BranchService = {
   getAll(): Promise<Result<readonly Branch[], AppError>>;
   getById(id: string): Promise<Result<Branch, AppError>>;
   findById(id: string): Promise<Option<Branch>>;
-  getLocalized(language: Language): Promise<Result<readonly LocalizedBranch[], AppError>>;
+  getAllLocalized(language: Language): Promise<Result<readonly LocalizedBranch[], AppError>>;
   getLocalizedById(id: string, language: Language): Promise<Result<LocalizedBranch, AppError>>;
 };
 

--- a/frontend/app/.server/domain/services/branch-service.ts
+++ b/frontend/app/.server/domain/services/branch-service.ts
@@ -1,13 +1,17 @@
+import type { Result, Option } from 'oxide.ts';
+
 import type { Branch, LocalizedBranch } from '~/.server/domain/models';
 import { getDefaultBranchService } from '~/.server/domain/services/branch-service-default';
 import { getMockBranchService } from '~/.server/domain/services/branch-service-mock';
 import { serverEnvironment } from '~/.server/environment';
+import type { AppError } from '~/errors/app-error';
 
 export type BranchService = {
-  getBranches(): Promise<readonly Branch[]>;
-  getBranchById(id: string): Promise<Branch | undefined>;
-  getLocalizedBranches(language: Language): Promise<readonly LocalizedBranch[]>;
-  getLocalizedBranchById(id: string, language: Language): Promise<LocalizedBranch | undefined>;
+  getAll(): Promise<Result<readonly Branch[], AppError>>;
+  getById(id: string): Promise<Result<Branch, AppError>>;
+  findById(id: string): Promise<Option<Branch>>;
+  getLocalized(language: Language): Promise<Result<readonly LocalizedBranch[], AppError>>;
+  getLocalizedById(id: string, language: Language): Promise<Result<LocalizedBranch, AppError>>;
 };
 
 export function getBranchService(): BranchService {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,6 +62,7 @@
     "minimatch": "^10.0.1",
     "morgan": "^1.10.0",
     "oauth4webapi": "^3.5.1",
+    "oxide.ts": "^1.1.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-i18next": "^15.5.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       oauth4webapi:
         specifier: ^3.5.1
         version: 3.5.1
+      oxide.ts:
+        specifier: ^1.1.0
+        version: 1.1.0
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -3813,6 +3816,9 @@ packages:
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
+
+  oxide.ts@1.1.0:
+    resolution: {integrity: sha512-+MkqFRQVHEe/x4/cJ6KuYz2m2VpnoBi7aKLbttGYTxmpNZalQ2RbKH2HxyfsTqXJhjh9DYxulPWfQV/hWMmzCg==}
 
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -8962,6 +8968,8 @@ snapshots:
       get-intrinsic: 1.3.0
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
+
+  oxide.ts@1.1.0: {}
 
   p-limit@3.1.0:
     dependencies:

--- a/frontend/tests/.server/domain/services/branch-service-default.test.ts
+++ b/frontend/tests/.server/domain/services/branch-service-default.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { getDefaultBranchService } from '~/.server/domain/services/branch-service-default';
+import { AppError } from '~/errors/app-error';
+import { HttpStatusCodes } from '~/errors/http-status-codes';
+
+const mockBranches = [
+  { id: '1', nameEn: 'Branch One', nameFr: 'Branche Un' },
+  { id: '2', nameEn: 'Branch Two', nameFr: 'Branche Deux' },
+];
+
+const service = getDefaultBranchService();
+
+beforeEach(() => {
+  global.fetch = vi.fn() as unknown as typeof fetch;
+});
+
+describe('getDefaultBranchService', () => {
+  it('getAll should return branches on success', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => mockBranches,
+    });
+
+    const result = await service.getAll();
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()).toEqual(mockBranches);
+  });
+
+  it('getAll should return error on failure', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    });
+
+    const result = await service.getAll();
+    expect(result.isErr()).toBe(true);
+    expect(result.unwrapErr()).toBeInstanceOf(AppError);
+  });
+
+  it('getById should return a branch if found', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => mockBranches[0],
+    });
+
+    const result = await service.getById('1');
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap().id).toBe('1');
+  });
+
+  it('getById should return not found error', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: HttpStatusCodes.NOT_FOUND,
+    });
+
+    const result = await service.getById('999');
+    expect(result.isErr()).toBe(true);
+    expect(result.unwrapErr()).toBeInstanceOf(AppError);
+  });
+
+  it('findById should return Some if branch exists', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => mockBranches,
+    });
+
+    const result = await service.findById('1');
+    expect(result.isSome()).toBe(true);
+    expect(result.unwrap().id).toBe('1');
+  });
+
+  it('findById should return None if branch does not exist', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => mockBranches,
+    });
+
+    const result = await service.findById('999');
+    expect(result.isNone()).toBe(true);
+  });
+
+  it('getLocalized should return localized branches in English', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => mockBranches,
+    });
+
+    const result = await service.getLocalized('en');
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap()[0]?.name).toBe('Branch One');
+  });
+
+  it('getLocalizedById should return localized branch', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => mockBranches[0],
+    });
+
+    const result = await service.getLocalizedById('1', 'fr');
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap().name).toBe('Branche Un');
+  });
+});

--- a/frontend/tests/.server/domain/services/branch-service-default.test.ts
+++ b/frontend/tests/.server/domain/services/branch-service-default.test.ts
@@ -87,7 +87,7 @@ describe('getDefaultBranchService', () => {
       json: () => mockBranches,
     });
 
-    const result = await service.getLocalized('en');
+    const result = await service.getAllLocalized('en');
     expect(result.isOk()).toBe(true);
     expect(result.unwrap()[0]?.name).toBe('Branch One');
   });

--- a/frontend/tests/.server/domain/services/branch-service-mock.test.ts
+++ b/frontend/tests/.server/domain/services/branch-service-mock.test.ts
@@ -60,7 +60,7 @@ describe('getMockBranchService', () => {
   });
 
   it('should return localized branches in English', async () => {
-    const result = await service.getLocalized('en' as Language);
+    const result = await service.getAllLocalized('en' as Language);
     expect(result.isOk()).toBe(true);
     const localized = result.unwrap();
     expect(localized.length).toBeGreaterThan(0);
@@ -68,14 +68,14 @@ describe('getMockBranchService', () => {
   });
 
   it('should return localized branches in French', async () => {
-    const result = await service.getLocalized('fr' as Language);
+    const result = await service.getAllLocalized('fr' as Language);
     expect(result.isOk()).toBe(true);
     const localized = result.unwrap();
     expect(localized[0]).toHaveProperty('name');
   });
 
   it('should return a localized branch by ID', async () => {
-    const localized = await service.getLocalized('en' as Language);
+    const localized = await service.getAllLocalized('en' as Language);
     const localizedBranches = localized.unwrap();
     const first = localizedBranches[0];
     if (!first) {

--- a/frontend/tests/.server/domain/services/branch-service-mock.test.ts
+++ b/frontend/tests/.server/domain/services/branch-service-mock.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+
+import { getMockBranchService } from '~/.server/domain/services/branch-service-mock';
+import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
+
+const service = getMockBranchService();
+
+describe('getMockBranchService', () => {
+  it('should return all mock branches data', async () => {
+    const result = await service.getAll();
+    expect(result.isOk()).toBe(true);
+    const branches = result.unwrap();
+    expect(Array.isArray(branches)).toBe(true);
+    expect(branches.length).toBeGreaterThan(0);
+  });
+
+  it('should return a branch by ID', async () => {
+    const all = await service.getAll();
+    expect(all.isOk()).toBe(true);
+
+    const branches = all.unwrap();
+    expect(branches.length).toBeGreaterThan(0);
+
+    const first = branches[0];
+    if (!first) {
+      throw new Error('Expected at least one branch in the list');
+    }
+
+    const result = await service.getById(first.id);
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap().id).toBe(first.id);
+  });
+
+  it('should return error if branch ID not found', async () => {
+    const result = await service.getById('non-existent-id');
+    expect(result.isErr()).toBe(true);
+
+    const err = result.unwrapErr();
+    expect(err).toBeInstanceOf(AppError);
+    expect((err as AppError).msg).toContain('not found');
+  });
+
+  it('should find a branch by ID using Option', async () => {
+    const all = await service.getAll();
+    const branches = all.unwrap();
+    const first = branches[0];
+    if (!first) {
+      throw new AppError('Expected at least one branch in the list');
+    }
+
+    const result = await service.findById(first.id);
+    expect(result.isSome()).toBe(true);
+    expect(result.unwrap().id).toBe(first.id);
+  });
+
+  it('should return None if branch not found using Option', async () => {
+    const result = await service.findById('non-existent-id');
+    expect(result.isNone()).toBe(true);
+  });
+
+  it('should return localized branches in English', async () => {
+    const result = await service.getLocalized('en' as Language);
+    expect(result.isOk()).toBe(true);
+    const localized = result.unwrap();
+    expect(localized.length).toBeGreaterThan(0);
+    expect(localized[0]).toHaveProperty('name');
+  });
+
+  it('should return localized branches in French', async () => {
+    const result = await service.getLocalized('fr' as Language);
+    expect(result.isOk()).toBe(true);
+    const localized = result.unwrap();
+    expect(localized[0]).toHaveProperty('name');
+  });
+
+  it('should return a localized branch by ID', async () => {
+    const localized = await service.getLocalized('en' as Language);
+    const localizedBranches = localized.unwrap();
+    const first = localizedBranches[0];
+    if (!first) {
+      throw new AppError('Expected at least one branch in the list');
+    }
+
+    const result = await service.getLocalizedById(first.id, 'en' as Language);
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap().id).toBe(first.id);
+  });
+
+  it('should return error if localized branch ID not found', async () => {
+    const result = await service.getLocalizedById('non-existent-id', 'en' as Language);
+    expect(result.isErr()).toBe(true);
+    expect(result.unwrapErr().errorCode).toBe(ErrorCodes.NO_BRANCH_FOUND);
+  });
+});


### PR DESCRIPTION
## Summary

[AB#6133](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6133)
[AB#6152](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6152)
- added [oxide](https://www.npmjs.com/package/oxide.ts) package to return `Option ` with `find` and `Result` with `get`
- update mock service and default service for ESDC branch
- added tests for mock and default services

## Types of changes

What types of changes does this PR introduce?

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>
