### PR TITLE
fix(frontend): move client-env script to document head

### DIFF
--- a/frontend/app/components/error-boundaries.tsx
+++ b/frontend/app/components/error-boundaries.tsx
@@ -32,6 +32,11 @@ export function BilingualErrorBoundary({ actionData, error, loaderData, params }
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
+        <script //
+          nonce={loaderData?.nonce}
+          src={`/api/client-env?v=${loaderData?.clientEnvRevision}`}
+          suppressHydrationWarning={true}
+        />
       </head>
       <body>
         <header className="border-b-[3px] border-slate-700 print:hidden">
@@ -139,11 +144,6 @@ export function BilingualErrorBoundary({ actionData, error, loaderData, params }
           </div>
         </footer>
         <Scripts nonce={loaderData?.nonce} />
-        <script //
-          nonce={loaderData?.nonce}
-          src={`/api/client-env?v=${loaderData?.clientEnvRevision}`}
-          suppressHydrationWarning={true}
-        />
       </body>
     </html>
   );
@@ -164,6 +164,11 @@ export function BilingualNotFound({ actionData, error, loaderData, params }: Rou
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
+        <script //
+          nonce={loaderData?.nonce}
+          src={`/api/client-env?v=${loaderData?.clientEnvRevision}`}
+          suppressHydrationWarning={true}
+        />
       </head>
       <body>
         <header className="border-b-[3px] border-slate-700 print:hidden">
@@ -222,11 +227,6 @@ export function BilingualNotFound({ actionData, error, loaderData, params }: Rou
           </div>
         </footer>
         <Scripts nonce={loaderData?.nonce} />
-        <script //
-          nonce={loaderData?.nonce}
-          src={`/api/client-env?v=${loaderData?.clientEnvRevision}`}
-          suppressHydrationWarning={true}
-        />
       </body>
     </html>
   );
@@ -252,6 +252,11 @@ export function UnilingualErrorBoundary({ actionData, error, loaderData, params 
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
+        <script //
+          nonce={loaderData?.nonce}
+          src={`/api/client-env?v=${loaderData?.clientEnvRevision}`}
+          suppressHydrationWarning={true}
+        />
       </head>
       <body>
         <header className="border-b-[3px] border-slate-700 print:hidden">
@@ -318,11 +323,6 @@ export function UnilingualErrorBoundary({ actionData, error, loaderData, params 
           </div>
         </footer>
         <Scripts nonce={loaderData?.nonce} />
-        <script //
-          nonce={loaderData?.nonce}
-          src={`/api/client-env?v=${loaderData?.clientEnvRevision}`}
-          suppressHydrationWarning={true}
-        />
       </body>
     </html>
   );
@@ -342,6 +342,11 @@ export function UnilingualNotFound({ actionData, error, loaderData, params }: Ro
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
+        <script //
+          nonce={loaderData?.nonce}
+          src={`/api/client-env?v=${loaderData?.clientEnvRevision}`}
+          suppressHydrationWarning={true}
+        />
       </head>
       <body>
         <header className="border-b-[3px] border-slate-700 print:hidden">
@@ -384,11 +389,6 @@ export function UnilingualNotFound({ actionData, error, loaderData, params }: Ro
           </div>
         </footer>
         <Scripts nonce={loaderData?.nonce} />
-        <script //
-          nonce={loaderData?.nonce}
-          src={`/api/client-env?v=${loaderData?.clientEnvRevision}`}
-          suppressHydrationWarning={true}
-        />
       </body>
     </html>
   );

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -68,16 +68,16 @@ export default function App({ loaderData }: Route.ComponentProps) {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
-      </head>
-      <body vocab="http://schema.org/" typeof="WebPage">
-        <Outlet />
-        <ScrollRestoration nonce={loaderData.nonce} />
-        <Scripts nonce={loaderData.nonce} />
         <script //
           nonce={loaderData.nonce}
           src={`/api/client-env?v=${loaderData.clientEnvRevision}`}
           suppressHydrationWarning={true}
         />
+      </head>
+      <body vocab="http://schema.org/" typeof="WebPage">
+        <Outlet />
+        <ScrollRestoration nonce={loaderData.nonce} />
+        <Scripts nonce={loaderData.nonce} />
       </body>
     </html>
   );

--- a/frontend/tests/components/__snapshots__/error-boundaries.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/error-boundaries.test.tsx.snap
@@ -16,6 +16,9 @@ exports[`error-boundaries > BilingualErrorBoundary > should correctly render the
       href="build/stub-path-to-module.js"
       rel="modulepreload"
     />
+    <script
+      src="/api/client-env?v=undefined"
+    />
   </head>
   <body>
     <div>
@@ -158,9 +161,6 @@ exports[`error-boundaries > BilingualErrorBoundary > should correctly render the
       >
          
       </script>
-      <script
-        src="/api/client-env?v=undefined"
-      />
     </div>
   </body>
 </html>
@@ -177,6 +177,9 @@ exports[`error-boundaries > BilingualErrorBoundary > should correctly render the
     <meta
       content="width=device-width, initial-scale=1"
       name="viewport"
+    />
+    <script
+      src="/api/client-env?v=undefined"
     />
   </head>
   <body>
@@ -325,9 +328,6 @@ exports[`error-boundaries > BilingualErrorBoundary > should correctly render the
           </div>
         </div>
       </footer>
-      <script
-        src="/api/client-env?v=undefined"
-      />
     </div>
   </body>
 </html>
@@ -344,6 +344,9 @@ exports[`error-boundaries > BilingualNotFound > should correctly render the bili
     <meta
       content="width=device-width, initial-scale=1"
       name="viewport"
+    />
+    <script
+      src="/api/client-env?v=undefined"
     />
   </head>
   <body>
@@ -482,9 +485,6 @@ exports[`error-boundaries > BilingualNotFound > should correctly render the bili
           </div>
         </div>
       </footer>
-      <script
-        src="/api/client-env?v=undefined"
-      />
     </div>
   </body>
 </html>
@@ -501,6 +501,9 @@ exports[`error-boundaries > UnilingualErrorBoundary > should correctly render th
     <meta
       content="width=device-width, initial-scale=1"
       name="viewport"
+    />
+    <script
+      src="/api/client-env?v=undefined"
     />
   </head>
   <body>
@@ -582,9 +585,6 @@ exports[`error-boundaries > UnilingualErrorBoundary > should correctly render th
           </div>
         </div>
       </footer>
-      <script
-        src="/api/client-env?v=undefined"
-      />
     </div>
   </body>
 </html>
@@ -601,6 +601,9 @@ exports[`error-boundaries > UnilingualErrorBoundary > should correctly render th
     <meta
       content="width=device-width, initial-scale=1"
       name="viewport"
+    />
+    <script
+      src="/api/client-env?v=undefined"
     />
   </head>
   <body>
@@ -692,9 +695,6 @@ exports[`error-boundaries > UnilingualErrorBoundary > should correctly render th
           </div>
         </div>
       </footer>
-      <script
-        src="/api/client-env?v=undefined"
-      />
     </div>
   </body>
 </html>
@@ -709,6 +709,9 @@ exports[`error-boundaries > UnilingualNotFound > should correctly render the uni
     <meta
       content="width=device-width, initial-scale=1"
       name="viewport"
+    />
+    <script
+      src="/api/client-env?v=undefined"
     />
   </head>
   <body>
@@ -790,9 +793,6 @@ exports[`error-boundaries > UnilingualNotFound > should correctly render the uni
           </div>
         </div>
       </footer>
-      <script
-        src="/api/client-env?v=undefined"
-      />
     </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary

This PR moves the client environment variables from the document `<body>` to the document `<head>` to prevent a <mark>Cannot destructure property '...' of 'globalThis.__appEnvironment'</mark> issue in chromium based browsers.
