### PR TITLE
refactor(frontend): update branch and directorate service

### DIFF
--- a/frontend/app/.server/domain/services/branch-service-mock.ts
+++ b/frontend/app/.server/domain/services/branch-service-mock.ts
@@ -1,5 +1,5 @@
 import type { Result, Option } from 'oxide.ts';
-import { Err, None, Ok, Some } from 'oxide.ts';
+import { Err, Ok } from 'oxide.ts';
 
 import type { Branch, LocalizedBranch } from '~/.server/domain/models';
 import type { BranchService } from '~/.server/domain/services/branch-service';
@@ -9,20 +9,24 @@ import { ErrorCodes } from '~/errors/error-codes';
 
 export function getMockBranchService(): BranchService {
   return {
-    getAll: () => Promise.resolve(getAll()),
+    listAll: () => Promise.resolve(listAll()),
     getById: (id: string) => Promise.resolve(getById(id)),
-    findById: (id: string) => Promise.resolve(findById(id)),
-    getAllLocalized: (language: Language) => Promise.resolve(getAllLocalized(language)),
+    getByCode: (code: string) => Promise.resolve(getByCode(code)),
+    listAllLocalized: (language: Language) => Promise.resolve(listAllLocalized(language)),
     getLocalizedById: (id: string, language: Language) => Promise.resolve(getLocalizedById(id, language)),
+    findLocalizedById: (id: string, language: Language) => Promise.resolve(findLocalizedById(id, language)),
+    getLocalizedByCode: (code: string, language: Language) => Promise.resolve(getLocalizedByCode(code, language)),
+    findLocalizedByCode: (code: string, language: Language) => Promise.resolve(findLocalizedByCode(code, language)),
   };
 }
 
 /**
  * Retrieves a list of all esdc branches.
  *
- * @returns An array of esdc branch objects.
+ * @returns A promise that resolves to an array of esdc branches objects. The array will be empty if none are found.
+ * @throws {AppError} if the API call fails for any reason (e.g., network error, server error).
  */
-function getAll(): Result<readonly Branch[], AppError> {
+function listAll(): Branch[] {
   const branches: Branch[] = workUnitData.content
     .filter((c) => c.parent === null)
     .map((branch) => ({
@@ -31,8 +35,7 @@ function getAll(): Result<readonly Branch[], AppError> {
       nameEn: branch.nameEn,
       nameFr: branch.nameFr,
     }));
-
-  return Ok(branches);
+  return branches;
 }
 
 /**
@@ -42,14 +45,8 @@ function getAll(): Result<readonly Branch[], AppError> {
  * @returns The branch object if found or {AppError} If the branch is not found.
  */
 function getById(id: string): Result<Branch, AppError> {
-  const result = getAll();
-
-  if (result.isErr()) {
-    return result;
-  }
-
-  const branches = result.unwrap();
-  const branch = branches.find((p) => p.id === id);
+  const result = listAll();
+  const branch = result.find((p) => p.id === id);
 
   return branch ? Ok(branch) : Err(new AppError(`Branch with ID '${id}' not found.`, ErrorCodes.NO_BRANCH_FOUND));
 }
@@ -57,37 +54,31 @@ function getById(id: string): Result<Branch, AppError> {
 /**
  * Retrieves a single branch by its ID.
  *
- * @param id The ID of the branch to retrieve.
- * @returns The branch object if found or undefined if not found.
+ * @param code The CODE of the branch to retrieve.
+ * @returns The branch object if found or {AppError} If the branch is not found.
  */
-function findById(id: string): Option<Branch> {
-  const result = getAll();
+function getByCode(code: string): Result<Branch, AppError> {
+  const result = listAll();
+  const branch = result.find((p) => p.code === code);
 
-  if (result.isErr()) {
-    return None;
-  }
-  const branches = result.unwrap();
-  const branch = branches.find((p) => p.id === id);
-
-  return branch ? Some(branch) : None;
+  return branch ? Ok(branch) : Err(new AppError(`Branch with CODE '${code}' not found.`, ErrorCodes.NO_BRANCH_FOUND));
 }
 
 /**
- * Retrieves a list of branches localized to the specified language.
+ * Retrieves a list of all branchs, localized to the specified language.
  *
- * @param language The language to localize the branch names to.
- * @returns An array of localized branch objects.
+ * @param language The language for localization.
+ * @returns A promise that resolves to an array of localized branch objects.
+ * @throws {AppError} if the API call fails for any reason.
  */
-function getAllLocalized(language: Language): Result<readonly LocalizedBranch[], AppError> {
-  return getAll().map((branches) =>
-    branches
-      .map((branch) => ({
-        id: branch.id.toString(),
-        code: branch.code,
-        name: language === 'fr' ? branch.nameFr : branch.nameEn,
-      }))
-      .sort((a, b) => a.name.localeCompare(b.name, language, { sensitivity: 'base' })),
-  );
+function listAllLocalized(language: Language): LocalizedBranch[] {
+  return listAll()
+    .map((branch) => ({
+      id: branch.id,
+      code: branch.code,
+      name: language === 'fr' ? branch.nameFr : branch.nameEn,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name, language, { sensitivity: 'base' }));
 }
 
 /**
@@ -98,9 +89,50 @@ function getAllLocalized(language: Language): Result<readonly LocalizedBranch[],
  * @returns The localized branch object if found or {AppError} If the branch is not found.
  */
 function getLocalizedById(id: string, language: Language): Result<LocalizedBranch, AppError> {
-  return getAllLocalized(language).andThen((branches) => {
-    const branch = branches.find((b) => b.id === id);
+  const result = getById(id);
+  return result.map((branch) => ({
+    id: branch.id,
+    code: branch.code,
+    name: language === 'fr' ? branch.nameFr : branch.nameEn,
+  }));
+}
 
-    return branch ? Ok(branch) : Err(new AppError(`Localized branch with ID '${id}' not found.`, ErrorCodes.NO_BRANCH_FOUND));
-  });
+/**
+ * Retrieves a single localized branch by its ID.
+ *
+ * @param id The ID of the branch to retrieve.
+ * @param language The language to localize the directorate name to.
+ * @returns The localized branch object if found or undefined if not found.
+ */
+function findLocalizedById(id: string, language: Language): Option<LocalizedBranch> {
+  const result = getLocalizedById(id, language);
+  return result.ok();
+}
+
+/**
+ * Retrieves a single localized branch by its CODE.
+ *
+ * @param code The CODE of the branch to retrieve.
+ * @param language The language to localize the language name to.
+ * @returns The localized branch object if found or {AppError} If the branch is not found.
+ */
+function getLocalizedByCode(code: string, language: Language): Result<LocalizedBranch, AppError> {
+  const result = getByCode(code);
+  return result.map((branch) => ({
+    id: branch.id,
+    code: branch.code,
+    name: language === 'fr' ? branch.nameFr : branch.nameEn,
+  }));
+}
+
+/**
+ * Retrieves a single localized branch by its CODE.
+ *
+ * @param code The CODE of the branch to retrieve.
+ * @param language The language to localize the directorate name to.
+ * @returns The localized branch object if found or undefined if not found.
+ */
+function findLocalizedByCode(code: string, language: Language): Option<LocalizedBranch> {
+  const result = getLocalizedByCode(code, language);
+  return result.ok();
 }

--- a/frontend/app/.server/domain/services/branch-service.ts
+++ b/frontend/app/.server/domain/services/branch-service.ts
@@ -7,11 +7,14 @@ import { serverEnvironment } from '~/.server/environment';
 import type { AppError } from '~/errors/app-error';
 
 export type BranchService = {
-  getAll(): Promise<Result<readonly Branch[], AppError>>;
+  listAll(): Promise<readonly Branch[]>;
   getById(id: string): Promise<Result<Branch, AppError>>;
-  findById(id: string): Promise<Option<Branch>>;
-  getAllLocalized(language: Language): Promise<Result<readonly LocalizedBranch[], AppError>>;
+  getByCode(code: string): Promise<Result<Branch, AppError>>;
+  listAllLocalized(language: Language): Promise<readonly LocalizedBranch[]>;
   getLocalizedById(id: string, language: Language): Promise<Result<LocalizedBranch, AppError>>;
+  findLocalizedById(id: string, language: Language): Promise<Option<LocalizedBranch>>;
+  getLocalizedByCode(code: string, language: Language): Promise<Result<LocalizedBranch, AppError>>;
+  findLocalizedByCode(code: string, language: Language): Promise<Option<LocalizedBranch>>;
 };
 
 export function getBranchService(): BranchService {

--- a/frontend/app/.server/domain/services/directorate-service-mock.ts
+++ b/frontend/app/.server/domain/services/directorate-service-mock.ts
@@ -1,7 +1,7 @@
 import type { Result, Option } from 'oxide.ts';
-import { Err, None, Ok, Some } from 'oxide.ts';
+import { Err, Ok } from 'oxide.ts';
 
-import type { Directorate, LocalizedDirectorate } from '~/.server/domain/models';
+import type { LocalizedDirectorate, Directorate } from '~/.server/domain/models';
 import type { DirectorateService } from '~/.server/domain/services/directorate-service';
 import workUnitData from '~/.server/resources/workUnit.json';
 import { AppError } from '~/errors/app-error';
@@ -9,14 +9,10 @@ import { ErrorCodes } from '~/errors/error-codes';
 
 export function getMockDirectorateService(): DirectorateService {
   return {
-    getAll: () => Promise.resolve(getAll()),
+    listAll: () => Promise.resolve(listAll()),
     getById: (id: string) => Promise.resolve(getById(id)),
-    findById: (id: string) => Promise.resolve(findById(id)),
     getByCode: (code: string) => Promise.resolve(getByCode(code)),
-    findByCode: (code: string) => Promise.resolve(findByCode(code)),
-    getAllByBranchId: (branchId: string) => Promise.resolve(getAllByBranchId(branchId)),
-    getAllByBranchCode: (branchCode: string) => Promise.resolve(getAllByBranchCode(branchCode)),
-    getAllLocalized: (language: Language) => Promise.resolve(getAllLocalized(language)),
+    listAllLocalized: (language: Language) => Promise.resolve(listAllLocalized(language)),
     getLocalizedById: (id: string, language: Language) => Promise.resolve(getLocalizedById(id, language)),
     findLocalizedById: (id: string, language: Language) => Promise.resolve(findLocalizedById(id, language)),
     getLocalizedByCode: (code: string, language: Language) => Promise.resolve(getLocalizedByCode(code, language)),
@@ -27,9 +23,10 @@ export function getMockDirectorateService(): DirectorateService {
 /**
  * Retrieves a list of all esdc directorates.
  *
- * @returns An array of esdc directorate objects.
+ * @returns A promise that resolves to an array of esdc directorates objects. The array will be empty if none are found.
+ * @throws {AppError} if the API call fails for any reason (e.g., network error, server error).
  */
-function getAll(): Result<readonly Directorate[], AppError> {
+function listAll(): Directorate[] {
   const directorates: Directorate[] = workUnitData.content
     .filter((c) => c.parent !== null)
     .map((directorate) => ({
@@ -44,8 +41,7 @@ function getAll(): Result<readonly Directorate[], AppError> {
         nameFr: directorate.parent.nameFr,
       },
     }));
-
-  return Ok(directorates);
+  return directorates;
 }
 
 /**
@@ -55,36 +51,12 @@ function getAll(): Result<readonly Directorate[], AppError> {
  * @returns The directorate object if found or {AppError} If the directorate is not found.
  */
 function getById(id: string): Result<Directorate, AppError> {
-  const result = getAll();
-
-  if (result.isErr()) {
-    return result;
-  }
-
-  const directorates = result.unwrap();
-  const directorate = directorates.find((p) => p.id === id);
+  const result = listAll();
+  const directorate = result.find((p) => p.id === id);
 
   return directorate
     ? Ok(directorate)
     : Err(new AppError(`Directorate with ID '${id}' not found.`, ErrorCodes.NO_DIRECTORATE_FOUND));
-}
-
-/**
- * Retrieves a single directorate by its ID.
- *
- * @param id The ID of the directorate to retrieve.
- * @returns The directorate object if found or undefined if not found.
- */
-function findById(id: string): Option<Directorate> {
-  const result = getAll();
-
-  if (result.isErr()) {
-    return None;
-  }
-  const directorates = result.unwrap();
-  const directorate = directorates.find((p) => p.id === id);
-
-  return directorate ? Some(directorate) : None;
 }
 
 /**
@@ -94,125 +66,34 @@ function findById(id: string): Option<Directorate> {
  * @returns The directorate object if found or {AppError} If the directorate is not found.
  */
 function getByCode(code: string): Result<Directorate, AppError> {
-  const result = getAll();
-
-  if (result.isErr()) {
-    return result;
-  }
-
-  const directorates = result.unwrap();
-  const directorate = directorates.find((p) => p.code === code);
+  const result = listAll();
+  const directorate = result.find((p) => p.code === code);
 
   return directorate
     ? Ok(directorate)
-    : Err(new AppError(`Directorate with ID '${code}' not found.`, ErrorCodes.NO_DIRECTORATE_FOUND));
+    : Err(new AppError(`Directorate with CODE '${code}' not found.`, ErrorCodes.NO_DIRECTORATE_FOUND));
 }
 
 /**
- * Retrieves a list of all directorates by branch ID.
+ * Retrieves a list of all directorates, localized to the specified language.
  *
- * @param branchId The ID of the branch to retrieve directorates.
- * @returns An array of directorates objects.
+ * @param language The language for localization.
+ * @returns A promise that resolves to an array of localized directorate objects.
+ * @throws {AppError} if the API call fails for any reason.
  */
-function getAllByBranchId(branchId: string): Result<readonly Directorate[], AppError> {
-  const result = getAll();
-
-  if (result.isErr()) {
-    return result;
-  }
-
-  const allDirectorates = result.unwrap();
-
-  const directorates = allDirectorates
-    .filter((c) => c.parent.id === branchId)
+function listAllLocalized(language: Language): LocalizedDirectorate[] {
+  return listAll()
     .map((directorate) => ({
-      id: directorate.id.toString(),
+      id: directorate.id,
       code: directorate.code,
-      nameEn: directorate.nameEn,
-      nameFr: directorate.nameFr,
+      name: language === 'fr' ? directorate.nameFr : directorate.nameEn,
       parent: {
-        id: directorate.parent.id.toString(),
+        id: directorate.parent.id,
         code: directorate.parent.code,
-        nameEn: directorate.parent.nameEn,
-        nameFr: directorate.parent.nameFr,
+        name: language === 'fr' ? directorate.parent.nameFr : directorate.parent.nameEn,
       },
-    }));
-
-  return Ok(directorates);
-}
-
-/**
- * Retrieves a list of all directorates by branch ID.
- *
- * @param branchId The ID of the branch to retrieve directorates.
- * @returns An array of directorates objects.
- */
-function getAllByBranchCode(branchCode: string): Result<readonly Directorate[], AppError> {
-  const result = getAll();
-
-  if (result.isErr()) {
-    return result;
-  }
-
-  const allDirectorates = result.unwrap();
-
-  const directorates = allDirectorates
-    .filter((c) => c.parent.code === branchCode)
-    .map((directorate) => ({
-      id: directorate.id.toString(),
-      code: directorate.code,
-      nameEn: directorate.nameEn,
-      nameFr: directorate.nameFr,
-      parent: {
-        id: directorate.parent.id.toString(),
-        code: directorate.parent.code,
-        nameEn: directorate.parent.nameEn,
-        nameFr: directorate.parent.nameFr,
-      },
-    }));
-
-  return Ok(directorates);
-}
-
-/**
- * Retrieves a single directorate by its CODE.
- *
- * @param code The CODE of the directorate to retrieve.
- * @returns The directorate object if found or undefined if not found.
- */
-function findByCode(code: string): Option<Directorate> {
-  const result = getAll();
-
-  if (result.isErr()) {
-    return None;
-  }
-  const directorates = result.unwrap();
-  const directorate = directorates.find((p) => p.code === code);
-
-  return directorate ? Some(directorate) : None;
-}
-
-/**
- * Retrieves a list of directorates localized to the specified language.
- *
- * @param language The language to localize the directorate names to.
- * @returns An array of localized directorate objects.
- */
-function getAllLocalized(language: Language): Result<readonly LocalizedDirectorate[], AppError> {
-  return getAll().map((directorates) =>
-    directorates
-      .map((directorate) => ({
-        id: directorate.id,
-        code: directorate.code,
-        name: language === 'fr' ? directorate.nameFr : directorate.nameEn,
-        parent: {
-          id: directorate.parent.id.toString(),
-          code: directorate.parent.code,
-          name: language === 'fr' ? directorate.parent.nameFr : directorate.parent.nameEn,
-        },
-      }))
-      .sort((a, b) => a.name.localeCompare(b.name, language, { sensitivity: 'base' })),
-  );
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name, language, { sensitivity: 'base' }));
 }
 
 /**
@@ -223,13 +104,17 @@ function getAllLocalized(language: Language): Result<readonly LocalizedDirectora
  * @returns The localized directorate object if found or {AppError} If the directorate is not found.
  */
 function getLocalizedById(id: string, language: Language): Result<LocalizedDirectorate, AppError> {
-  return getAllLocalized(language).andThen((directorates) => {
-    const directorate = directorates.find((c) => c.id === id);
-
-    return directorate
-      ? Ok(directorate)
-      : Err(new AppError(`Localized directorate with ID '${id}' not found.`, ErrorCodes.NO_DIRECTORATE_FOUND));
-  });
+  const result = getById(id);
+  return result.map((directorate) => ({
+    id: directorate.id,
+    code: directorate.code,
+    name: language === 'fr' ? directorate.nameFr : directorate.nameEn,
+    parent: {
+      id: directorate.parent.id,
+      code: directorate.parent.code,
+      name: language === 'fr' ? directorate.parent.nameFr : directorate.parent.nameEn,
+    },
+  }));
 }
 
 /**
@@ -240,15 +125,8 @@ function getLocalizedById(id: string, language: Language): Result<LocalizedDirec
  * @returns The localized directorate object if found or undefined If the directorate is not found.
  */
 function findLocalizedById(id: string, language: Language): Option<LocalizedDirectorate> {
-  const result = getAllLocalized(language);
-
-  if (result.isErr()) {
-    return None;
-  }
-  const directorates = result.unwrap();
-  const directorate = directorates.find((p) => p.id === id);
-
-  return directorate ? Some(directorate) : None;
+  const result = getLocalizedById(id, language);
+  return result.ok();
 }
 
 /**
@@ -259,13 +137,17 @@ function findLocalizedById(id: string, language: Language): Option<LocalizedDire
  * @returns The localized directorate object if found or {AppError} If the directorate is not found.
  */
 function getLocalizedByCode(code: string, language: Language): Result<LocalizedDirectorate, AppError> {
-  return getAllLocalized(language).andThen((directorates) => {
-    const directorate = directorates.find((c) => c.code === code);
-
-    return directorate
-      ? Ok(directorate)
-      : Err(new AppError(`Localized Directorate with code '${code}' not found.`, ErrorCodes.NO_DIRECTORATE_FOUND));
-  });
+  const result = getByCode(code);
+  return result.map((directorate) => ({
+    id: directorate.id,
+    code: directorate.code,
+    name: language === 'fr' ? directorate.nameFr : directorate.nameEn,
+    parent: {
+      id: directorate.parent.id,
+      code: directorate.parent.code,
+      name: language === 'fr' ? directorate.parent.nameFr : directorate.parent.nameEn,
+    },
+  }));
 }
 
 /**
@@ -276,13 +158,6 @@ function getLocalizedByCode(code: string, language: Language): Result<LocalizedD
  * @returns The localized directorate object if found or undefined If the directorate is not found.
  */
 function findLocalizedByCode(code: string, language: Language): Option<LocalizedDirectorate> {
-  const result = getAllLocalized(language);
-
-  if (result.isErr()) {
-    return None;
-  }
-  const directorates = result.unwrap();
-  const directorate = directorates.find((c) => c.code === code);
-
-  return directorate ? Some(directorate) : None;
+  const result = getLocalizedByCode(code, language);
+  return result.ok();
 }

--- a/frontend/app/.server/domain/services/directorate-service.ts
+++ b/frontend/app/.server/domain/services/directorate-service.ts
@@ -7,14 +7,10 @@ import { serverEnvironment } from '~/.server/environment';
 import type { AppError } from '~/errors/app-error';
 
 export type DirectorateService = {
-  getAll(): Promise<Result<readonly Directorate[], AppError>>;
+  listAll(): Promise<readonly Directorate[]>;
   getById(id: string): Promise<Result<Directorate, AppError>>;
-  findById(id: string): Promise<Option<Directorate>>;
   getByCode(code: string): Promise<Result<Directorate, AppError>>;
-  findByCode(code: string): Promise<Option<Directorate>>;
-  getAllByBranchId(branchId: string): Promise<Result<readonly Directorate[], AppError>>;
-  getAllByBranchCode(branchCode: string): Promise<Result<readonly Directorate[], AppError>>;
-  getAllLocalized(language: Language): Promise<Result<readonly LocalizedDirectorate[], AppError>>;
+  listAllLocalized(language: Language): Promise<readonly LocalizedDirectorate[]>;
   getLocalizedById(id: string, language: Language): Promise<Result<LocalizedDirectorate, AppError>>;
   findLocalizedById(id: string, language: Language): Promise<Option<LocalizedDirectorate>>;
   getLocalizedByCode(code: string, language: Language): Promise<Result<LocalizedDirectorate, AppError>>;

--- a/frontend/app/.server/domain/services/makeApiRequest.ts
+++ b/frontend/app/.server/domain/services/makeApiRequest.ts
@@ -1,6 +1,7 @@
 import { serverEnvironment } from '~/.server/environment';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
+import type { HttpStatusCode } from '~/errors/http-status-codes';
 
 /**
  * Centralized API request logic.
@@ -29,6 +30,7 @@ export async function apiFetch(path: string, context: string): Promise<Response>
     throw new AppError(
       `Failed to ${context.toLowerCase()}. The server responded with status ${response.status}.`,
       ErrorCodes.VACMAN_API_ERROR,
+      { httpStatusCode: response.status as HttpStatusCode },
     );
   }
 

--- a/frontend/app/routes/employee/[id]/profile/employment-information.tsx
+++ b/frontend/app/routes/employee/[id]/profile/employment-information.tsx
@@ -63,8 +63,8 @@ export async function action({ context, params, request }: Route.ActionArgs) {
 export async function loader({ context, request }: Route.LoaderArgs) {
   const { lang, t } = await getTranslation(request, handle.i18nNamespace);
   const substantivePositions = await getClassificationService().getAll();
-  const branchOrServiceCanadaRegions = await getBranchService().getAllLocalized(lang);
-  const directorates = await getDirectorateService().getAllLocalized(lang);
+  const branchOrServiceCanadaRegions = await getBranchService().listAllLocalized(lang);
+  const directorates = await getDirectorateService().listAllLocalized(lang);
   const provinces = await getProvinceService().getAllLocalized(lang);
   const cities = await getCityService().getAllLocalized(lang);
   const wfaStatuses = await getWFAStatuses().getAllLocalized(lang);
@@ -85,8 +85,8 @@ export async function loader({ context, request }: Route.LoaderArgs) {
       hrAdvisor: undefined as string | undefined,
     },
     substantivePositions: substantivePositions.unwrap(),
-    branchOrServiceCanadaRegions: branchOrServiceCanadaRegions.unwrap(),
-    directorates: directorates.unwrap(),
+    branchOrServiceCanadaRegions: branchOrServiceCanadaRegions,
+    directorates: directorates,
     provinces: provinces.unwrap(),
     cities: cities.unwrap(),
     wfaStatuses: wfaStatuses.unwrap(),
@@ -112,7 +112,7 @@ export default function EmploymentInformation({ loaderData, actionData, params }
     { id: 'select-option', name: '' },
     ...loaderData.branchOrServiceCanadaRegions,
   ].map(({ id, name }) => ({
-    value: id === 'select-option' ? '' : id,
+    value: id === 'select-option' ? '' : String(id),
     children: id === 'select-option' ? t('app:form.select-option') : name,
   }));
 
@@ -120,7 +120,7 @@ export default function EmploymentInformation({ loaderData, actionData, params }
     { id: 'select-option', name: '' },
     ...loaderData.directorates.filter((c) => c.parent.id === branch),
   ].map(({ id, name }) => ({
-    value: id === 'select-option' ? '' : id,
+    value: id === 'select-option' ? '' : String(id),
     children: id === 'select-option' ? t('app:form.select-option') : name,
   }));
 

--- a/frontend/app/routes/employee/[id]/profile/index.tsx
+++ b/frontend/app/routes/employee/[id]/profile/index.tsx
@@ -10,7 +10,6 @@ import { useTranslation } from 'react-i18next';
 import type { Route } from './+types/index';
 
 import type { Profile } from '~/.server/domain/models';
-import { getBranchService } from '~/.server/domain/services/branch-service';
 import { getCityService } from '~/.server/domain/services/city-service';
 import { getClassificationService } from '~/.server/domain/services/classification-service';
 import { getDirectorateService } from '~/.server/domain/services/directorate-service';
@@ -89,6 +88,9 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
   const preferredLanguageResult =
     profileData.personalInformation.preferredLanguageId &&
     (await getLanguageForCorrespondenceService().findLocalizedById(profileData.personalInformation.preferredLanguageId, lang));
+  const workUnitResult =
+    profileData.employmentInformation.workUnitId &&
+    (await getDirectorateService().findLocalizedById(profileData.employmentInformation.workUnitId, lang));
 
   const completed = countCompletedItems(profileData);
   const total = Object.keys(profileData).length;
@@ -104,11 +106,8 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
     profileData.employmentInformation.classificationId &&
     (await getClassificationService().findById(profileData.employmentInformation.classificationId)).unwrap().name;
   const branchOrServiceCanadaRegion =
-    profileData.employmentInformation.workUnitId &&
-    (await getBranchService().getLocalizedById(profileData.employmentInformation.workUnitId, lang)).unwrap().name; //TODO add find localized by ID in service
-  const directorate =
-    profileData.employmentInformation.workUnitId &&
-    (await getDirectorateService().findLocalizedById(profileData.employmentInformation.workUnitId, lang)).unwrap().name;
+    workUnitResult && workUnitResult.isSome() ? workUnitResult.unwrap().parent.name : undefined;
+  const directorate = workUnitResult && workUnitResult.isSome() ? workUnitResult.unwrap().name : undefined;
   const province =
     profileData.employmentInformation.provinceId &&
     (await getProvinceService().findLocalizedById(profileData.employmentInformation.provinceId, lang)).unwrap().name;

--- a/frontend/app/routes/employee/[id]/profile/validation.server.ts
+++ b/frontend/app/routes/employee/[id]/profile/validation.server.ts
@@ -25,10 +25,8 @@ const allEducationLevels = await getEducationLevelService().getAll();
 const educationLevels = allEducationLevels.unwrap();
 const allSubstantivePositions = await getClassificationService().getAll();
 const substantivePositions = allSubstantivePositions.unwrap();
-const allBranchOrServiceCanadaRegions = await getBranchService().getAll();
-const branchOrServiceCanadaRegions = allBranchOrServiceCanadaRegions.unwrap();
-const allDirectorates = await getDirectorateService().getAll();
-const directorates = allDirectorates.unwrap();
+const allBranchOrServiceCanadaRegions = await getBranchService().listAll();
+const allDirectorates = await getDirectorateService().listAll();
 const allProvinces = await getProvinceService().getAll();
 const province = allProvinces.unwrap();
 const allCities = await getCityService().getAll();
@@ -99,13 +97,13 @@ export const employmentInformationSchema = v.intersect([
     ),
     branchOrServiceCanadaRegion: v.lazy(() =>
       v.picklist(
-        branchOrServiceCanadaRegions.map(({ id }) => id),
+        allBranchOrServiceCanadaRegions.map(({ id }) => String(id)),
         'app:employment-information.errors.branch-or-service-canada-region-required',
       ),
     ),
     directorate: v.lazy(() =>
       v.picklist(
-        directorates.map(({ id }) => id),
+        allDirectorates.map(({ id }) => String(id)),
         'app:employment-information.errors.directorate-required',
       ),
     ),

--- a/frontend/tests/.server/domain/services/branch-service-default.test.ts
+++ b/frontend/tests/.server/domain/services/branch-service-default.test.ts
@@ -1,13 +1,32 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+import type { Branch } from '~/.server/domain/models';
 import { getDefaultBranchService } from '~/.server/domain/services/branch-service-default';
 import { AppError } from '~/errors/app-error';
+import { ErrorCodes } from '~/errors/error-codes';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
 
-const mockBranches = [
-  { id: '1', nameEn: 'Branch One', nameFr: 'Branche Un' },
-  { id: '2', nameEn: 'Branch Two', nameFr: 'Branche Deux' },
-];
+// Helper to convert API WorkUnit object to Branch, mirroring the implementation
+function toBranch(obj: Branch): Branch {
+  return {
+    id: obj.id.toString(),
+    code: obj.code,
+    nameEn: obj.nameEn,
+    nameFr: obj.nameFr,
+  };
+}
+
+// More robust mock data that also tests the filtering logic in `listAll`
+const mockApiData = {
+  content: [
+    { id: '1', code: 'B01', nameEn: 'Branch One', nameFr: 'Branche Un' },
+    { id: '2', code: 'B02', nameEn: 'Branch Two', nameFr: 'Branche Deux' },
+    { id: '3', code: 'S01', nameEn: 'Sub One', nameFr: 'Sous Un', parent: { id: '1' } }, // This should be filtered out
+  ],
+};
+
+const mockBranchList = mockApiData.content.filter((c) => !('parent' in c)).map(toBranch);
+const singleMockBranch = mockApiData.content[0];
 
 const service = getDefaultBranchService();
 
@@ -16,90 +35,91 @@ beforeEach(() => {
 });
 
 describe('getDefaultBranchService', () => {
-  it('getAll should return branches on success', async () => {
+  it('listAll should return a filtered and mapped list of branches on success', async () => {
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
-      json: () => mockBranches,
+      json: () => Promise.resolve(mockApiData),
     });
 
-    const result = await service.getAll();
-    expect(result.isOk()).toBe(true);
-    expect(result.unwrap()).toEqual(mockBranches);
+    const result = await service.listAll();
+    expect(result).toEqual(mockBranchList);
+    expect(result.length).toBe(2);
   });
 
-  it('getAll should return error on failure', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: false,
-      status: 500,
-    });
-
-    const result = await service.getAll();
-    expect(result.isErr()).toBe(true);
-    expect(result.unwrapErr()).toBeInstanceOf(AppError);
-  });
-
-  it('getById should return a branch if found', async () => {
+  it('getById should return an Ok result with a branch if found', async () => {
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
-      json: () => mockBranches[0],
+      json: () => Promise.resolve(singleMockBranch),
     });
 
     const result = await service.getById('1');
     expect(result.isOk()).toBe(true);
-    expect(result.unwrap().id).toBe('1');
+    expect(result.unwrap()).toEqual(singleMockBranch);
   });
 
-  it('getById should return not found error', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+  it('getById should return an Err result for a 404 Not Found status', async () => {
+    // Mock a non-ok response, which will cause apiFetch to throw an AppError.
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: false,
       status: HttpStatusCodes.NOT_FOUND,
     });
 
     const result = await service.getById('999');
     expect(result.isErr()).toBe(true);
-    expect(result.unwrapErr()).toBeInstanceOf(AppError);
+    const err = result.unwrapErr();
+    expect(err).toBeInstanceOf(AppError);
+    expect(err.errorCode).toBe(ErrorCodes.NO_BRANCH_FOUND);
+    expect(err.message).toBe("ESDC Branches with ID '999' not found.");
   });
 
-  it('findById should return Some if branch exists', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+  it('findLocalizedById should return Some(LocalizedBranch) if branch exists', async () => {
+    // This method calls getById internally, so we mock the fetch for that call.
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
-      json: () => mockBranches,
+      json: () => Promise.resolve(singleMockBranch),
     });
 
-    const result = await service.findById('1');
+    const result = await service.findLocalizedById('1', 'en');
     expect(result.isSome()).toBe(true);
-    expect(result.unwrap().id).toBe('1');
+    const branch = result.unwrap();
+    expect(branch.id).toBe('1');
+    expect(branch.name).toBe('Branch One'); // Check for correct localization
   });
 
-  it('findById should return None if branch does not exist', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: () => mockBranches,
+  it('findLocalizedById should return None if branch does not exist (404)', async () => {
+    // Mock a 404 response for the internal getById call.
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: HttpStatusCodes.NOT_FOUND,
     });
 
-    const result = await service.findById('999');
+    const result = await service.findLocalizedById('999', 'en');
+    // The service handles the 404, converts it to an Err, and find... converts the Err to None.
     expect(result.isNone()).toBe(true);
   });
 
-  it('getLocalized should return localized branches in English', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+  it('listAllLocalized should return localized branches in English', async () => {
+    // Mock for the internal listAll call
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
-      json: () => mockBranches,
+      json: () => Promise.resolve(mockApiData),
     });
 
-    const result = await service.getAllLocalized('en');
-    expect(result.isOk()).toBe(true);
-    expect(result.unwrap()[0]?.name).toBe('Branch One');
+    const result = await service.listAllLocalized('en');
+    expect(result[0]?.name).toBe('Branch One');
+    expect(result[1]?.name).toBe('Branch Two');
+    expect(result.length).toBe(2);
   });
 
-  it('getLocalizedById should return localized branch', async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+  it('getLocalizedById should return an Ok result with a localized branch', async () => {
+    // Mock for the internal getById call
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
-      json: () => mockBranches[0],
+      json: () => Promise.resolve(singleMockBranch),
     });
 
     const result = await service.getLocalizedById('1', 'fr');
     expect(result.isOk()).toBe(true);
-    expect(result.unwrap().name).toBe('Branche Un');
+    expect(result.unwrap().name).toBe('Branche Un'); // Check for correct FR localization
   });
 });

--- a/frontend/tests/.server/domain/services/branch-service-mock.test.ts
+++ b/frontend/tests/.server/domain/services/branch-service-mock.test.ts
@@ -8,21 +8,16 @@ const service = getMockBranchService();
 
 describe('getMockBranchService', () => {
   it('should return all mock branches data', async () => {
-    const result = await service.getAll();
-    expect(result.isOk()).toBe(true);
-    const branches = result.unwrap();
-    expect(Array.isArray(branches)).toBe(true);
-    expect(branches.length).toBeGreaterThan(0);
+    const result = await service.listAll();
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBeGreaterThan(0);
   });
 
   it('should return a branch by ID', async () => {
-    const all = await service.getAll();
-    expect(all.isOk()).toBe(true);
+    const all = await service.listAll();
+    expect(all.length).toBeGreaterThan(0);
 
-    const branches = all.unwrap();
-    expect(branches.length).toBeGreaterThan(0);
-
-    const first = branches[0];
+    const first = all[0];
     if (!first) {
       throw new Error('Expected at least one branch in the list');
     }
@@ -42,41 +37,35 @@ describe('getMockBranchService', () => {
   });
 
   it('should find a branch by ID using Option', async () => {
-    const all = await service.getAll();
-    const branches = all.unwrap();
+    const branches = await service.listAll();
     const first = branches[0];
     if (!first) {
       throw new AppError('Expected at least one branch in the list');
     }
 
-    const result = await service.findById(first.id);
+    const result = await service.findLocalizedById(first.id, 'en');
     expect(result.isSome()).toBe(true);
     expect(result.unwrap().id).toBe(first.id);
   });
 
   it('should return None if branch not found using Option', async () => {
-    const result = await service.findById('non-existent-id');
+    const result = await service.findLocalizedById('non-existent-id', 'en');
     expect(result.isNone()).toBe(true);
   });
 
   it('should return localized branches in English', async () => {
-    const result = await service.getAllLocalized('en' as Language);
-    expect(result.isOk()).toBe(true);
-    const localized = result.unwrap();
-    expect(localized.length).toBeGreaterThan(0);
-    expect(localized[0]).toHaveProperty('name');
+    const result = await service.listAllLocalized('en' as Language);
+    expect(result.length).toBeGreaterThan(0);
+    expect(result[0]).toHaveProperty('name');
   });
 
   it('should return localized branches in French', async () => {
-    const result = await service.getAllLocalized('fr' as Language);
-    expect(result.isOk()).toBe(true);
-    const localized = result.unwrap();
-    expect(localized[0]).toHaveProperty('name');
+    const result = await service.listAllLocalized('fr' as Language);
+    expect(result[0]).toHaveProperty('name');
   });
 
   it('should return a localized branch by ID', async () => {
-    const localized = await service.getAllLocalized('en' as Language);
-    const localizedBranches = localized.unwrap();
+    const localizedBranches = await service.listAllLocalized('en' as Language);
     const first = localizedBranches[0];
     if (!first) {
       throw new AppError('Expected at least one branch in the list');


### PR DESCRIPTION
## Summary

[AB#6281](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6281)
[AB#6282](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6282)
update branch and directorate service to connect with work unit api endpoint
There is single endpoint work-unit for getting the branches and directorates. The branches have no parent, while directorates have a parent work-unit. On the frontend we need both lists separately, so separating them at service level, getting the directories if work unit have a parent, and getting the branches if the work unit have no parent.
While displaying the data, we need only the work unit, the directorate name and branch name can be extracted from work unit.

For validating the pr:
run the api locally.
call the default service directly
and set the env variable to point to the local api

## Types of changes

What types of changes does this PR introduce?

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [x] documentation has been updated to reflect the changes (if applicable)

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>