### PR TITLE
fix(frontend): adjust background width on edit-profile page

### DIFF
--- a/frontend/app/routes/employee/[id]/profile/index.tsx
+++ b/frontend/app/routes/employee/[id]/profile/index.tsx
@@ -191,7 +191,7 @@ export default function EditProfile({ loaderData, params }: Route.ComponentProps
         </p>
         <div
           role="presentation"
-          className="absolute top-0 left-0 -z-10 h-60 w-screen scale-x-[-1] bg-[rgba(9,28,45,1)] bg-[url('/VacMan-design-element-06.svg')] bg-size-[450px] bg-left-bottom bg-no-repeat"
+          className="absolute top-0 left-0 -z-10 h-60 w-full scale-x-[-1] bg-[rgba(9,28,45,1)] bg-[url('/VacMan-design-element-06.svg')] bg-size-[450px] bg-left-bottom bg-no-repeat"
         />
       </div>
       <div className="justify-between md:grid md:grid-cols-2">


### PR DESCRIPTION
## Summary

Fix banner overflow on edit-profile page.

## Screenshots

### Before

<img width="924" height="352" alt="Screenshot from 2025-07-17 08-11-30" src="https://github.com/user-attachments/assets/97938441-e2d5-47d6-abc1-2905b487bc6f" />

### After

<img width="924" height="352" alt="Screenshot from 2025-07-17 08-16-34" src="https://github.com/user-attachments/assets/929727b6-a3fa-48a1-9a65-c42c7e7be4fd" />
