### PR TITLE
refactor(language-switcher): prevent page reload when switching languages

### DIFF
--- a/frontend/app/components/language-switcher.tsx
+++ b/frontend/app/components/language-switcher.tsx
@@ -2,6 +2,8 @@ import type { ComponentProps } from 'react';
 
 import { useLocation, useParams } from 'react-router';
 
+import { useTranslation } from 'react-i18next';
+
 import { InlineLink } from '~/components/links';
 import { useLanguage } from '~/hooks/use-language';
 import { useRoute } from '~/hooks/use-route';
@@ -15,6 +17,7 @@ type LanguageSwitcherProps = OmitStrict<
 
 export function LanguageSwitcher({ className, children, ...props }: LanguageSwitcherProps) {
   const { altLanguage } = useLanguage();
+  const { i18n } = useTranslation(['gcweb', 'app']);
   const { search } = useLocation();
   const { file } = useRoute();
   const params = useParams();
@@ -24,8 +27,12 @@ export function LanguageSwitcher({ className, children, ...props }: LanguageSwit
       className={cn('text-slate-700 sm:text-lg', className)}
       file={file as I18nRouteFile}
       lang={altLanguage}
+      onClick={async () => {
+        // Match the i18n language to the route change
+        await i18n.changeLanguage(altLanguage);
+      }}
       params={params}
-      reloadDocument={true}
+      reloadDocument={false}
       search={search}
       {...props}
     >


### PR DESCRIPTION
[AB#6207](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6207)

This pull request updates the `LanguageSwitcher` component in `frontend/app/components/language-switcher.tsx` to enhance language-switching functionality by integrating the `i18next` library and improving the user experience. The changes primarily focus on synchronizing the application's language state with route changes and optimizing the reload behavior.

### Enhancements to language-switching functionality:
* Added `useTranslation` import from `react-i18next` to enable language management within the component.
* Integrated `i18n.changeLanguage` from `react-i18next` to dynamically update the language when the user switches languages. This ensures the application's language state matches the route change. [[1]](diffhunk://#diff-5a4ca5b528aaf8411c9cb8f6c6ba138f324ef5ae6d39537f8c6a6c2e204e78a9R20) [[2]](diffhunk://#diff-5a4ca5b528aaf8411c9cb8f6c6ba138f324ef5ae6d39537f8c6a6c2e204e78a9R30-R35)

### Optimizations to reload behavior:
* Modified the `reloadDocument` property from `true` to `false` to prevent unnecessary page reloads during language switches, improving user experience.