### PR TITLE
refactor(frontend): update the language of correspondence service

### DIFF
--- a/frontend/app/.server/domain/models.ts
+++ b/frontend/app/.server/domain/models.ts
@@ -116,12 +116,14 @@ export type LocalizedLanguageReferralType = Readonly<{
 
 export type LanguageOfCorrespondence = Readonly<{
   id: string;
+  code: string;
   nameEn: string;
   nameFr: string;
 }>;
 
 export type LocalizedLanguageOfCorrespondence = Readonly<{
   id: string;
+  code: string;
   name: string;
 }>;
 

--- a/frontend/app/.server/domain/services/language-for-correspondence-service-default.ts
+++ b/frontend/app/.server/domain/services/language-for-correspondence-service-default.ts
@@ -1,5 +1,5 @@
 import type { Result, Option } from 'oxide.ts';
-import { Some, None, Ok, Err } from 'oxide.ts';
+import { Ok, Err } from 'oxide.ts';
 
 import type { LanguageOfCorrespondence, LocalizedLanguageOfCorrespondence } from '~/.server/domain/models';
 import type { LanguageForCorrespondenceService } from '~/.server/domain/services/language-for-correspondence-service';
@@ -9,127 +9,170 @@ import { ErrorCodes } from '~/errors/error-codes';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
 
 //TODO: Revisit when the api endpoints are avaialable
-export function getDefaultLanguageForCorrespondenceService(): LanguageForCorrespondenceService {
-  return {
-    /**
-     * Retrieves a list of languages of correspondence.
-     *
-     * @returns An array of language of correspondence objects or {AppError} if the request fails or if the server responds with an error status.
-     */
-    async getAll(): Promise<Result<readonly LanguageOfCorrespondence[], AppError>> {
-      try {
-        const response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}/languagesOfCorrespondance`);
+// Centralized API request logic
+async function makeApiRequest<T>(path: string, context: string): Promise<Result<T, AppError>> {
+  try {
+    const response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}${path}`);
 
-        if (!response.ok) {
-          return Err(
-            new AppError(
-              `Failed to retrieve all Languages of Correspondance. Server responded with status ${response.status}.`,
-              ErrorCodes.VACMAN_API_ERROR,
-            ),
-          );
-        }
+    if (response.status === HttpStatusCodes.NOT_FOUND) {
+      return Err(new AppError(`${context} not found.`, ErrorCodes.NO_DIRECTORATE_FOUND));
+    }
 
-        const data: LanguageOfCorrespondence[] = await response.json();
-        return Ok(data);
-      } catch (error) {
-        return Err(
-          new AppError(
-            `Unexpected error occurred while fetching Languages of Correspondance: ${String(error)}`,
-            ErrorCodes.VACMAN_API_ERROR,
-          ),
-        );
-      }
-    },
-
-    /**
-     * Retrieves a single language of correspondence by its ID.
-     *
-     * @param id The ID of the language of correspondence to retrieve.
-     * @returns The language of correspondence object if found or {AppError} If the language of correspondence is not found or if the request fails or if the server responds with an error status.
-     */
-    async getById(id: string): Promise<Result<LanguageOfCorrespondence, AppError>> {
-      try {
-        const response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}/languagesOfCorrespondance/${id}`);
-
-        if (response.status === HttpStatusCodes.NOT_FOUND) {
-          return Err(
-            new AppError(
-              `Language of Correspondance with ID '${id}' not found.`,
-              ErrorCodes.NO_LANGUAGE_OF_CORRESPONDENCE_FOUND,
-            ),
-          );
-        }
-
-        if (!response.ok) {
-          return Err(
-            new AppError(
-              `Failed to find the Language of Correspondance with ID '${id}'. Server responded with status ${response.status}.`,
-              ErrorCodes.VACMAN_API_ERROR,
-            ),
-          );
-        }
-
-        const data: LanguageOfCorrespondence = await response.json();
-        return Ok(data);
-      } catch (error) {
-        return Err(
-          new AppError(
-            `Unexpected error occurred while fetching Language of Correspondance by ID: ${String(error)}`,
-            ErrorCodes.VACMAN_API_ERROR,
-          ),
-        );
-      }
-    },
-
-    /**
-     * Retrieves a single language of correspondence by its ID.
-     *
-     * @param id The ID of the language of correspondence to retrieve.
-     * @returns The language of correspondence object if found or undefined if not found.
-     */
-
-    async findById(id: string): Promise<Option<LanguageOfCorrespondence>> {
-      const result = await getDefaultLanguageForCorrespondenceService().getAll();
-
-      if (result.isErr()) {
-        return None;
-      }
-
-      const found = result.unwrap().find((languageOfCorrespondence) => languageOfCorrespondence.id === id);
-      return found ? Some(found) : None;
-    },
-
-    /**
-     * Retrieves a list of languages of correspondence localized to the specified language.
-     *
-     * @param language The language to localize the language names to.
-     * @returns An array of localized language of correspondence objects or {AppError} if the request fails or if the server responds with an error status.
-     */
-    async getAllLocalized(language: Language): Promise<Result<readonly LocalizedLanguageOfCorrespondence[], AppError>> {
-      const result = await getDefaultLanguageForCorrespondenceService().getAll();
-
-      return result.map((languagesOfCorrespondence) =>
-        languagesOfCorrespondence.map((languageOfCorrespondence) => ({
-          id: languageOfCorrespondence.id,
-          name: language === 'fr' ? languageOfCorrespondence.nameFr : languageOfCorrespondence.nameEn,
-        })),
+    if (!response.ok) {
+      return Err(
+        new AppError(
+          `Failed to ${context.toLowerCase()}. Server responded with status ${response.status}.`,
+          ErrorCodes.VACMAN_API_ERROR,
+        ),
       );
-    },
+    }
 
-    /**
-     * Retrieves a single localized language of correspondence by its ID.
-     *
-     * @param id The ID of the localized language of correspondence to retrieve.
-     * @param language The language to localize the language names to.
-     * @returns The localized language of correspondence object if found or {AppError} If the language of correspondence is not found or if the request fails or if the server responds with an error status.
-     */
-    async getLocalizedById(id: string, language: Language): Promise<Result<LocalizedLanguageOfCorrespondence, AppError>> {
-      const result = await getDefaultLanguageForCorrespondenceService().getById(id);
+    // Handle cases where the server returns 204 No Content for a successful empty response
+    if (response.status === HttpStatusCodes.NO_CONTENT) {
+      return Ok([] as unknown as T); // Return an empty array or appropriate empty value
+    }
 
-      return result.map((languageOfCorrespondence) => ({
-        id: languageOfCorrespondence.id,
-        name: language === 'fr' ? languageOfCorrespondence.nameFr : languageOfCorrespondence.nameEn,
-      }));
-    },
+    const data: T = await response.json();
+    return Ok(data);
+  } catch (error) {
+    return Err(
+      new AppError(`Unexpected error occurred while ${context.toLowerCase()}: ${String(error)}`, ErrorCodes.VACMAN_API_ERROR),
+    );
+  }
+}
+
+// Centralized localization logic
+function localizedLanguageOfCorrespondence(
+  languageOfCorrespondence: LanguageOfCorrespondence,
+  language: Language,
+): LocalizedLanguageOfCorrespondence {
+  return {
+    id: languageOfCorrespondence.id,
+    code: languageOfCorrespondence.code,
+    name: language === 'fr' ? languageOfCorrespondence.nameFr : languageOfCorrespondence.nameEn,
   };
+}
+
+// Create a single instance of the service (Singleton)
+export const languageForCorrespondenceService: LanguageForCorrespondenceService = {
+  /**
+   * Retrieves a list of languages of correspondence.
+   *
+   * @returns An array of language of correspondence objects or {AppError} if the request fails or if the server responds with an error status.
+   */
+  getAll(): Promise<Result<readonly LanguageOfCorrespondence[], AppError>> {
+    return makeApiRequest('/languagesOfCorrespondance', 'Retrieve all directorates');
+  },
+
+  /**
+   * Retrieves a single language of correspondence by its ID.
+   *
+   * @param id The ID of the language of correspondence to retrieve.
+   * @returns The language of correspondence object if found or {AppError} If the language of correspondence is not found or if the request fails or if the server responds with an error status.
+   */
+  getById(id: string): Promise<Result<LanguageOfCorrespondence, AppError>> {
+    return makeApiRequest(`/languagesOfCorrespondance/${id}`, `Find Language of Correspondance with ID '${id}'`);
+  },
+
+  /**
+   * Retrieves a single language of correspondence by its CODE.
+   *
+   * @param code The CODE of the language of correspondence to retrieve.
+   * @returns The language of correspondence object if found or {AppError} If the language of correspondence is not found or if the request fails or if the server responds with an error status.
+   */
+  getByCode(code: string): Promise<Result<LanguageOfCorrespondence, AppError>> {
+    return makeApiRequest(`/languagesOfCorrespondance?code=${code}`, `Find Language of Correspondance with CODE '${code}'`);
+  },
+
+  /**
+   * Retrieves a single language of correspondence by its ID.
+   *
+   * @param id The ID of the language of correspondence to retrieve.
+   * @returns The language of correspondence object if found or undefined if not found.
+   */
+  async findById(id: string): Promise<Option<LanguageOfCorrespondence>> {
+    const result = await this.getById(id);
+    // .ok() converts a Result<T, E> into an Option<T>
+    return result.ok();
+  },
+
+  /**
+   * Retrieves a single language of correspondence by its CODE.
+   *
+   * @param code The CODE of the language of correspondence to retrieve.
+   * @returns The language of correspondence object if found or undefined If the language of correspondence is not found or if the request fails or if the server responds with an error status.
+   */
+  async findByCode(code: string): Promise<Option<LanguageOfCorrespondence>> {
+    const result = await this.getByCode(code);
+    return result.ok();
+  },
+
+  // Localized methods
+
+  /**
+   * Retrieves a list of language of correspondence localized to the specified language.
+   *
+   * @param language The language to localize the branch names to.
+   * @returns An array of localized language of correspondence objects or AppError if the request fails or if the server responds with an error status.
+   */
+  async getAllLocalized(language: Language): Promise<Result<readonly LocalizedLanguageOfCorrespondence[], AppError>> {
+    const result = await this.getAll();
+    return result.map((languagesOfCorrespondance) =>
+      languagesOfCorrespondance.map((languageOfCorrespondance) =>
+        localizedLanguageOfCorrespondence(languageOfCorrespondance, language),
+      ),
+    );
+  },
+
+  /**
+   * Retrieves a single localized language of correspondence by its ID.
+   *
+   * @param id The ID of the language of correspondence to retrieve.
+   * @param language The language to localize the language of correspondence name to.
+   * @returns The localized language of correspondence object if found or AppError if the request fails or if the server responds with an error status.
+   */
+  async getLocalizedById(id: string, language: Language): Promise<Result<LocalizedLanguageOfCorrespondence, AppError>> {
+    const result = await this.getById(id);
+    return result.map((languageOfCorrespondance) => localizedLanguageOfCorrespondence(languageOfCorrespondance, language));
+  },
+
+  /**
+   * Retrieves a single localized language of correspondence by its ID.
+   *
+   * @param code The CODE of the language of correspondence to retrieve.
+   * @param language The language to localize the language of correspondence name to.
+   * @returns The localized language of correspondence object if found or AppError if the request fails or if the server responds with an error status.
+   */
+  async getLocalizedByCode(code: string, language: Language): Promise<Result<LocalizedLanguageOfCorrespondence, AppError>> {
+    const result = await this.getByCode(code);
+    return result.map((languageOfCorrespondance) => localizedLanguageOfCorrespondence(languageOfCorrespondance, language));
+  },
+
+  /**
+   * Retrieves a single localized language of correspondence by its ID.
+   *
+   * @param id The ID of the language of correspondence to retrieve.
+   * @param language The language to localize the language of correspondence name to.
+   * @returns The localized language of correspondence object if found or undefined if the request fails or if the server responds with an error status.
+   */
+  async findLocalizedById(id: string, language: Language): Promise<Option<LocalizedLanguageOfCorrespondence>> {
+    const result = await this.getLocalizedById(id, language);
+    return result.ok();
+  },
+
+  /**
+   * Retrieves a single localized language of correspondence by its ID.
+   *
+   * @param code The CODE of the language of correspondence to retrieve.
+   * @param language The language to localize the language of correspondence name to.
+   * @returns The localized language of correspondence object if found or undefined if the request fails or if the server responds with an error status.
+   */
+  async findLocalizedByCode(code: string, language: Language): Promise<Option<LocalizedLanguageOfCorrespondence>> {
+    const result = await this.getLocalizedByCode(code, language);
+    return result.ok();
+  },
+};
+
+export function getDefaultLanguageForCorrespondenceService(): LanguageForCorrespondenceService {
+  return languageForCorrespondenceService;
 }

--- a/frontend/app/.server/domain/services/language-for-correspondence-service-mock.ts
+++ b/frontend/app/.server/domain/services/language-for-correspondence-service-mock.ts
@@ -12,8 +12,13 @@ export function getMockLanguageForCorrespondenceService(): LanguageForCorrespond
     getAll: () => Promise.resolve(getAll()),
     getById: (id: string) => Promise.resolve(getById(id)),
     findById: (id: string) => Promise.resolve(findById(id)),
+    getByCode: (code: string) => Promise.resolve(getByCode(code)),
+    findByCode: (code: string) => Promise.resolve(findByCode(code)),
     getAllLocalized: (language: Language) => Promise.resolve(getAllLocalized(language)),
     getLocalizedById: (id: string, language: Language) => Promise.resolve(getLocalizedById(id, language)),
+    findLocalizedById: (id: string, language: Language) => Promise.resolve(findLocalizedById(id, language)),
+    getLocalizedByCode: (code: string, language: Language) => Promise.resolve(getLocalizedByCode(code, language)),
+    findLocalizedByCode: (code: string, language: Language) => Promise.resolve(findLocalizedByCode(code, language)),
   };
 }
 
@@ -25,6 +30,7 @@ export function getMockLanguageForCorrespondenceService(): LanguageForCorrespond
 function getAll(): Result<readonly LanguageOfCorrespondence[], AppError> {
   const languages: LanguageOfCorrespondence[] = esdcLanguageOfCorrespondenceData.content.map((option) => ({
     id: option.id.toString(),
+    code: option.code,
     nameEn: option.nameEn,
     nameFr: option.nameFr,
   }));
@@ -75,6 +81,51 @@ function findById(id: string): Option<LanguageOfCorrespondence> {
 }
 
 /**
+ * Retrieves a single language of correspondence by its CODE.
+ *
+ * @param code The CODE of the language of correspondence to retrieve.
+ * @returns The language of correspondence object if found or {AppError} If the language of correspondence is not found.
+ */
+function getByCode(code: string): Result<LanguageOfCorrespondence, AppError> {
+  const result = getAll();
+
+  if (result.isErr()) {
+    return result;
+  }
+
+  const languagesOfCorrespondence = result.unwrap();
+  const languageOfCorrespondence = languagesOfCorrespondence.find((l) => l.code === code);
+
+  return languageOfCorrespondence
+    ? Ok(languageOfCorrespondence)
+    : Err(
+        new AppError(
+          `Language of correspondence with CODE '${code}' not found.`,
+          ErrorCodes.NO_LANGUAGE_OF_CORRESPONDENCE_FOUND,
+        ),
+      );
+}
+
+/**
+ * Retrieves a single language of correspondence by its CODE.
+ *
+ * @param code The CODE of the language of correspondence to retrieve.
+ * @returns The language of correspondence object if found or undefined if not found.
+ */
+function findByCode(code: string): Option<LanguageOfCorrespondence> {
+  const result = getAll();
+
+  if (result.isErr()) {
+    return None;
+  }
+
+  const languagesOfCorrespondence = result.unwrap();
+  const languageOfCorrespondence = languagesOfCorrespondence.find((l) => l.code === code);
+
+  return languageOfCorrespondence ? Some(languageOfCorrespondence) : None;
+}
+
+/**
  * Retrieves a list of languages of correspondence localized to the specified language.
  *
  * @param language The language to localize the language names to.
@@ -85,6 +136,7 @@ function getAllLocalized(language: Language): Result<readonly LocalizedLanguageO
     options
       .map((option) => ({
         id: option.id,
+        code: option.code,
         name: language === 'fr' ? option.nameFr : option.nameEn,
       }))
       .sort((a, b) => a.name.localeCompare(b.name, language, { sensitivity: 'base' })),
@@ -111,4 +163,64 @@ function getLocalizedById(id: string, language: Language): Result<LocalizedLangu
           ),
         );
   });
+}
+
+/**
+ * Retrieves a single localized language of correspondence by its ID.
+ *
+ * @param id The ID of the language of correspondence to retrieve.
+ * @param language The language to localize the language of correspondence name to.
+ * @returns The localized language of correspondence object if found or undefined If the language of correspondence is not found.
+ */
+function findLocalizedById(id: string, language: Language): Option<LocalizedLanguageOfCorrespondence> {
+  const result = getAllLocalized(language);
+
+  if (result.isErr()) {
+    return None;
+  }
+  const languagesOfCorrespondence = result.unwrap();
+  const languageOfCorrespondence = languagesOfCorrespondence.find((p) => p.id === id);
+
+  return languageOfCorrespondence ? Some(languageOfCorrespondence) : None;
+}
+
+/**
+ * Retrieves a single localized language of correspondence by its CODE.
+ *
+ * @param code The CODE of the language of correspondence to retrieve.
+ * @param language The language to localize the language name to.
+ * @returns The localized language of correspondence object if found or {AppError} If the language of correspondence is not found.
+ */
+function getLocalizedByCode(code: string, language: Language): Result<LocalizedLanguageOfCorrespondence, AppError> {
+  return getAllLocalized(language).andThen((languagesOfCorrespondence) => {
+    const languageOfCorrespondence = languagesOfCorrespondence.find((b) => b.code === code);
+
+    return languageOfCorrespondence
+      ? Ok(languageOfCorrespondence)
+      : Err(
+          new AppError(
+            `Localized language of correspondence with CODE '${code}' not found.`,
+            ErrorCodes.NO_LANGUAGE_OF_CORRESPONDENCE_FOUND,
+          ),
+        );
+  });
+}
+
+/**
+ * Retrieves a single localized language of correspondence by its CODE.
+ *
+ * @param code The CODE of the language of correspondence to retrieve.
+ * @param language The language to localize the language of correspondence name to.
+ * @returns The localized language of correspondence object if found or undefined If the language of correspondence is not found.
+ */
+function findLocalizedByCode(code: string, language: Language): Option<LocalizedLanguageOfCorrespondence> {
+  const result = getAllLocalized(language);
+
+  if (result.isErr()) {
+    return None;
+  }
+  const languagesOfCorrespondence = result.unwrap();
+  const languageOfCorrespondence = languagesOfCorrespondence.find((p) => p.code === code);
+
+  return languageOfCorrespondence ? Some(languageOfCorrespondence) : None;
 }

--- a/frontend/app/.server/domain/services/language-for-correspondence-service.ts
+++ b/frontend/app/.server/domain/services/language-for-correspondence-service.ts
@@ -10,8 +10,13 @@ export type LanguageForCorrespondenceService = {
   getAll(): Promise<Result<readonly LanguageOfCorrespondence[], AppError>>;
   getById(id: string): Promise<Result<LanguageOfCorrespondence, AppError>>;
   findById(id: string): Promise<Option<LanguageOfCorrespondence>>;
+  getByCode(code: string): Promise<Result<LanguageOfCorrespondence, AppError>>;
+  findByCode(code: string): Promise<Option<LanguageOfCorrespondence>>;
   getAllLocalized(language: Language): Promise<Result<readonly LocalizedLanguageOfCorrespondence[], AppError>>;
   getLocalizedById(id: string, language: Language): Promise<Result<LocalizedLanguageOfCorrespondence, AppError>>;
+  findLocalizedById(id: string, language: Language): Promise<Option<LocalizedLanguageOfCorrespondence>>;
+  getLocalizedByCode(code: string, language: Language): Promise<Result<LocalizedLanguageOfCorrespondence, AppError>>;
+  findLocalizedByCode(code: string, language: Language): Promise<Option<LocalizedLanguageOfCorrespondence>>;
 };
 
 export function getLanguageForCorrespondenceService(): LanguageForCorrespondenceService {

--- a/frontend/app/.server/resources/preferredLanguageForCorrespondence.json
+++ b/frontend/app/.server/resources/preferredLanguageForCorrespondence.json
@@ -2,11 +2,13 @@
   "content": [
     {
       "id": 874190000,
+      "code": "EN",
       "nameEn": "English",
       "nameFr": "Anglais"
     },
     {
       "id": 874190001,
+      "code": "FR",
       "nameEn": "French",
       "nameFr": "Français"
     }

--- a/frontend/app/routes/employee/profile/index.tsx
+++ b/frontend/app/routes/employee/profile/index.tsx
@@ -82,8 +82,9 @@ export async function loader({ context, request }: Route.LoaderArgs) {
   // convert the IDs to display names
   const preferredLanguage =
     profileData.personalInformation.preferredLanguageId &&
-    (await getLanguageForCorrespondenceService().getLocalizedById(profileData.personalInformation.preferredLanguageId, lang)) //TODO add find localized by ID in service
-      .unwrap().name;
+    (
+      await getLanguageForCorrespondenceService().findLocalizedById(profileData.personalInformation.preferredLanguageId, lang)
+    ).unwrap().name;
   const education =
     profileData.personalInformation.educationLevelId &&
     (await getEducationLevelService().getLocalizedById(profileData.personalInformation.educationLevelId, lang)).unwrap().name; //TODO add find localized by ID in service


### PR DESCRIPTION
## Summary

[AB#6277](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6277)
update the language of correspondence service

- Add the `code` field to the mock data
- Add new functions for:
- - get by code
- - find by code
- - find localized by id
- - get localized by code
- - find localized by code

## Types of changes

What types of changes does this PR introduce?

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.

- [x] code has been linted and formatted locally

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>