### PR TITLE
ci: Adding backend build and test job

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -20,6 +20,12 @@ jobs:
     if: ${{ github.repository == 'DTS-STN/vacman' }}
     steps:
       - uses: actions/checkout@v4
+      - id: backend
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            src:
+              - backend/**
       - id: frontend
         uses: dorny/paths-filter@v3
         with:
@@ -33,8 +39,34 @@ jobs:
             src:
               - gitops/**
     outputs:
+      backend-changed: ${{ steps.backend.outputs.src }}
       frontend-changed: ${{ steps.frontend.outputs.src }}
       gitops-changed: ${{ steps.gitops.outputs.src }}
+
+  test-backend:
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.backend-changed == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - run: mvn clean verify
+        working-directory: backend/
+  build-backend:
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.backend-changed == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - run: mvn spring-boot:build-image
+        working-directory: backend/
 
   test-frontend:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

This PR updates the GitHub Actions workflow to include a new job that builds and tests the `backend` project. 
The job runs only when changes are detected in the `backend` directory.

Marking as draft until #148 is merged as it fixes broken `backend` tests.

## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [x] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Additional Notes

This has been previously tested on the `nick/in-memory-tests` branch.
See https://github.com/DTS-STN/vacman/actions/runs/15901374508
