### PR TITLE
refactor(frontend): update preferred language of correspondence service

### DIFF
--- a/frontend/app/.server/domain/services/branch-service-default.ts
+++ b/frontend/app/.server/domain/services/branch-service-default.ts
@@ -14,8 +14,7 @@ export function getDefaultBranchService(): BranchService {
     /**
      * Retrieves a list of all esdc branches.
      *
-     * @returns An array of esdc branch objects.
-     * @throws AppError if the request fails or if the server responds with an error status.
+     * @returns An array of esdc branch objects or {AppError} if the request fails or if the server responds with an error status.
      */
 
     async getAll(): Promise<Result<readonly Branch[], AppError>> {
@@ -81,7 +80,6 @@ export function getDefaultBranchService(): BranchService {
      *
      * @param id The ID of the branch to retrieve.
      * @returns The branch object if found or undefined if not found.
-     * @throws {AppError} If the request fails or if the server responds with an error status.
      */
 
     async findById(id: string): Promise<Option<Branch>> {
@@ -99,8 +97,7 @@ export function getDefaultBranchService(): BranchService {
      * Retrieves a list of branches localized to the specified language.
      *
      * @param language The language to localize the branch names to.
-     * @returns An array of localized branch objects.
-     * @throws AppError if the request fails or if the server responds with an error status.
+     * @returns An array of localized branch objects or {AppError} if the request fails or if the server responds with an error status.
      */
 
     async getAllLocalized(language: Language): Promise<Result<readonly LocalizedBranch[], AppError>> {
@@ -119,8 +116,7 @@ export function getDefaultBranchService(): BranchService {
      *
      * @param id The ID of the branch to retrieve.
      * @param language The language to localize the branch name to.
-     * @returns The localized branch object if found.
-     * @throws {AppError} If the branch is not found or if the request fails or if the server responds with an error status.
+     * @returns The localized branch object if found or {AppError} If the branch is not found or if the request fails or if the server responds with an error status.
      */
 
     async getLocalizedById(id: string, language: Language): Promise<Result<LocalizedBranch, AppError>> {

--- a/frontend/app/.server/domain/services/language-for-correspondence-service.ts
+++ b/frontend/app/.server/domain/services/language-for-correspondence-service.ts
@@ -1,16 +1,17 @@
+import type { Result, Option } from 'oxide.ts';
+
 import type { LanguageOfCorrespondence, LocalizedLanguageOfCorrespondence } from '~/.server/domain/models';
 import { getDefaultLanguageForCorrespondenceService } from '~/.server/domain/services/language-for-correspondence-service-default';
 import { getMockLanguageForCorrespondenceService } from '~/.server/domain/services/language-for-correspondence-service-mock';
 import { serverEnvironment } from '~/.server/environment';
+import type { AppError } from '~/errors/app-error';
 
 export type LanguageForCorrespondenceService = {
-  getLanguagesOfCorrespondence(): Promise<readonly LanguageOfCorrespondence[]>;
-  getLanguageOfCorrespondenceById(id: string): Promise<LanguageOfCorrespondence | undefined>;
-  getLocalizedLanguageOfCorrespondence(language: Language): Promise<readonly LocalizedLanguageOfCorrespondence[]>;
-  getLocalizedLanguageOfCorrespondenceById(
-    id: string,
-    language: Language,
-  ): Promise<LocalizedLanguageOfCorrespondence | undefined>;
+  getAll(): Promise<Result<readonly LanguageOfCorrespondence[], AppError>>;
+  getById(id: string): Promise<Result<LanguageOfCorrespondence, AppError>>;
+  findById(id: string): Promise<Option<LanguageOfCorrespondence>>;
+  getAllLocalized(language: Language): Promise<Result<readonly LocalizedLanguageOfCorrespondence[], AppError>>;
+  getLocalizedById(id: string, language: Language): Promise<Result<LocalizedLanguageOfCorrespondence, AppError>>;
 };
 
 export function getLanguageForCorrespondenceService(): LanguageForCorrespondenceService {

--- a/frontend/app/routes/profile/personal-information.tsx
+++ b/frontend/app/routes/profile/personal-information.tsx
@@ -62,8 +62,8 @@ export async function action({ context, params, request }: Route.ActionArgs) {
 export async function loader({ context, request }: Route.LoaderArgs) {
   requireAllRoles(context.session, new URL(request.url), ['employee']);
   const { lang, t } = await getTranslation(request, handle.i18nNamespace);
-  const allLocalizedEducationLevels = await getEducationLevelService().getAllLocalized(lang);
-  const localizedEducationLevels = allLocalizedEducationLevels.unwrap();
+  const localizedEducationLevels = await getEducationLevelService().getAllLocalized(lang);
+  const localizedLanguagesOfCorrespondance = await getLanguageForCorrespondenceService().getAllLocalized(lang);
 
   return {
     documentTitle: t('app:personal-information.page-title'),
@@ -78,8 +78,8 @@ export async function loader({ context, request }: Route.LoaderArgs) {
       personalPhone: undefined,
       education: undefined as string | undefined,
     },
-    languagesOfCorrespondence: await getLanguageForCorrespondenceService().getLocalizedLanguageOfCorrespondence(lang),
-    education: localizedEducationLevels,
+    languagesOfCorrespondence: localizedLanguagesOfCorrespondance.unwrap(),
+    education: localizedEducationLevels.unwrap(),
   };
 }
 

--- a/frontend/app/routes/profile/validation.server.ts
+++ b/frontend/app/routes/profile/validation.server.ts
@@ -6,7 +6,8 @@ import { getLanguageForCorrespondenceService } from '~/.server/domain/services/l
 import { isValidPhone } from '~/utils/phone-utils';
 import { REGEX_PATTERNS } from '~/utils/regex-utils';
 
-const languagesOfCorrespondence = await getLanguageForCorrespondenceService().getLanguagesOfCorrespondence();
+const allLanguagesOfCorrespondance = await getLanguageForCorrespondenceService().getAll();
+const languagesOfCorrespondence = allLanguagesOfCorrespondance.unwrap();
 const allEducationLevels = await getEducationLevelService().getAll();
 const educationLevels = allEducationLevels.unwrap();
 


### PR DESCRIPTION
## Summary

[AB#6133](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6133)
[AB#6206](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6206)

- update mock service and default service for preferred language of correspondence service to use [oxide](https://www.npmjs.com/package/oxide.ts) package to return Option with find and Result with get
- update Personal information page to consume data coming from preferred language of correspondence service


## Types of changes

What types of changes does this PR introduce?

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.

- [x] code has been linted and formatted locally

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>