### PR TITLE
feat(gitops): Add base and overlay files for `backend` support

### DIFF
--- a/gitops/nonprod/base/vacman-backend/deployments.yaml
+++ b/gitops/nonprod/base/vacman-backend/deployments.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vacman-backend
+  labels:
+    app.kubernetes.io/name: vacman-backend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vacman-backend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: vacman-backend
+    spec:
+      containers:
+        - name: vacman-backend
+          # Note: image tag should be pinned to a specific version in overlays
+          image: dtsrhpdevscedacr.azurecr.io/vacman/vacman-backend
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            initialDelaySeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+            initialDelaySeconds: 30
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              memory: 1024Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+          volumeMounts:
+            - name: config
+              mountPath: /workspace/BOOT-INF/classes/application-local.yaml
+              subPath: application.yaml
+      volumes:
+        - name: config
+          configMap:
+            name: vacman-backend-configmap

--- a/gitops/nonprod/base/vacman-backend/kustomization.yaml
+++ b/gitops/nonprod/base/vacman-backend/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployments.yaml

--- a/gitops/nonprod/overlays/dev/configs/vacman-backend.yaml
+++ b/gitops/nonprod/overlays/dev/configs/vacman-backend.yaml
@@ -1,0 +1,37 @@
+#######################################################################################################################
+# Configuration intended to be mounted as `application-local.yaml` for the vacman-backend Spring Boot application.
+#
+# This file provides environment-specific overrides to the default configuration.
+#######################################################################################################################
+
+spring:
+  datasource:
+    # Use an in-memory H2 database with SQL Server compatibility mode.
+    # Keeps identifiers case-sensitive and avoids converting them to uppercase.
+    # DB_CLOSE_DELAY=-1 means the DB will stay open until the JVM shuts down.
+    url: jdbc:h2:mem:testdb;MODE=MSSQLServer;DATABASE_TO_UPPER=false;CASE_INSENSITIVE_IDENTIFIERS=true;DB_CLOSE_DELAY=-1;
+
+  jpa:
+    hibernate:
+      # Automatically update the database schema to match entity definitions.
+      # Use cautiously in production — better for dev/testing.
+      ddl-auto: update
+
+    # Ensures that JPA waits until the datasource is initialized for data.sql scripts.
+    defer-datasource-initialization: true
+
+    # Prints SQL statements in logs — useful for debugging.
+    show-sql: true
+
+  h2:
+    console:
+      # Enables the H2 web console at runtime.
+      enabled: true
+      # Sets the path to access the H2 web console in the browser.
+      path: /h2-console
+
+application:
+  security:
+    # Disables custom application security.
+    # Make sure this is never set to true in production.
+    disabled: true

--- a/gitops/nonprod/overlays/dev/kustomization.yaml
+++ b/gitops/nonprod/overlays/dev/kustomization.yaml
@@ -13,6 +13,7 @@ labels:
       app.kubernetes.io/environment: dev
       app.kubernetes.io/tier: nonprod
 resources:
+  - ../../base/vacman-backend/
   - ../../base/vacman-frontend/
   - ./ingresses.yaml
 patches:
@@ -21,4 +22,8 @@ configMapGenerator:
   - name: vacman-frontend
     behavior: create
     envs:
-      - ./configs/vacman-frontend.conf
+    - ./configs/vacman-frontend.conf
+  - name: vacman-backend-configmap
+    behavior: create
+    files:
+    - application.yaml=./configs/vacman-backend.yaml


### PR DESCRIPTION
## Summary

- Added `base` deployment for `backend` with container, probes, and resource limits
- Added `dev` overlay with environment-specific Kustomize configuration
- `ConfigMap` generator added for `application-local.yaml` overrides

These changes have been tested locally (via port-forwarding) and applied to the cluster.

## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [x] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Additional Notes

Connection to MSSQL Server will be handled in a future PR.
