### PR TITLE
feat(frontend): add cancel button on personal information screen

### DIFF
--- a/frontend/app/.server/locales/app-en.json
+++ b/frontend/app/.server/locales/app-en.json
@@ -37,6 +37,7 @@
     "back": "Back to profile"
   },
   "form": {
+    "cancel": "Cancel",
     "save": "Save",
     "submit": "Submit"
   },

--- a/frontend/app/.server/locales/app-fr.json
+++ b/frontend/app/.server/locales/app-fr.json
@@ -37,6 +37,7 @@
     "back": "Retour au profil"
   },
   "form": {
+    "cancel": "Annuler",
     "save": "Enregistrer",
     "submit": "Soumettre"
   },

--- a/frontend/app/components/button-link.tsx
+++ b/frontend/app/components/button-link.tsx
@@ -17,7 +17,7 @@ const sizes = {
 
 // prettier-ignore
 const variants = {
-  alternative: 'border-gray-200 bg-white text-gray-900 hover:bg-gray-100 hover:text-blue-700 focus:bg-gray-100 focus:text-blue-700',
+  alternative: 'border-gray-900 bg-white text-gray-900 hover:bg-gray-100 hover:text-blue-700 focus:bg-gray-100 focus:text-blue-700',
   default: 'border-gray-300 bg-gray-200 text-slate-700 hover:bg-neutral-300 focus:bg-neutral-300',
   dark: 'border-gray-800 bg-gray-800 text-white hover:bg-gray-900 focus:bg-gray-900',
   green: 'border-green-700 bg-green-700 text-white hover:bg-green-800 focus:bg-green-800',

--- a/frontend/app/components/button.tsx
+++ b/frontend/app/components/button.tsx
@@ -16,7 +16,7 @@ const sizes = {
 
 // prettier-ignore
 const variants = {
-  alternative: 'border-gray-200 bg-white text-gray-900 hover:bg-gray-100 hover:text-blue-700 focus:bg-gray-100 focus:text-blue-700',
+  alternative: 'border-gray-900 bg-white text-gray-900 hover:bg-gray-100 hover:text-blue-700 focus:bg-gray-100 focus:text-blue-700',
   default: 'border-gray-300 bg-gray-200 text-slate-700 hover:bg-neutral-300 focus:bg-neutral-300',
   dark: 'border-gray-800 bg-gray-800 text-white hover:bg-gray-900 focus:bg-gray-900',
   green: 'border-green-700 bg-green-700 text-white hover:bg-green-800 focus:bg-green-800',

--- a/frontend/app/routes/profile/personal-information.tsx
+++ b/frontend/app/routes/profile/personal-information.tsx
@@ -11,6 +11,7 @@ import { getLanguageForCorrespondenceService } from '~/.server/domain/services/l
 import { requireAllRoles } from '~/.server/utils/auth-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { Button } from '~/components/button';
+import { ButtonLink } from '~/components/button-link';
 import { ActionDataErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
 import { InputPhoneField } from '~/components/input-phone-field';
@@ -177,9 +178,14 @@ export default function PersonalInformation({ loaderData, actionData, params }: 
                 helpMessage={t('app:personal-information.additional-info-help-message')}
                 maxLength={100}
               />
-              <Button className="px-12" name="action" variant="primary" id="save-button">
-                {t('app:form.save')}
-              </Button>
+              <div className="mt-8 grid grid-cols-1 place-items-start gap-6">
+                <Button className="w-30" name="action" variant="primary" id="save-button">
+                  {t('app:form.save')}
+                </Button>
+                <ButtonLink className="w-30" file="routes/profile/index.tsx" id="cancel-button" variant="alternative">
+                  {t('app:form.cancel')}
+                </ButtonLink>
+              </div>
             </div>
           </Form>
         </ActionDataErrorSummary>


### PR DESCRIPTION
## Summary

[AB#6229](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6229)
 add cancel button on personal information screen as shown in figma.

## Types of changes

What types of changes does this PR introduce?

- [x] ✨ **new feature** -- non-breaking change that adds functionality

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.

- [x] code has been linted and formatted locally

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/0abea498-34f6-4004-8926-32f6ce52084f)
![image](https://github.com/user-attachments/assets/420c1c7c-5350-4136-869c-a6e2599f835a)
