### PR TITLE
feat(frontend): add reference preferences screen

### DIFF
--- a/frontend/app/.server/locales/app-en.ts
+++ b/frontend/app/.server/locales/app-en.ts
@@ -136,6 +136,8 @@ export default {
     'employment-tenure': 'Are you interested in any of the following employment opportunities?',
     'errors': {
       'language-referral-type-required': 'Language profile is required.',
+      'language-referral-type-invalid': 'Language profile is invalid.',
+      'language-referral-type-duplicate': 'Duplicate items for language profile are not allowed.',
       'classification-required': 'Classification group and level is required.',
       'work-location-required': 'Work location is required.',
       'province-required': 'Province is required.',
@@ -143,6 +145,8 @@ export default {
       'referral-availibility-required': 'Availablility for referrals is required.',
       'alternate-opportunity-required': 'Alternation opportunities is required.',
       'employment-tenure-required': 'Employment opportunities is required.',
+      'employment-tenure-invalid': 'Employment opportunities is invalid.',
+      'employment-tenure-duplicate': 'Duplicate items for employment opportunities are not allowed.',
     },
   },
 };

--- a/frontend/app/.server/locales/app-en.ts
+++ b/frontend/app/.server/locales/app-en.ts
@@ -44,6 +44,7 @@ export default {
     'save': 'Save',
     'submit': 'Submit',
     'select-option': 'Select option',
+    'select-all-that-apply': 'Select all that apply',
   },
   'personal-information': {
     'page-title': 'Personal information',
@@ -114,6 +115,34 @@ export default {
         'invalid-day': 'Day of end date of your WFA status is invalid.',
       },
       'hr-advisor-required': 'HR advisor is required.',
+    },
+  },
+  'referral-preferences': {
+    'page-title': 'Referral preferences',
+    'language-referral-type': 'Which language profiles would you like to be referred for?',
+    'classification': 'Which classification group(s) and level(s) would you like to be referred for?',
+    'classification-group-help-message-primary':
+      'The group and levels selected must be the same or equivalent to your substantive position.',
+    'work-location': 'Which work location(s) would you like to be referred to?',
+    'province': 'Province',
+    'city': 'City',
+    'referral-availibility': 'Are you currently available for referrals?',
+    'referral-availibility-help-message-primary':
+      "Select no if you'll be on leave or are currently not interested in referrals.",
+    'alternate-opportunity': 'Are you interested in alternation opportunities?',
+    'what-is-alternation': 'What is alternation?',
+    'alternation-description-text':
+      "Alternation occurs when an employee who has not been given a gaurentee of a reasonable job offer (GRJO) who wishes to continue employment in the core public service exchanges positions with an alternate (non-affected employee) willing to leave the Core Public Administration with a Transition Support Measure (TSM - cash payment based on the employee's years of service) or with an Education Allowance.",
+    'employment-tenure': 'Are you interested in any of the following employment opportunities?',
+    'errors': {
+      'language-referral-type-required': 'Language profile is required.',
+      'classification-required': 'Classification group and level is required.',
+      'work-location-required': 'Work location is required.',
+      'province-required': 'Province is required.',
+      'city-required': 'City is required.',
+      'referral-availibility-required': 'Availablility for referrals is required.',
+      'alternate-opportunity-required': 'Alternation opportunities is required.',
+      'employment-tenure-required': 'Employment opportunities is required.',
     },
   },
 };

--- a/frontend/app/.server/locales/app-fr.ts
+++ b/frontend/app/.server/locales/app-fr.ts
@@ -139,6 +139,8 @@ export default {
     'employment-tenure': "Êtes-vous intéressé par las opportunités d'emploi temporaires suivantes?",
     'errors': {
       'language-referral-type-required': 'La langue est requise.',
+      'language-referral-type-invalid': 'La langue est invalide.',
+      'language-referral-type-duplicate': 'Les éléments dupliqués pour le profil linguistique ne sont pas permis.',
       'classification-required': 'Groupe et niveau de votre est requis.',
       'work-location-required': "L'emplacement de travail est requis.",
       'province-required': 'La ville est requise.',
@@ -146,6 +148,8 @@ export default {
       'referral-availibility-required': 'La disponibilité pour les références est requise.',
       'alternate-opportunity-required': "Opportunités d'échange est requise.",
       'employment-tenure-required': "Opportunités d'emploi est requise.",
+      'employment-tenure-invalid': "Opportunités d'emploi est invalide.",
+      'employment-tenure-duplicate': "Les éléments dupliqués pour les opportunités d'emploi ne sont pas permis.",
     },
   },
 } satisfies typeof appEn;

--- a/frontend/app/.server/locales/app-fr.ts
+++ b/frontend/app/.server/locales/app-fr.ts
@@ -46,6 +46,7 @@ export default {
     'save': 'Enregistrer',
     'submit': 'Soumettre',
     'select-option': 'Sélectionner une option',
+    'select-all-that-apply': "Sélectionnez tout ce qui s'applique",
   },
   'personal-information': {
     'page-title': 'Informations personnelles',
@@ -76,7 +77,7 @@ export default {
   },
   'employment-information': {
     'page-title': "Informations sur l'emploi",
-    'substantive-position-heading': '',
+    'substantive-position-heading': 'Substantive position',
     'substantive-position-group-and-level': 'Groupe et niveau de votre poste substantif',
     'branch-or-service-canada-region': 'Direction générale ou Région de Service Canada',
     'directorate': 'Direction',
@@ -117,6 +118,34 @@ export default {
         'invalid-day': 'La jour de fin de votre statut de RE est invalide.',
       },
       'hr-advisor-required': 'Le conseiller en RH est requis.',
+    },
+  },
+  'referral-preferences': {
+    'page-title': 'Préférences de référence',
+    'language-referral-type': 'Pour quel(s) profil(s) de langue aimeriez-vous être référé?',
+    'classification': 'Pour quel(s) groupe(s) et niveau(x) de classification souhaiteriez-vous être référé?',
+    'classification-group-help-message-primary':
+      'The group and levels selected must be the same or equivalent to your substantive position',
+    'work-location': 'Pour quel(s) lieu(x) de travail aimeriez-vous être référé?',
+    'province': 'Province',
+    'city': 'Ville',
+    'referral-availibility': 'Êtes-vous actuellement disponible pour être référé?',
+    'referral-availibility-help-message-primary':
+      "Select no if you'll be on leave or are currently not interested in referrals",
+    'alternate-opportunity': "Êtes-vous intéressé par des opportunités d'échange de poste?",
+    'what-is-alternation': 'What is alternation?',
+    'alternation-description-text':
+      "Alternation occurs when an employee who has not been given a gaurentee of a reasonable job offer (GRJO) who wishes to continue employment in the core public service exchanges positions with an alternate (non-affected employee) willing to leave the Core Public Administration with a Transition Support Measure (TSM - cash payment based on the employee's years of service) or with an Education Allowance.",
+    'employment-tenure': "Êtes-vous intéressé par las opportunités d'emploi temporaires suivantes?",
+    'errors': {
+      'language-referral-type-required': 'La langue est requise.',
+      'classification-required': 'Groupe et niveau de votre est requis.',
+      'work-location-required': "L'emplacement de travail est requis.",
+      'province-required': 'La ville est requise.',
+      'city-required': 'La ville est requise.',
+      'referral-availibility-required': 'La disponibilité pour les références est requise.',
+      'alternate-opportunity-required': "Opportunités d'échange est requise.",
+      'employment-tenure-required': "Opportunités d'emploi est requise.",
     },
   },
 } satisfies typeof appEn;

--- a/frontend/app/.server/locales/gcweb-en.ts
+++ b/frontend/app/.server/locales/gcweb-en.ts
@@ -77,6 +77,10 @@ export default {
     'choose-file': 'Choose File',
     'no-file': 'No file chosen',
   },
+  'input-option': {
+    yes: 'Yes',
+    no: 'No',
+  },
   'error-summary': {
     header_one: 'The following error was found in the form:',
     header_other: 'The following {{count}} errors were found in the form:',

--- a/frontend/app/.server/locales/gcweb-fr.ts
+++ b/frontend/app/.server/locales/gcweb-fr.ts
@@ -79,6 +79,10 @@ export default {
     'choose-file': 'Choisir un fichier',
     'no-file': 'Aucun fichier choisi',
   },
+  'input-option': {
+    yes: 'Oui',
+    no: 'Non',
+  },
   'error-summary': {
     header_one: "L'erreur suivante a été trouvée dans le formulaire\u00a0:",
     header_other: 'Les {{count}} erreurs suivantes ont été trouvées dans le formulaire\u00a0:',

--- a/frontend/app/components/collapsible.tsx
+++ b/frontend/app/components/collapsible.tsx
@@ -1,0 +1,33 @@
+import { useId } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
+
+import { cn } from '~/utils/tailwind-utils';
+
+export type CollapsibleSummaryProps = ComponentProps<'summary'>;
+
+export function CollapsibleSummary({ children, className, ...props }: CollapsibleSummaryProps) {
+  return (
+    <summary className={cn('cursor-pointer marker:text-blue-900', className)} {...props}>
+      <span className="ml-4 inline-block text-blue-900 hover:underline">{children}</span>
+    </summary>
+  );
+}
+
+export interface CollapsibleProps extends ComponentProps<'details'> {
+  contentClassName?: string;
+  summary: ReactNode;
+}
+
+export function Collapsible({ children, contentClassName, id, summary, ...props }: CollapsibleProps) {
+  const uniqueId = useId();
+  const summaryId = `${id ?? uniqueId}-summary`;
+  const contentId = `${id ?? uniqueId}-content`;
+  return (
+    <details id={id ?? uniqueId} {...props}>
+      <CollapsibleSummary id={summaryId}>{summary}</CollapsibleSummary>
+      <div id={contentId} className={cn('mt-2 border-l-[6px] border-l-sky-800 bg-sky-50 px-6 py-4', contentClassName)}>
+        {children}
+      </div>
+    </details>
+  );
+}

--- a/frontend/app/i18n-routes.ts
+++ b/frontend/app/i18n-routes.ts
@@ -154,6 +154,14 @@ export const i18nRoutes = [
       },
       {
         id: 'EMPL-0006',
+        file: 'routes/employee/profile/referral-preferences.tsx',
+        paths: {
+          en: '/en/employee/profile/referral-preferences',
+          fr: '/fr/employe/profil/préférences-de-référence',
+        },
+      },
+      {
+        id: 'EMPL-0007',
         file: 'routes/employee/profile/personal-details.tsx',
         paths: {
           en: '/en/employee/profile/personal-details',

--- a/frontend/app/routes/employee/profile/index.tsx
+++ b/frontend/app/routes/employee/profile/index.tsx
@@ -108,7 +108,7 @@ export default function EditProfile({ loaderData, params }: Route.ComponentProps
         <ProfileCard
           title={t('app:profile.referral.title')}
           linkLabel={t('app:profile.referral.link-label')}
-          file="routes/employee/profile/personal-details.tsx"
+          file="routes/employee/profile/referral-preferences.tsx"
           completed={loaderData.referral.completed}
           total={3}
           required={true}

--- a/frontend/app/routes/employee/profile/referral-preferences.tsx
+++ b/frontend/app/routes/employee/profile/referral-preferences.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import type { RouteHandle } from 'react-router';
 import { data, Form } from 'react-router';
 
@@ -6,16 +8,27 @@ import * as v from 'valibot';
 
 import type { Route } from './+types/referral-preferences';
 
+import { getEmploymentTenureService } from '~/.server/domain/services/employment-tenure-service';
+import { getLanguageReferralTypeService } from '~/.server/domain/services/language-referral-type-service';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { Button } from '~/components/button';
 import { ButtonLink } from '~/components/button-link';
+import { Collapsible } from '~/components/collapsible';
 import { ActionDataErrorSummary } from '~/components/error-summary';
+import { InputCheckboxes } from '~/components/input-checkboxes';
+import { InputRadios } from '~/components/input-radios';
+import type { InputRadiosProps } from '~/components/input-radios';
 import { InlineLink } from '~/components/links';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
 import { getTranslation } from '~/i18n-config.server';
 import { refferralPreferencesSchema } from '~/routes/employee/profile/validation.server';
 import { handle as parentHandle } from '~/routes/layout';
-import { formString } from '~/utils/string-utils';
+import { extractValidationKey } from '~/utils/validation-utils';
+
+const REQUIRE_OPTIONS = {
+  yes: 'Yes', //
+  no: 'No',
+} as const;
 
 export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace],
@@ -29,12 +42,16 @@ export async function action({ context, params, request }: Route.ActionArgs) {
   // Since parent layout ensures authentication, we can safely cast the session
   const formData = await request.formData();
   const parseResult = v.safeParse(refferralPreferencesSchema, {
-    languageReferralTypes: formString(formData.get('languageReferralTypes')),
-    classification: formString(formData.get('classification')),
-    workLocations: formString(formData.get('workLocations')),
-    referralAvailibility: formString(formData.get('referralAvailibility')),
-    alternateOpportunity: formString(formData.get('alternateOpportunity')),
-    employmentTenures: formString(formData.get('employmentTenures')),
+    languageReferralTypes: formData.getAll('languageReferralTypes').map(String),
+    classification: formData.getAll('classification').map(String),
+    workLocations: formData.getAll('workLocations').map(String),
+    referralAvailibility: formData.get('referralAvailibility')
+      ? formData.get('referralAvailibility') === REQUIRE_OPTIONS.yes
+      : undefined,
+    alternateOpportunity: formData.get('alternateOpportunity')
+      ? formData.get('alternateOpportunity') === REQUIRE_OPTIONS.yes
+      : undefined,
+    employmentTenures: formData.getAll('employmentTenures').map(String),
   });
 
   if (!parseResult.success) {
@@ -51,7 +68,9 @@ export async function action({ context, params, request }: Route.ActionArgs) {
 
 export async function loader({ context, request }: Route.LoaderArgs) {
   // Since parent layout ensures authentication, we can safely cast the session
-  const { t } = await getTranslation(request, handle.i18nNamespace);
+  const { lang, t } = await getTranslation(request, handle.i18nNamespace);
+  const localizedLanguageReferralTypes = await getLanguageReferralTypeService().getAllLocalized(lang);
+  const localizedEmploymentTenures = await getEmploymentTenureService().getAllLocalized(lang);
   return {
     documentTitle: t('app:referral-preferences.page-title'),
     defaultValues: {
@@ -59,15 +78,61 @@ export async function loader({ context, request }: Route.LoaderArgs) {
       languageReferralTypes: undefined as string[] | undefined,
       classification: undefined as string[] | undefined,
       workLocations: undefined as string[] | undefined,
-      referralAvailibility: undefined as string | undefined,
-      alternateOpportunity: undefined as string | undefined,
+      referralAvailibility: undefined as boolean | undefined,
+      alternateOpportunity: undefined as boolean | undefined,
       employmentTenures: undefined as string[] | undefined,
     },
+    localizedLanguageReferralTypes: localizedLanguageReferralTypes.unwrap(),
+    localizedEmploymentTenures: localizedEmploymentTenures.unwrap(),
   };
 }
 
-export default function PersonalDetails({ loaderData, params }: Route.ComponentProps) {
+export default function PersonalDetails({ loaderData, actionData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespace);
+  const errors = actionData?.errors;
+
+  const [referralAvailibility, setReferralAvailibility] = useState(loaderData.defaultValues.referralAvailibility);
+  const [alternateOpportunity, setAlternateOpportunity] = useState(loaderData.defaultValues.alternateOpportunity);
+
+  const languageReferralTypeOptions = loaderData.localizedLanguageReferralTypes.map((langReferral) => ({
+    value: langReferral.id,
+    children: langReferral.name,
+    defaultChecked: loaderData.defaultValues.languageReferralTypes?.includes(langReferral.id) ?? false,
+  }));
+  const referralAvailibilityOptions: InputRadiosProps['options'] = [
+    {
+      children: t('gcweb:input-option.yes'),
+      value: REQUIRE_OPTIONS.yes,
+      defaultChecked: referralAvailibility === true,
+      onChange: ({ target }) => setReferralAvailibility(target.value === REQUIRE_OPTIONS.yes),
+    },
+    {
+      children: t('gcweb:input-option.no'),
+      value: REQUIRE_OPTIONS.no,
+      defaultChecked: referralAvailibility === false,
+      onChange: ({ target }) => setReferralAvailibility(target.value === REQUIRE_OPTIONS.yes),
+    },
+  ];
+  const alternateOpportunityOptions: InputRadiosProps['options'] = [
+    {
+      children: t('gcweb:input-option.yes'),
+      value: REQUIRE_OPTIONS.yes,
+      defaultChecked: alternateOpportunity === true,
+      onChange: ({ target }) => setAlternateOpportunity(target.value === REQUIRE_OPTIONS.yes),
+    },
+    {
+      children: t('gcweb:input-option.no'),
+      value: REQUIRE_OPTIONS.no,
+      defaultChecked: alternateOpportunity === false,
+      onChange: ({ target }) => setAlternateOpportunity(target.value === REQUIRE_OPTIONS.yes),
+    },
+  ];
+  const employmentTenureOptions = loaderData.localizedEmploymentTenures.map((employmentTenures) => ({
+    value: employmentTenures.id,
+    children: employmentTenures.name,
+    defaultChecked: loaderData.defaultValues.employmentTenures?.includes(employmentTenures.id) ?? false,
+  }));
+
   return (
     <>
       <InlineLink className="mt-6 block" file="routes/employee/profile/index.tsx" id="back-button">
@@ -78,6 +143,46 @@ export default function PersonalDetails({ loaderData, params }: Route.ComponentP
         <ActionDataErrorSummary actionData>
           <Form method="post" noValidate>
             <div className="space-y-6">
+              <InputCheckboxes
+                id="languageReferralTypesId"
+                errorMessage={t(extractValidationKey(errors?.languageReferralTypes))}
+                legend={t('app:referral-preferences.language-referral-type')}
+                name="languageReferralTypes"
+                options={languageReferralTypeOptions}
+                helpMessagePrimary={t('app:form.select-all-that-apply')}
+                required
+              />
+              <InputRadios
+                id="referralAvailibilityId"
+                legend={t('app:referral-preferences.referral-availibility')}
+                name="referralAvailibility"
+                options={referralAvailibilityOptions}
+                required
+                errorMessage={t(extractValidationKey(errors?.referralAvailibility))}
+                helpMessagePrimary={t('app:referral-preferences.referral-availibility-help-message-primary')}
+              />
+              <InputRadios
+                id="alternateOpportunityId"
+                legend={t('app:referral-preferences.alternate-opportunity')}
+                name="alternateOpportunity"
+                options={alternateOpportunityOptions}
+                required
+                errorMessage={t(extractValidationKey(errors?.alternateOpportunity))}
+                helpMessagePrimary={
+                  <Collapsible summary={t('app:referral-preferences.what-is-alternation')}>
+                    {t('app:referral-preferences.alternation-description-text')}
+                  </Collapsible>
+                }
+              />
+              <InputCheckboxes
+                id="employmentTenuresId"
+                errorMessage={t(extractValidationKey(errors?.languageReferralTypes))}
+                legend={t('app:referral-preferences.employment-tenure')}
+                name="employmentTenures"
+                options={employmentTenureOptions}
+                helpMessagePrimary={t('app:form.select-all-that-apply')}
+                required
+              />
               <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
                 <Button name="action" variant="primary" id="save-button">
                   {t('app:form.save')}

--- a/frontend/app/routes/employee/profile/referral-preferences.tsx
+++ b/frontend/app/routes/employee/profile/referral-preferences.tsx
@@ -61,7 +61,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     );
   }
 
-  //TODO: Save form data & work email after validation, workEmail: context.session.authState.idTokenClaims.email
+  //TODO: Save form data
 
   throw i18nRedirect('routes/employee/profile/index.tsx', request);
 }
@@ -176,7 +176,7 @@ export default function PersonalDetails({ loaderData, actionData, params }: Rout
               />
               <InputCheckboxes
                 id="employmentTenuresId"
-                errorMessage={t(extractValidationKey(errors?.languageReferralTypes))}
+                errorMessage={t(extractValidationKey(errors?.employmentTenures))}
                 legend={t('app:referral-preferences.employment-tenure')}
                 name="employmentTenures"
                 options={employmentTenureOptions}

--- a/frontend/app/routes/employee/profile/referral-preferences.tsx
+++ b/frontend/app/routes/employee/profile/referral-preferences.tsx
@@ -1,0 +1,95 @@
+import type { RouteHandle } from 'react-router';
+import { data, Form } from 'react-router';
+
+import { useTranslation } from 'react-i18next';
+import * as v from 'valibot';
+
+import type { Route } from './+types/referral-preferences';
+
+import { i18nRedirect } from '~/.server/utils/route-utils';
+import { Button } from '~/components/button';
+import { ButtonLink } from '~/components/button-link';
+import { ActionDataErrorSummary } from '~/components/error-summary';
+import { InlineLink } from '~/components/links';
+import { HttpStatusCodes } from '~/errors/http-status-codes';
+import { getTranslation } from '~/i18n-config.server';
+import { refferralPreferencesSchema } from '~/routes/employee/profile/validation.server';
+import { handle as parentHandle } from '~/routes/layout';
+import { formString } from '~/utils/string-utils';
+
+export const handle = {
+  i18nNamespace: [...parentHandle.i18nNamespace],
+} as const satisfies RouteHandle;
+
+export function meta({ data }: Route.MetaArgs) {
+  return [{ title: data?.documentTitle }];
+}
+
+export async function action({ context, params, request }: Route.ActionArgs) {
+  // Since parent layout ensures authentication, we can safely cast the session
+  const formData = await request.formData();
+  const parseResult = v.safeParse(refferralPreferencesSchema, {
+    languageReferralTypes: formString(formData.get('languageReferralTypes')),
+    classification: formString(formData.get('classification')),
+    workLocations: formString(formData.get('workLocations')),
+    referralAvailibility: formString(formData.get('referralAvailibility')),
+    alternateOpportunity: formString(formData.get('alternateOpportunity')),
+    employmentTenures: formString(formData.get('employmentTenures')),
+  });
+
+  if (!parseResult.success) {
+    return data(
+      { errors: v.flatten<typeof refferralPreferencesSchema>(parseResult.issues).nested },
+      { status: HttpStatusCodes.BAD_REQUEST },
+    );
+  }
+
+  //TODO: Save form data & work email after validation, workEmail: context.session.authState.idTokenClaims.email
+
+  throw i18nRedirect('routes/employee/profile/index.tsx', request);
+}
+
+export async function loader({ context, request }: Route.LoaderArgs) {
+  // Since parent layout ensures authentication, we can safely cast the session
+  const { t } = await getTranslation(request, handle.i18nNamespace);
+  return {
+    documentTitle: t('app:referral-preferences.page-title'),
+    defaultValues: {
+      //TODO: Replace with actual values
+      languageReferralTypes: undefined as string[] | undefined,
+      classification: undefined as string[] | undefined,
+      workLocations: undefined as string[] | undefined,
+      referralAvailibility: undefined as string | undefined,
+      alternateOpportunity: undefined as string | undefined,
+      employmentTenures: undefined as string[] | undefined,
+    },
+  };
+}
+
+export default function PersonalDetails({ loaderData, params }: Route.ComponentProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
+  return (
+    <>
+      <InlineLink className="mt-6 block" file="routes/employee/profile/index.tsx" id="back-button">
+        {`< ${t('app:profile.back')}`}
+      </InlineLink>
+      <div className="max-w-prose">
+        <h1 className="my-5 text-3xl">{t('app:referral-preferences.page-title')}</h1>
+        <ActionDataErrorSummary actionData>
+          <Form method="post" noValidate>
+            <div className="space-y-6">
+              <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+                <Button name="action" variant="primary" id="save-button">
+                  {t('app:form.save')}
+                </Button>
+                <ButtonLink file="routes/employee/profile/index.tsx" id="cancel-button" variant="alternative">
+                  {t('app:form.cancel')}
+                </ButtonLink>
+              </div>
+            </div>
+          </Form>
+        </ActionDataErrorSummary>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/employee/profile/validation.server.ts
+++ b/frontend/app/routes/employee/profile/validation.server.ts
@@ -208,6 +208,15 @@ export const employmentInformationSchema = v.intersect([
   ),
 ]);
 
+export const refferralPreferencesSchema = v.object({
+  languageReferralTypes: v.optional(v.string()),
+  classification: v.optional(v.string()),
+  workLocations: v.optional(v.string()),
+  referralAvailibility: v.optional(v.string()),
+  alternateOpportunity: v.optional(v.string()),
+  employmentTenures: v.optional(v.string()),
+});
+
 export function parseEmploymentInformation(formData: FormData) {
   const wfaEffectiveDateYear = formData.get('wfaEffectiveDateYear')?.toString();
   const wfaEffectiveDateMonth = formData.get('wfaEffectiveDateMonth')?.toString();


### PR DESCRIPTION
## Summary

[AB#6262](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6262)
[AB#6266](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6266)
add reference preferences screen
add  fields for language profile, referral availability, alternation opportunities and employment tenure
add the corresponding locals and validation strings
update the route on employee profile to redirect to reference preferences screen

Next steps:
Add the fields for:
Classification groups and level (multi-select drop down)
Work locations(multi-select drop down)

## Types of changes

What types of changes does this PR introduce?

- [x] ✨ **new feature** -- non-breaking change that adds functionality

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.

- [x] code has been linted and formatted locally

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/2027c9be-d5e7-4f09-8012-231138439533)