### PR TITLE
feat(users): add endpoint to retrieve user by network name

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/repository/UserRepository.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/repository/UserRepository.java
@@ -1,5 +1,7 @@
 package ca.gov.dtsstn.vacman.api.data.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.ListCrudRepository;
@@ -12,5 +14,7 @@ import ca.gov.dtsstn.vacman.api.data.entity.UserEntity;
 public interface UserRepository extends ListCrudRepository<UserEntity, Long>, PagingAndSortingRepository<UserEntity, Long> {
 
   Page<UserEntity> findAll(Pageable pageable);
+
+  Optional<UserEntity> findByNetworkName(String networkName);
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/UserService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/UserService.java
@@ -97,6 +97,10 @@ public class UserService {
 		return userRepository.findById(id);
 	}
 
+	public Optional<UserEntity> getUserByNetworkName(String networkName) {
+		return userRepository.findByNetworkName(networkName);
+	}
+
 	public List<UserEntity> getAllUsers() {
 		return List.copyOf(userRepository.findAll());
 	}

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/UsersController.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/UsersController.java
@@ -74,4 +74,15 @@ public class UsersController {
 			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User with ID '" + id + "' not found"));
 		return ResponseEntity.ok(result);
 	}
+
+	@GetMapping("/by-network-name")
+	@Operation(summary = "Get a user by network name.")
+	@SecurityRequirement(name = SpringDocConfig.AZURE_AD)
+	public ResponseEntity<UserReadModel> getUserByNetworkName(
+			@RequestParam String networkName) {
+		UserReadModel result = userService.getUserByNetworkName(networkName)
+			.map(userModelMapper::toModel)
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User with network name '" + networkName + "' not found"));
+		return ResponseEntity.ok(result);
+	}
 }

--- a/backend/src/test/java/ca/gov/dtsstn/vacman/api/data/repository/UserRepositoryTest.java
+++ b/backend/src/test/java/ca/gov/dtsstn/vacman/api/data/repository/UserRepositoryTest.java
@@ -67,5 +67,40 @@ class UserRepositoryTest {
 		assertThat(foundUser.getLastModifiedDate()).isNotNull();
 	}
 
+	@Test
+	@DisplayName("findByNetworkName should return empty Optional when user does not exist")
+	void whenFindByNetworkName_givenUserDoesNotExist_thenReturnEmptyOptional() {
+		assertThat(userRepository.findByNetworkName("12345678-1234-1234-1234-123456789abc")).isNotPresent();
+	}
+
+	@Test
+	@Disabled("Needs to be updated to latest entity models")
+	@DisplayName("findByNetworkName should return user when networkName exists")
+	void whenFindByNetworkName_givenUserExists_thenReturnUser() {
+		when(securityAuditor.getCurrentAuditor()).thenReturn(Optional.of("test-auditor"));
+
+		final var testNetworkName = "2ca209f5-7913-491e-af5a-1f488ce0613b";
+		final var savedUser = userRepository.save(
+			new UserEntityBuilder()
+				.firstName("Test")
+				.lastName("User")
+				.networkName(testNetworkName)
+				.build());
+
+		assertThat(savedUser).isNotNull();
+		assertThat(savedUser.getId()).isNotNull();
+		assertThat(savedUser.getNetworkName()).isEqualTo(testNetworkName);
+
+		final var foundUserOptional = userRepository.findByNetworkName(testNetworkName);
+
+		assertThat(foundUserOptional).isPresent();
+
+		final var foundUser = foundUserOptional.get();
+		assertThat(foundUser.getId()).isEqualTo(savedUser.getId());
+		assertThat(foundUser.getNetworkName()).isEqualTo(testNetworkName);
+		assertThat(foundUser.getFirstName()).isEqualTo("Test");
+		assertThat(foundUser.getLastName()).isEqualTo("User");
+	}
+
 
 }

--- a/backend/src/test/java/ca/gov/dtsstn/vacman/api/service/UserServiceTest.java
+++ b/backend/src/test/java/ca/gov/dtsstn/vacman/api/service/UserServiceTest.java
@@ -130,4 +130,38 @@ class UserServiceTest {
 		assertThat(outputUsers).extracting(UserEntity::getLastName).containsExactly("One", "Two");
 	}
 
+	@Test
+	@DisplayName("getUserByNetworkName should return empty Optional when user does not exist")
+	void getUserByNetworkName_givenUserDoesNotExist_shouldReturnEmptyOptional() {
+		when(userRepository.findByNetworkName("12345678-1234-1234-1234-123456789abc"))
+			.thenReturn(Optional.empty());
+
+		final var result = userService.getUserByNetworkName("12345678-1234-1234-1234-123456789abc");
+
+		assertThat(result).isNotPresent();
+		verify(userRepository).findByNetworkName("12345678-1234-1234-1234-123456789abc");
+	}
+
+	@Test
+	@DisplayName("getUserByNetworkName should return user when networkName exists")
+	void getUserByNetworkName_givenUserExists_shouldReturnUser() {
+		final var testNetworkName = "2ca209f5-7913-491e-af5a-1f488ce0613b";
+		final var mockUser = new UserEntityBuilder()
+			.firstName("Test")
+			.lastName("User")
+			.networkName(testNetworkName)
+			.build();
+
+		when(userRepository.findByNetworkName(testNetworkName))
+			.thenReturn(Optional.of(mockUser));
+
+		final var result = userService.getUserByNetworkName(testNetworkName);
+
+		assertThat(result).isPresent();
+		assertThat(result.get().getNetworkName()).isEqualTo(testNetworkName);
+		assertThat(result.get().getFirstName()).isEqualTo("Test");
+		assertThat(result.get().getLastName()).isEqualTo("User");
+		verify(userRepository).findByNetworkName(testNetworkName);
+	}
+
 }

--- a/backend/src/test/java/ca/gov/dtsstn/vacman/api/web/UsersControllerTest.java
+++ b/backend/src/test/java/ca/gov/dtsstn/vacman/api/web/UsersControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -30,7 +31,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import ca.gov.dtsstn.vacman.api.config.WebSecurityConfig;
-import ca.gov.dtsstn.vacman.api.data.entity.UserEntity;
 import ca.gov.dtsstn.vacman.api.data.entity.UserEntityBuilder;
 import ca.gov.dtsstn.vacman.api.service.UserService;
 import ca.gov.dtsstn.vacman.api.web.model.UserCreateModel;
@@ -65,7 +65,7 @@ class UsersControllerTest {
 				.lastName("Doe")
 				.middelName("A")
 				.initial("JAD")
-				.networkName("john.doe@example.com")
+				.networkName("a1b2c3d4-5678-9012-3456-789abcdef012")
 				.businessEmailAddress("john.doe@example.com")
 				.businessPhoneNumber("555-123-4567")
 				.build(),
@@ -74,7 +74,7 @@ class UsersControllerTest {
 				.lastName("Smith")
 				.middelName("B")
 				.initial("JBS")
-				.networkName("jane.smith@example.com")
+				.networkName("f0e1d2c3-b4a5-9687-1234-56789abcdef0")
 				.businessEmailAddress("jane.smith@example.com")
 				.businessPhoneNumber("555-987-6543")
 				.build());
@@ -103,7 +103,7 @@ class UsersControllerTest {
 			.lastName("Doe")
 			.middelName("A")
 			.initial("JAD")
-			.networkName("test@example.com")
+			.networkName("9f8e7d6c-5b4a-3921-8765-4321098765dc")
 			.businessEmailAddress("test@example.com")
 			.businessPhoneNumber("555-123-4567")
 			.build();
@@ -121,6 +121,87 @@ class UsersControllerTest {
 			.andExpect(content().json(objectMapper.writeValueAsString(expectedResponse)));
 
 		verify(userService).createUser(any(UserCreateModel.class));
+	}
+
+	@Test
+	@WithMockUser(authorities = { "SCOPE_employee" })
+	@DisplayName("GET /api/v1/users?networkName=... - Should return user collection when networkName exists")
+	void getUsers_givenNetworkNameExists_shouldReturnUserCollection() throws Exception {
+		final var testNetworkName = "2ca209f5-7913-491e-af5a-1f488ce0613b";
+		final var mockUser = new UserEntityBuilder()
+			.firstName("Test")
+			.lastName("User")
+			.middelName("T")
+			.initial("TTU")
+			.networkName(testNetworkName)
+			.businessEmailAddress("test.user@example.com")
+			.businessPhoneNumber("555-123-4567")
+			.build();
+
+		when(userService.getUserByNetworkName(testNetworkName))
+			.thenReturn(Optional.of(mockUser));
+
+		final var expectedUserModel = userModelMapper.toModel(mockUser);
+		final var expectedResponse = List.of(expectedUserModel);
+
+		mockMvc.perform(get("/api/v1/users")
+			.param("networkName", testNetworkName))
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+			.andExpect(content().json(objectMapper.writeValueAsString(expectedResponse)));
+
+		verify(userService).getUserByNetworkName(testNetworkName);
+	}
+
+	@Test
+	@WithMockUser(authorities = { "SCOPE_employee" })
+	@DisplayName("GET /api/v1/users?networkName=... - Should return empty collection when user does not exist")
+	void getUsers_givenNetworkNameDoesNotExist_shouldReturnEmptyCollection() throws Exception {
+		final var testNetworkName = "12345678-1234-1234-1234-123456789abc";
+
+		when(userService.getUserByNetworkName(testNetworkName))
+			.thenReturn(Optional.empty());
+
+		final var expectedResponse = List.of();
+
+		mockMvc.perform(get("/api/v1/users")
+			.param("networkName", testNetworkName))
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+			.andExpect(content().json(objectMapper.writeValueAsString(expectedResponse)));
+
+		verify(userService).getUserByNetworkName(testNetworkName);
+	}
+
+	@Test
+	@WithMockUser(authorities = { "SCOPE_employee" })
+	@DisplayName("GET /api/v1/users?networkName= - Should return empty collection when networkName is blank")
+	void getUsers_givenBlankNetworkName_shouldReturnPaginatedResults() throws Exception {
+		final var mockUsers = List.of(
+			new UserEntityBuilder()
+				.firstName("John")
+				.lastName("Doe")
+				.middelName("A")
+				.initial("JAD")
+				.networkName("c4b3a2d1-e5f6-7890-1234-56789abcdef0")
+				.businessEmailAddress("john.doe@example.com")
+				.businessPhoneNumber("555-123-4567")
+				.build());
+
+		final var pageable = PageRequest.of(0, 20);
+		final var mockPage = new PageImpl<>(mockUsers, pageable, 1);
+
+		when(userService.getUsers(any(Pageable.class))).thenReturn(mockPage);
+
+		final var expectedResponse = mockPage.map(userModelMapper::toModel);
+
+		mockMvc.perform(get("/api/v1/users")
+			.param("networkName", ""))
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+			.andExpect(content().json(objectMapper.writeValueAsString(expectedResponse)));
+
+		verify(userService).getUsers(any(Pageable.class));
 	}
 
 }


### PR DESCRIPTION
This pull request adds functionality to retrieve a user by their network name across the repository, service, and controller layers. The most important changes include introducing a new method in `UserRepository`, updating `UserService` to support the new retrieval method, and adding a new endpoint in `UsersController`.

### Repository layer changes:
* [`backend/src/main/java/ca/gov/dtsstn/vacman/api/data/repository/UserRepository.java`](diffhunk://#diff-f015137b1db2975563b19bc413db635a84ebe191dc8f91cb8554dfe9fab525a4R18-R19): Added `findByNetworkName(String networkName)` method to allow querying users by their network name.

### Service layer changes:
* [`backend/src/main/java/ca/gov/dtsstn/vacman/api/service/UserService.java`](diffhunk://#diff-976db1c7259d084d38bd7ca417d672fc44552661afdd0061aa0b9db238d7792eR100-R103): Introduced `getUserByNetworkName(String networkName)` method to wrap the repository call for retrieving users by network name.

### Controller layer changes:
* [`backend/src/main/java/ca/gov/dtsstn/vacman/api/web/UsersController.java`](diffhunk://#diff-f40df9bae6b6b1ffa33042b434338d0e1b1f0e611a10d24ed7a0feda91fe48baR77-R87): Added a new endpoint `/by-network-name` to retrieve user details by network name, including security requirements and OpenAPI documentation.