### PR TITLE
feat(frontend): add fields for substantive position on Employment information screen

### DIFF
--- a/frontend/app/.server/locales/app-en.ts
+++ b/frontend/app/.server/locales/app-en.ts
@@ -38,9 +38,10 @@ export default {
     'back': 'Back to profile',
   },
   'form': {
-    cancel: 'Cancel',
-    save: 'Save',
-    submit: 'Submit',
+    'cancel': 'Cancel',
+    'save': 'Save',
+    'submit': 'Submit',
+    'select-option': 'Select option',
   },
   'personal-information': {
     'page-title': 'Personal information',
@@ -86,8 +87,7 @@ export default {
     'wfa-end-date': 'End date of your WFA status (if applicable)',
     'hr-advisor': 'HR advisor identified on your WFA letter',
     'errors': {
-      'substantive-group-required': 'Substantive group is required.',
-      'substantive-level-required': 'Substantive level is required.',
+      'substantive-group-and-level-required': 'Group and level of your substantive position is required.',
       'branch-or-service-canada-region-required': 'Branch or Service Canada Region is required.',
       'directorate-required': 'Directorate is required.',
       'provinces-required': 'Province of the designated work location is required.',

--- a/frontend/app/.server/locales/app-fr.ts
+++ b/frontend/app/.server/locales/app-fr.ts
@@ -40,9 +40,10 @@ export default {
     'back': 'Retour au profil',
   },
   'form': {
-    cancel: 'Annuler',
-    save: 'Enregistrer',
-    submit: 'Soumettre',
+    'cancel': 'Annuler',
+    'save': 'Enregistrer',
+    'submit': 'Soumettre',
+    'select-option': 'Sélectionner une option',
   },
   'personal-information': {
     'page-title': 'Informations personnelles',
@@ -88,8 +89,7 @@ export default {
     'wfa-end-date': 'Date de fin de votre statut de RE (si applicable)',
     'hr-advisor': 'Conseiller en RH identifié dans votre lettre de RE',
     'errors': {
-      'substantive-group-required': 'Un groupe substantif est requis.',
-      'substantive-level-required': 'Le niveau de votre poste substantif est requis.',
+      'substantive-group-and-level-required': 'Groupe et niveau de votre poste substantif est requis.',
       'branch-or-service-canada-region-required': 'La direction générale ou la région de Service Canada est requise.',
       'directorate-required': 'La direction est requise.',
       'provinces-required': 'La province du lieu de travail désigné de votre poste substantif est requise.',

--- a/frontend/app/routes/profile/employment-information.tsx
+++ b/frontend/app/routes/profile/employment-information.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import type { RouteHandle } from 'react-router';
 import { data, Form } from 'react-router';
 
@@ -6,16 +8,24 @@ import * as v from 'valibot';
 
 import type { Route } from './+types/employment-information';
 
+import { getBranchService } from '~/.server/domain/services/branch-service';
+import { getCityService } from '~/.server/domain/services/city-service';
+import { getClassificationService } from '~/.server/domain/services/classification-service';
+import { getDirectorateService } from '~/.server/domain/services/directorate-service';
+import { getProvinceService } from '~/.server/domain/services/province-service';
 import { requireAllRoles } from '~/.server/utils/auth-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { Button } from '~/components/button';
+import { ButtonLink } from '~/components/button-link';
 import { ActionDataErrorSummary } from '~/components/error-summary';
+import { InputSelect } from '~/components/input-select';
 import { InlineLink } from '~/components/links';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/layout';
 import { employmentInformationSchema } from '~/routes/profile/validation.server';
 import { formString } from '~/utils/string-utils';
+import { extractValidationKey } from '~/utils/validation-utils';
 
 export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace],
@@ -53,7 +63,13 @@ export async function action({ context, params, request }: Route.ActionArgs) {
 
 export async function loader({ context, request }: Route.LoaderArgs) {
   requireAllRoles(context.session, new URL(request.url), ['employee']);
-  const { t } = await getTranslation(request, handle.i18nNamespace);
+  const { lang, t } = await getTranslation(request, handle.i18nNamespace);
+  const substantivePositions = await getClassificationService().getAll();
+  const branchOrServiceCanadaRegions = await getBranchService().getAllLocalized(lang);
+  const directorates = await getDirectorateService().getLocalizedDirectorates(lang);
+  const provinces = await getProvinceService().getAllLocalized(lang);
+  const cities = await getCityService().getAllLocalized(lang);
+
   return {
     documentTitle: t('app:employmeny-information.page-title'),
     defaultValues: {
@@ -66,11 +82,51 @@ export async function loader({ context, request }: Route.LoaderArgs) {
       currentWFAStatus: undefined as string | undefined,
       hrAdvisor: undefined,
     },
+    substantivePositions: substantivePositions.unwrap(),
+    branchOrServiceCanadaRegions: branchOrServiceCanadaRegions.unwrap(),
+    directorates: directorates,
+    provinces: provinces.unwrap(),
+    cities: cities.unwrap(),
   };
 }
 
 export default function EmploymentInformation({ loaderData, actionData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespace);
+  const errors = actionData?.errors;
+  const [province, setProvince] = useState(loaderData.defaultValues.province);
+
+  const substantivePositionOptions = [{ id: 'select-option', name: '' }, ...loaderData.substantivePositions].map(
+    ({ id, name }) => ({
+      value: id === 'select-option' ? '' : id,
+      children: id === 'select-option' ? t('app:form.select-option') : name,
+    }),
+  );
+
+  const branchOrServiceCanadaRegionOptions = [
+    { id: 'select-option', name: '' },
+    ...loaderData.branchOrServiceCanadaRegions,
+  ].map(({ id, name }) => ({
+    value: id === 'select-option' ? '' : id,
+    children: id === 'select-option' ? t('app:form.select-option') : name,
+  }));
+
+  const directorateOptions = [{ id: 'select-option', name: '' }, ...loaderData.directorates].map(({ id, name }) => ({
+    value: id === 'select-option' ? '' : id,
+    children: id === 'select-option' ? t('app:form.select-option') : name,
+  }));
+
+  const provinceOptions = [{ id: 'select-option', name: '' }, ...loaderData.provinces].map(({ id, name }) => ({
+    value: id === 'select-option' ? '' : id,
+    children: id === 'select-option' ? t('app:form.select-option') : name,
+  }));
+
+  const cityOptions = [{ id: 'select-option', name: '' }, ...loaderData.cities.filter((c) => c.province.id === province)].map(
+    ({ id, name }) => ({
+      value: id === 'select-option' ? '' : id,
+      children: id === 'select-option' ? t('app:form.select-option') : name,
+    }),
+  );
+
   return (
     <>
       <InlineLink className="mt-6 block" file="routes/profile/index.tsx" id="back-button">
@@ -81,9 +137,70 @@ export default function EmploymentInformation({ loaderData, actionData, params }
         <ActionDataErrorSummary actionData>
           <Form method="post" noValidate>
             <div className="space-y-6">
-              <Button className="px-12" name="action" variant="primary" id="save-button">
-                {t('app:form.save')}
-              </Button>
+              <h2 className="font-lato text-2xl font-bold">{t('app:employmeny-information.substantive-position-heading')}</h2>
+              <InputSelect
+                id="substantivePosition"
+                name="substantivePosition"
+                errorMessage={t(extractValidationKey(errors?.substantivePosition))}
+                required
+                options={substantivePositionOptions}
+                label={t('app:employmeny-information.substantive-position-group-and-level')}
+                defaultValue={loaderData.defaultValues.substantivePosition ?? ''}
+                className="w-full sm:w-1/2"
+              />
+              <InputSelect
+                id="branchOrServiceCanadaRegion"
+                name="branchOrServiceCanadaRegion"
+                errorMessage={t(extractValidationKey(errors?.branchOrServiceCanadaRegion))}
+                required
+                options={branchOrServiceCanadaRegionOptions}
+                label={t('app:employmeny-information.branch-or-service-canada-region')}
+                defaultValue={loaderData.defaultValues.branchOrServiceCanadaRegion ?? ''}
+                className="w-full sm:w-1/2"
+              />
+              <InputSelect
+                id="directorate"
+                name="directorate"
+                errorMessage={t(extractValidationKey(errors?.directorate))}
+                required
+                options={directorateOptions}
+                label={t('app:employmeny-information.branch-or-service-canada-region')}
+                defaultValue={loaderData.defaultValues.directorate ?? ''}
+                className="w-full sm:w-1/2"
+              />
+              <InputSelect
+                className="w-full sm:w-1/2"
+                id="province"
+                name="province"
+                label={t('app:employmeny-information.provinces')}
+                options={provinceOptions}
+                errorMessage={t(extractValidationKey(errors?.province))}
+                value={province}
+                onChange={({ target }) => setProvince(target.value)}
+                required
+              />
+              {province && (
+                <>
+                  <InputSelect
+                    id="city"
+                    name="city"
+                    errorMessage={t(extractValidationKey(errors?.city))}
+                    required
+                    options={cityOptions}
+                    label={t('app:employmeny-information.city')}
+                    defaultValue={loaderData.defaultValues.city ?? ''}
+                    className="w-full sm:w-1/2"
+                  />
+                </>
+              )}
+              <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+                <Button name="action" variant="primary" id="save-button">
+                  {t('app:form.save')}
+                </Button>
+                <ButtonLink file="routes/profile/index.tsx" id="cancel-button" variant="alternative">
+                  {t('app:form.cancel')}
+                </ButtonLink>
+              </div>
             </div>
           </Form>
         </ActionDataErrorSummary>

--- a/frontend/app/routes/profile/validation.server.ts
+++ b/frontend/app/routes/profile/validation.server.ts
@@ -1,8 +1,13 @@
 import { parsePhoneNumberWithError } from 'libphonenumber-js';
 import * as v from 'valibot';
 
+import { getBranchService } from '~/.server/domain/services/branch-service';
+import { getCityService } from '~/.server/domain/services/city-service';
+import { getClassificationService } from '~/.server/domain/services/classification-service';
+import { getDirectorateService } from '~/.server/domain/services/directorate-service';
 import { getEducationLevelService } from '~/.server/domain/services/education-level-service';
 import { getLanguageForCorrespondenceService } from '~/.server/domain/services/language-for-correspondence-service';
+import { getProvinceService } from '~/.server/domain/services/province-service';
 import { isValidPhone } from '~/utils/phone-utils';
 import { REGEX_PATTERNS } from '~/utils/regex-utils';
 
@@ -10,6 +15,15 @@ const allLanguagesOfCorrespondance = await getLanguageForCorrespondenceService()
 const languagesOfCorrespondence = allLanguagesOfCorrespondance.unwrap();
 const allEducationLevels = await getEducationLevelService().getAll();
 const educationLevels = allEducationLevels.unwrap();
+const allSubstantivePositions = await getClassificationService().getAll();
+const substantivePositions = allSubstantivePositions.unwrap();
+const allBranchOrServiceCanadaRegions = await getBranchService().getAll();
+const branchOrServiceCanadaRegions = allBranchOrServiceCanadaRegions.unwrap();
+const directorates = await getDirectorateService().getDirectorates();
+const allProvinces = await getProvinceService().getAll();
+const province = allProvinces.unwrap();
+const allCities = await getCityService().getAll();
+const cities = allCities.unwrap();
 
 export const personalInformationSchema = v.object({
   personalRecordIdentifier: v.pipe(
@@ -61,11 +75,36 @@ export const personalInformationSchema = v.object({
 });
 
 export const employmentInformationSchema = v.object({
-  substantivePosition: v.optional(v.string()),
-  branchOrServiceCanadaRegion: v.optional(v.string()),
-  directorate: v.optional(v.string()),
-  province: v.optional(v.string()),
-  city: v.optional(v.string()),
+  substantivePosition: v.lazy(() =>
+    v.picklist(
+      substantivePositions.map(({ id }) => id),
+      'app:employmeny-information.errors.substantive-group-and-level-required',
+    ),
+  ),
+  branchOrServiceCanadaRegion: v.lazy(() =>
+    v.picklist(
+      branchOrServiceCanadaRegions.map(({ id }) => id),
+      'app:employmeny-information.errors.branch-or-service-canada-region-required',
+    ),
+  ),
+  directorate: v.lazy(() =>
+    v.picklist(
+      directorates.map(({ id }) => id),
+      'app:employmeny-information.errors.directorate-required',
+    ),
+  ),
+  province: v.lazy(() =>
+    v.picklist(
+      province.map(({ id }) => id),
+      'app:employmeny-information.errors.provinces-required',
+    ),
+  ),
+  city: v.lazy(() =>
+    v.picklist(
+      cities.map(({ id }) => id),
+      'app:employmeny-information.errors.city-required',
+    ),
+  ),
   currentWFAStatus: v.optional(v.string()),
   hrAdvisor: v.optional(v.string()),
 });


### PR DESCRIPTION
## Summary

[AB#6251](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6251)
[AB#6260](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6260)
Added following fields and respective validations for substantive position on Employment information screen
- substantive position (group and level)
- branch
- directorate
- province
- city

On selecting Province, the respective cities are in the drop down

## Types of changes

What types of changes does this PR introduce?

- [x] ✨ **new feature** -- non-breaking change that adds functionality

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.


- [x] code has been linted and formatted locally

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/c68cdff2-22c3-4b36-a641-1123ab153b1a)
