### PR TITLE
chore(backend): fix compiler warnings

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/entity/CityEntity.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/entity/CityEntity.java
@@ -48,7 +48,7 @@ public class CityEntity extends AbstractLookupEntity {
 		return province;
 	}
 
-	public void setProvinceId(ProvinceEntity province) {
+	public void setProvince(ProvinceEntity province) {
 		this.province = province;
 	}
 

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/repository/ClassificationRepository.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/repository/ClassificationRepository.java
@@ -1,13 +1,12 @@
 package ca.gov.dtsstn.vacman.api.data.repository;
 
-import ca.gov.dtsstn.vacman.api.data.entity.ClassificationEntity;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import java.util.Optional;
+
 import org.springframework.data.repository.ListCrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import ca.gov.dtsstn.vacman.api.data.entity.ClassificationEntity;
 
 @Repository
 public interface ClassificationRepository extends ListCrudRepository<ClassificationEntity, Long>, PagingAndSortingRepository<ClassificationEntity, Long> {

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/repository/LanguageReferralTypeRepository.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/repository/LanguageReferralTypeRepository.java
@@ -1,13 +1,12 @@
 package ca.gov.dtsstn.vacman.api.data.repository;
 
-import ca.gov.dtsstn.vacman.api.data.entity.LanguageReferralTypeEntity;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import java.util.Optional;
+
 import org.springframework.data.repository.ListCrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import ca.gov.dtsstn.vacman.api.data.entity.LanguageReferralTypeEntity;
 
 @Repository
 public interface LanguageReferralTypeRepository extends ListCrudRepository<LanguageReferralTypeEntity, Long>, PagingAndSortingRepository<LanguageReferralTypeEntity, Long> {

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/repository/LanguageRepository.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/repository/LanguageRepository.java
@@ -1,13 +1,12 @@
 package ca.gov.dtsstn.vacman.api.data.repository;
 
-import ca.gov.dtsstn.vacman.api.data.entity.LanguageEntity;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import java.util.Optional;
+
 import org.springframework.data.repository.ListCrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import ca.gov.dtsstn.vacman.api.data.entity.LanguageEntity;
 
 @Repository
 public interface LanguageRepository extends ListCrudRepository<LanguageEntity, Long>, PagingAndSortingRepository<LanguageEntity, Long> {

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/repository/WorkUnitRepository.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/repository/WorkUnitRepository.java
@@ -1,13 +1,12 @@
 package ca.gov.dtsstn.vacman.api.data.repository;
 
-import ca.gov.dtsstn.vacman.api.data.entity.WorkUnitEntity;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import java.util.Optional;
+
 import org.springframework.data.repository.ListCrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import ca.gov.dtsstn.vacman.api.data.entity.WorkUnitEntity;
 
 @Repository
 public interface WorkUnitRepository extends ListCrudRepository<WorkUnitEntity, Long>, PagingAndSortingRepository<WorkUnitEntity, Long> {

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/ClassificationService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/ClassificationService.java
@@ -1,13 +1,13 @@
 package ca.gov.dtsstn.vacman.api.service;
 
-import ca.gov.dtsstn.vacman.api.data.entity.ClassificationEntity;
-import ca.gov.dtsstn.vacman.api.data.repository.ClassificationRepository;
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Optional;
+import ca.gov.dtsstn.vacman.api.data.entity.ClassificationEntity;
+import ca.gov.dtsstn.vacman.api.data.repository.ClassificationRepository;
 
 @Service
 public class ClassificationService {

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/EducationLevelService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/EducationLevelService.java
@@ -1,13 +1,13 @@
 package ca.gov.dtsstn.vacman.api.service;
 
-import ca.gov.dtsstn.vacman.api.data.entity.EducationLevelEntity;
-import ca.gov.dtsstn.vacman.api.data.repository.EducationLevelRepository;
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Optional;
+import ca.gov.dtsstn.vacman.api.data.entity.EducationLevelEntity;
+import ca.gov.dtsstn.vacman.api.data.repository.EducationLevelRepository;
 
 @Service
 public class EducationLevelService {

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/LanguageReferralTypeService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/LanguageReferralTypeService.java
@@ -1,13 +1,13 @@
 package ca.gov.dtsstn.vacman.api.service;
 
-import ca.gov.dtsstn.vacman.api.data.entity.LanguageReferralTypeEntity;
-import ca.gov.dtsstn.vacman.api.data.repository.LanguageReferralTypeRepository;
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Optional;
+import ca.gov.dtsstn.vacman.api.data.entity.LanguageReferralTypeEntity;
+import ca.gov.dtsstn.vacman.api.data.repository.LanguageReferralTypeRepository;
 
 @Service
 public class LanguageReferralTypeService {

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/LanguageService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/LanguageService.java
@@ -1,13 +1,13 @@
 package ca.gov.dtsstn.vacman.api.service;
 
-import ca.gov.dtsstn.vacman.api.data.entity.LanguageEntity;
-import ca.gov.dtsstn.vacman.api.data.repository.LanguageRepository;
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Optional;
+import ca.gov.dtsstn.vacman.api.data.entity.LanguageEntity;
+import ca.gov.dtsstn.vacman.api.data.repository.LanguageRepository;
 
 @Service
 public class LanguageService {

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/WfaStatusService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/WfaStatusService.java
@@ -1,6 +1,5 @@
 package ca.gov.dtsstn.vacman.api.service;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/model/UserReadModel.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/model/UserReadModel.java
@@ -1,7 +1,5 @@
 package ca.gov.dtsstn.vacman.api.web.model;
 
-import java.time.Instant;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.AccessMode;
 


### PR DESCRIPTION
## Summary

Fix most compiler warnings. The vast majority of them were because of unused imports.
