### PR TITLE
feat(frontend): fix html errors and remove unused locale values

### DIFF
--- a/frontend/app/.server/locales/app-en.ts
+++ b/frontend/app/.server/locales/app-en.ts
@@ -145,8 +145,6 @@ export default {
       'work-location-city-required': 'Work location city is required.',
       'work-location-city-invalid': 'Work location city is invalid.',
       'work-location-city-duplicate': 'Duplicate items for work location city are not allowed.',
-      'province-required': 'Province is required.',
-      'city-required': 'City is required.',
       'referral-availibility-required': 'Availablility for referrals is required.',
       'alternate-opportunity-required': 'Alternation opportunities is required.',
       'employment-tenure-required': 'Employment opportunities is required.',

--- a/frontend/app/.server/locales/app-fr.ts
+++ b/frontend/app/.server/locales/app-fr.ts
@@ -111,7 +111,7 @@ export default {
         'invalid-before-effective-date':
           "La date de fin de votre statut de RE doit être postérieure à la date d'entrée en vigueur de votre statut RE.",
         'required-year': "L'année de fin de votre statut de RE est requise.",
-        'invalid-year': "L'année de fin de votre statut de RE est requise.",
+        'invalid-year': "L'année de fin de votre statut de RE est invalide.",
         'required-month': 'La mois de fin de votre statut de RE est requise.',
         'invalid-month': 'La mois de fin de votre statut de RE est invalide.',
         'required-day': 'La jour de fin de votre statut de RE est requise.',
@@ -148,8 +148,6 @@ export default {
       'work-location-city-required': 'La ville de travail est requise.',
       'work-location-city-invalid': "La ville de travail n'est pas valide.",
       'work-location-city-duplicate': 'Les éléments dupliqués pour la ville du lieu de travail ne sont pas permis.',
-      'province-required': 'La ville est requise.',
-      'city-required': 'La ville est requise.',
       'referral-availibility-required': 'La disponibilité pour les références est requise.',
       'alternate-opportunity-required': "Opportunités d'échange est requise.",
       'employment-tenure-required': "Opportunités d'emploi est requise.",

--- a/frontend/app/components/app-bar.tsx
+++ b/frontend/app/components/app-bar.tsx
@@ -46,14 +46,14 @@ function UserButton({ className, children, name }: UserButtonProps): JSX.Element
           className,
         )}
       >
-        <div className="text-md my-auto flex flex-nowrap items-center space-x-2 py-2">
-          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-white">
+        <span className="text-md my-auto flex flex-nowrap items-center space-x-2 py-2">
+          <span className="flex h-8 w-8 items-center justify-center rounded-full bg-white">
             <FontAwesomeIcon icon={faUser} className="size-5 text-slate-700" />
-          </div>
-          <span id="menu-label" className="text-md hidden py-2 font-bold sm:block">
+          </span>
+          <span id="app-bar-menu-label" className="text-md hidden py-2 font-bold sm:block">
             {name}
           </span>
-        </div>
+        </span>
         <FontAwesomeIcon icon={faChevronDown} className="my-auto size-4" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-64 bg-slate-700">

--- a/frontend/app/components/card.tsx
+++ b/frontend/app/components/card.tsx
@@ -32,11 +32,16 @@ export function Card({ className, asChild, ...props }: CardProps): JSX.Element {
   );
 }
 
+type CardHeaderProps = ComponentProps<'div'> & {
+  asChild?: boolean;
+};
+
 /**
  * CardHeader component renders the header section of a card.
  */
-export function CardHeader({ className, ...props }: ComponentProps<'div'>) {
-  return <div className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />;
+export function CardHeader({ className, asChild, ...props }: CardHeaderProps) {
+  const Component = asChild ? Slot : 'div';
+  return <Component className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />;
 }
 
 type CardTitleProps = ComponentProps<'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'> & {
@@ -64,25 +69,40 @@ export function CardTitle({ asChild, className, ...props }: CardTitleProps) {
   );
 }
 
+type CardDescriptionProps = ComponentProps<'div'> & {
+  asChild?: boolean;
+};
+
 /**
  * CardDescription component renders the description of a card.
  */
-export function CardDescription({ className, ...props }: ComponentProps<'div'>) {
-  return <div className={cn('text-sm text-black/60', className)} {...props} />;
+export function CardDescription({ className, asChild, ...props }: CardDescriptionProps) {
+  const Component = asChild ? Slot : 'div';
+  return <Component className={cn('text-sm text-black/60', className)} {...props} />;
 }
+
+type CardContentProps = ComponentProps<'div'> & {
+  asChild?: boolean;
+};
 
 /**
  * CardContent component renders the content section of a card.
  */
-export function CardContent({ className, ...props }: ComponentProps<'div'>) {
-  return <div className={cn('p-6 pt-0', className)} {...props} />;
+export function CardContent({ className, asChild, ...props }: CardContentProps) {
+  const Component = asChild ? Slot : 'div';
+  return <Component className={cn('p-6 pt-0', className)} {...props} />;
 }
+
+type CardFooterProps = ComponentProps<'div'> & {
+  asChild?: boolean;
+};
 
 /**
  * CardFooter component renders the footer section of a card.
  */
-export function CardFooter({ className, ...props }: ComponentProps<'div'>) {
-  return <div className={cn('flex items-center p-6 pt-0', className)} {...props} />;
+export function CardFooter({ className, asChild, ...props }: CardFooterProps) {
+  const Component = asChild ? Slot : 'div';
+  return <Component className={cn('flex items-center p-6 pt-0', className)} {...props} />;
 }
 
 /**
@@ -127,8 +147,8 @@ type CardIconProps = OmitStrict<ComponentProps<'div'>, 'children'> & {
  */
 export function CardIcon({ className, icon, iconClassName, iconFlip, ...props }: CardIconProps) {
   return (
-    <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-slate-700 sm:size-12" {...props}>
+    <span className="flex size-10 shrink-0 items-center justify-center rounded-full bg-slate-700 sm:size-12" {...props}>
       <FontAwesomeIcon icon={icon} flip={iconFlip} className={cn('size-4 text-white sm:size-5', iconClassName)} />
-    </div>
+    </span>
   );
 }

--- a/frontend/app/routes/employee/index.tsx
+++ b/frontend/app/routes/employee/index.tsx
@@ -66,11 +66,15 @@ function ActionCard({ action, icon, title }: ActionCardProps): JSX.Element {
       <Card asChild className="flex cursor-pointer items-center gap-4 p-4 transition-colors hover:bg-gray-50 sm:p-6">
         <button type="submit" className="w-full text-left">
           <CardIcon icon={icon} />
-          <CardHeader className="p-0">
-            <CardTitle className="flex items-center gap-2">
-              <span>{title}</span>
-              <FontAwesomeIcon icon={faChevronRight} />
-            </CardTitle>
+          <CardHeader asChild className="p-0">
+            <span>
+              <CardTitle asChild className="flex items-center gap-2">
+                <span role="heading" aria-level={3}>
+                  {title}
+                  <FontAwesomeIcon icon={faChevronRight} />
+                </span>
+              </CardTitle>
+            </span>
           </CardHeader>
         </button>
       </Card>

--- a/frontend/app/routes/employee/index.tsx
+++ b/frontend/app/routes/employee/index.tsx
@@ -69,7 +69,7 @@ function ActionCard({ action, icon, title }: ActionCardProps): JSX.Element {
           <CardHeader asChild className="p-0">
             <span>
               <CardTitle asChild className="flex items-center gap-2">
-                <span role="heading" aria-level={3}>
+                <span role="heading" aria-level={2}>
                   {title}
                   <FontAwesomeIcon icon={faChevronRight} />
                 </span>

--- a/frontend/app/routes/index.tsx
+++ b/frontend/app/routes/index.tsx
@@ -127,7 +127,7 @@ function DashboardCard({ dashboard, icon, title }: DashboardCardProps): JSX.Elem
           <CardHeader asChild className="p-0">
             <span>
               <CardTitle asChild className="flex items-center gap-2">
-                <span role="heading" aria-level={3}>
+                <span role="heading" aria-level={2}>
                   {title}
                   <FontAwesomeIcon icon={faChevronRight} />
                 </span>

--- a/frontend/app/routes/index.tsx
+++ b/frontend/app/routes/index.tsx
@@ -124,11 +124,15 @@ function DashboardCard({ dashboard, icon, title }: DashboardCardProps): JSX.Elem
       <Card asChild className="flex cursor-pointer items-center gap-4 p-4 transition-colors hover:bg-gray-50 sm:p-6">
         <button type="submit" className="w-full text-left">
           <CardIcon icon={icon} />
-          <CardHeader className="p-0">
-            <CardTitle className="flex items-center gap-2">
-              <span>{title}</span>
-              <FontAwesomeIcon icon={faChevronRight} />
-            </CardTitle>
+          <CardHeader asChild className="p-0">
+            <span>
+              <CardTitle asChild className="flex items-center gap-2">
+                <span role="heading" aria-level={3}>
+                  {title}
+                  <FontAwesomeIcon icon={faChevronRight} />
+                </span>
+              </CardTitle>
+            </span>
           </CardHeader>
         </button>
       </Card>

--- a/frontend/tests/components/__snapshots__/app-bar.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/app-bar.test.tsx.snap
@@ -153,10 +153,10 @@ exports[`AppBar > should render render an AppBar with a name provided > expected
           id="radix-«r6»"
           type="button"
         >
-          <div
+          <span
             class="text-md my-auto flex flex-nowrap items-center space-x-2 py-2"
           >
-            <div
+            <span
               class="flex h-8 w-8 items-center justify-center rounded-full bg-white"
             >
               <svg
@@ -174,14 +174,14 @@ exports[`AppBar > should render render an AppBar with a name provided > expected
                   fill="currentColor"
                 />
               </svg>
-            </div>
+            </span>
             <span
               class="text-md hidden py-2 font-bold sm:block"
-              id="menu-label"
+              id="app-bar-menu-label"
             >
               Test User
             </span>
-          </div>
+          </span>
           <svg
             aria-hidden="true"
             class="svg-inline--fa fa-chevron-down my-auto size-4"
@@ -257,10 +257,10 @@ exports[`AppBar > should render render an AppBar with a profile item provided > 
           id="radix-«ra»"
           type="button"
         >
-          <div
+          <span
             class="text-md my-auto flex flex-nowrap items-center space-x-2 py-2"
           >
-            <div
+            <span
               class="flex h-8 w-8 items-center justify-center rounded-full bg-white"
             >
               <svg
@@ -278,14 +278,14 @@ exports[`AppBar > should render render an AppBar with a profile item provided > 
                   fill="currentColor"
                 />
               </svg>
-            </div>
+            </span>
             <span
               class="text-md hidden py-2 font-bold sm:block"
-              id="menu-label"
+              id="app-bar-menu-label"
             >
               Test User
             </span>
-          </div>
+          </span>
           <svg
             aria-hidden="true"
             class="svg-inline--fa fa-chevron-down my-auto size-4"

--- a/frontend/tests/components/__snapshots__/card.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/card.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`Card > should render a card with a link with an icon > expected html 1`
     <div
       class="flex items-center gap-4 p-6"
     >
-      <div
+      <span
         class="flex size-10 shrink-0 items-center justify-center rounded-full bg-slate-700 sm:size-12"
       >
         <svg
@@ -74,7 +74,7 @@ exports[`Card > should render a card with a link with an icon > expected html 1`
             fill="currentColor"
           />
         </svg>
-      </div>
+      </span>
       <div
         class="flex flex-col space-y-1.5 p-0"
       >
@@ -102,7 +102,7 @@ exports[`Card > should render a card with a link with an icon, content, footer w
     <div
       class="flex items-center gap-4 p-6"
     >
-      <div
+      <span
         class="flex size-10 shrink-0 items-center justify-center rounded-full bg-slate-700 sm:size-12"
       >
         <svg
@@ -120,7 +120,7 @@ exports[`Card > should render a card with a link with an icon, content, footer w
             fill="currentColor"
           />
         </svg>
-      </div>
+      </span>
       <div
         class="flex flex-col space-y-1.5 p-0"
       >


### PR DESCRIPTION
## Summary

- Removed unused locales from app-en and app-fr files.
- Fixed html errors indicated by [w3c validator](https://validator.w3.org/#validate_by_input)
- - Duplicate ID "menu-label" on the app menu bar (updated the id on app menu)
- Updated the Card component to accommodate the "button" element so that following html errors indicated by [w3c validator](https://validator.w3.org/#validate_by_input) are fixed. The fix was to change div to span element, as span are allowed inside button element.
- - Element "div" not allowed as child of element "button" in this context on the main dashboard
- - Element "div" not allowed as child of element "button" in this context on the employee dashboard
- Updated the heading level to h2 from h3 for cards. There was h1 for the page header, then h3 for card header and h2 was missing (which would cause a11y audit fail) 

## Types of changes

What types of changes does this PR introduce?

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)
Fixed the following html errors as indicated by [HTML validator](https://validator.w3.org/)
![image](https://github.com/user-attachments/assets/dfae7238-177b-45e1-aa6b-b4fa65e55c30)
