### PR TITLE
refactor(frontend): update the default services to pass along the error in Err

### DIFF
--- a/frontend/app/.server/domain/services/api-client.ts
+++ b/frontend/app/.server/domain/services/api-client.ts
@@ -1,3 +1,6 @@
+import type { Result } from 'oxide.ts';
+import { Err, Ok } from 'oxide.ts';
+
 import { serverEnvironment } from '~/.server/environment';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
@@ -5,34 +8,71 @@ import type { HttpStatusCode } from '~/errors/http-status-codes';
 
 /**
  * Centralized API request logic.
- * This function handles the fetch call and basic error checking.
- * It will throw an AppError for network failures or non-successful HTTP responses (e.g., 500, 401).
- * The caller is responsible for handling specific status codes like 404 if needed and for parsing the response body.
+ * Performs the raw fetch and handles network/HTTP status errors.
+ * This is an internal helper function for the apiClient.
  * @param path The API endpoint path.
  * @param context A descriptive string for the action being performed, used in error messages.
- * @returns A Promise that resolves to the Response object on success.
- * @throws {AppError} if the fetch call fails or if the server returns a non-ok status.
+ * @returns A Promise that resolves to Result containing the raw Response object or an AppError non-successful HTTP responses (e.g., 500, 401).
+ * @throws {AppError} for network failures or DNS errors etc.
  */
-export async function apiFetch(path: string, context: string): Promise<Response> {
-  let response: Response;
+async function baseFetch(path: string, context: string): Promise<Result<Response, AppError>> {
   try {
-    response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}${path}`);
+    const response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}${path}`);
+
+    // Check for non-successful status codes (4xx, 5xx)
+    if (!response.ok) {
+      return Err(
+        new AppError(
+          `Failed to ${context.toLowerCase()}. The server responded with status ${response.status}.`,
+          ErrorCodes.VACMAN_API_ERROR,
+          { httpStatusCode: response.status as HttpStatusCode },
+        ),
+      );
+    }
+
+    return Ok(response);
   } catch (error) {
     // Network errors, DNS errors, etc.
-    throw new AppError(
-      `A network error occurred while trying to ${context.toLowerCase()}: ${String(error)}`,
-      ErrorCodes.VACMAN_API_ERROR,
+    return Err(
+      new AppError(
+        `A network error occurred while trying to ${context.toLowerCase()}: ${String(error)}`,
+        ErrorCodes.VACMAN_API_ERROR,
+      ),
     );
   }
-
-  if (!response.ok) {
-    // API returned a non-successful status code (4xx, 5xx)
-    throw new AppError(
-      `Failed to ${context.toLowerCase()}. The server responded with status ${response.status}.`,
-      ErrorCodes.VACMAN_API_ERROR,
-      { httpStatusCode: response.status as HttpStatusCode },
-    );
-  }
-
-  return response;
 }
+
+export const apiClient = {
+  /**
+   * Fetches data from a given path and parses it as JSON.
+   * @param T The expected type of the JSON response.
+   * @param path The API endpoint path.
+   * @param context A descriptive string for the action, used in error messages.
+   * @returns A Promise resolving to a Result containing the typed data (T) or an AppError.
+   */
+  async get<T>(path: string, context: string): Promise<Result<T, AppError>> {
+    // Get the raw response using our base fetcher
+    const responseResult = await baseFetch(path, context);
+
+    if (responseResult.isErr()) {
+      return responseResult; // Pass through network/HTTP errors
+    }
+
+    const response = responseResult.unwrap();
+
+    // Try to parse the JSON, handling any parsing errors
+    try {
+      const data = (await response.json()) as T;
+      return Ok(data);
+    } catch (parsingError) {
+      return Err(
+        new AppError(
+          `Failed to parse JSON response on '${context.toLowerCase()}': ${String(parsingError)}`,
+          ErrorCodes.VACMAN_API_ERROR,
+        ),
+      );
+    }
+  },
+
+  // TODO: add post, put, delete methods here in the future following the same pattern.
+};

--- a/frontend/app/.server/domain/services/city-service-default.ts
+++ b/frontend/app/.server/domain/services/city-service-default.ts
@@ -88,7 +88,7 @@ export const cityService: CityService = {
       throw response.unwrapErr();
     }
     const data = response.unwrap();
-    const city = data.content[0]; // Get the first element from the response array
+    const city = data.content.at(0); // Get the first element from the response array
 
     if (!city) {
       // The request was successful, but no status with that code exists.

--- a/frontend/app/.server/domain/services/city-service-default.ts
+++ b/frontend/app/.server/domain/services/city-service-default.ts
@@ -2,7 +2,7 @@ import { Ok, Err } from 'oxide.ts';
 import type { Result, Option } from 'oxide.ts';
 
 import type { City, LocalizedCity } from '~/.server/domain/models';
-import { apiFetch } from '~/.server/domain/services/api-client';
+import { apiClient } from '~/.server/domain/services/api-client';
 import type { CityService } from '~/.server/domain/services/city-service';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
@@ -35,9 +35,13 @@ export const cityService: CityService = {
       content: readonly City[];
     };
     const context = 'list all cities';
-    const response = await apiFetch('/cities', context);
+    const response = await apiClient.get<ApiResponse>('/cities', context);
 
-    const data: ApiResponse = await response.json();
+    if (response.isErr()) {
+      throw response.unwrapErr();
+    }
+
+    const data = response.unwrap();
     return data.content;
   },
 
@@ -49,18 +53,22 @@ export const cityService: CityService = {
    * @throws {AppError} if the API call fails for any reason other than a 404 not found.
    */
   async getById(id: string): Promise<Result<City, AppError>> {
-    const context = `get city with ID '${id}'`;
-    try {
-      const response = await apiFetch(`/cities/${id}`, context);
-      const data: City = await response.json();
-      return Ok(data);
-    } catch (error) {
-      if (error instanceof AppError && error.httpStatusCode === HttpStatusCodes.NOT_FOUND) {
-        return Err(new AppError(`City type with ID '${id}' not found.`, ErrorCodes.NO_CITY_FOUND));
+    const context = `Get City with ID '${id}'`;
+
+    const response = await apiClient.get<City>(`/cities/${id}`, context);
+
+    if (response.isErr()) {
+      const apiFetchError = response.unwrapErr();
+
+      if (apiFetchError.httpStatusCode === HttpStatusCodes.NOT_FOUND) {
+        return Err(new AppError(`${context} not found.`, ErrorCodes.NO_CITY_FOUND));
       }
-      // Re-throw any other error
-      throw error;
+
+      // For all other errors (500, parsing, network), just return them as is.
+      return Err(apiFetchError);
     }
+
+    return response;
   },
 
   /**
@@ -72,17 +80,22 @@ export const cityService: CityService = {
    */
   async getByCode(code: string): Promise<Result<City, AppError>> {
     const context = `get city with CODE '${code}'`;
-    try {
-      const response = await apiFetch(`/cities?code=${code}`, context);
-      const data: City = await response.json();
-      return Ok(data);
-    } catch (error) {
-      if (error instanceof AppError && error.httpStatusCode === HttpStatusCodes.NOT_FOUND) {
-        return Err(new AppError(`City with CODE '${code}' not found.`, ErrorCodes.NO_CITY_FOUND));
-      }
-      // Re-throw any other error
-      throw error;
+    type ApiResponse = {
+      content: readonly City[];
+    };
+    const response = await apiClient.get<ApiResponse>(`/cities?code=${code}`, context);
+    if (response.isErr()) {
+      throw response.unwrapErr();
     }
+    const data = response.unwrap();
+    const city = data.content[0]; // Get the first element from the response array
+
+    if (!city) {
+      // The request was successful, but no status with that code exists.
+      return Err(new AppError(`'${context}' not found.`, ErrorCodes.NO_CITY_FOUND));
+    }
+
+    return Ok(city);
   },
 
   // Localized methods

--- a/frontend/app/.server/domain/services/language-for-correspondence-service-default.ts
+++ b/frontend/app/.server/domain/services/language-for-correspondence-service-default.ts
@@ -1,8 +1,8 @@
 import type { Result, Option } from 'oxide.ts';
-import { Ok, Err } from 'oxide.ts';
+import { Err, Ok } from 'oxide.ts';
 
 import type { LanguageOfCorrespondence, LocalizedLanguageOfCorrespondence } from '~/.server/domain/models';
-import { apiFetch } from '~/.server/domain/services/api-client';
+import { apiClient } from '~/.server/domain/services/api-client';
 import type { LanguageForCorrespondenceService } from '~/.server/domain/services/language-for-correspondence-service';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
@@ -33,9 +33,13 @@ export const languageForCorrespondenceService: LanguageForCorrespondenceService 
       content: readonly LanguageOfCorrespondence[];
     };
     const context = 'list all language of correspondence';
-    const response = await apiFetch('/languages', context);
+    const response = await apiClient.get<ApiResponse>('/languages', context);
 
-    const data: ApiResponse = await response.json();
+    if (response.isErr()) {
+      throw response.unwrapErr();
+    }
+
+    const data = response.unwrap();
     return data.content;
   },
 
@@ -47,20 +51,21 @@ export const languageForCorrespondenceService: LanguageForCorrespondenceService 
    * @throws {AppError} if the API call fails for any reason other than a 404 not found.
    */
   async getById(id: string): Promise<Result<LanguageOfCorrespondence, AppError>> {
-    const context = `get language of correspondence with ID '${id}'`;
-    try {
-      const response = await apiFetch(`/languages/${id}`, context);
-      const data: LanguageOfCorrespondence = await response.json();
-      return Ok(data);
-    } catch (error) {
-      if (error instanceof AppError && error.httpStatusCode === HttpStatusCodes.NOT_FOUND) {
-        return Err(
-          new AppError(`Language of Correspondence with ID '${id}' not found.`, ErrorCodes.NO_LANGUAGE_OF_CORRESPONDENCE_FOUND),
-        );
+    const context = `Get Language of correspondence with ID '${id}'`;
+
+    const response = await apiClient.get<LanguageOfCorrespondence>(`/languages/${id}`, context);
+
+    if (response.isErr()) {
+      const apiFetchError = response.unwrapErr();
+
+      if (apiFetchError.httpStatusCode === HttpStatusCodes.NOT_FOUND) {
+        return Err(new AppError(`${context} not found.`, ErrorCodes.NO_LANGUAGE_OF_CORRESPONDENCE_FOUND));
       }
-      // Re-throw any other error
-      throw error;
+
+      // For all other errors (500, parsing, network), just return them as is.
+      return Err(apiFetchError);
     }
+    return response;
   },
 
   /**
@@ -72,22 +77,23 @@ export const languageForCorrespondenceService: LanguageForCorrespondenceService 
    */
   async getByCode(code: string): Promise<Result<LanguageOfCorrespondence, AppError>> {
     const context = `get Language of Correspondence with CODE '${code}'`;
-    try {
-      const response = await apiFetch(`/languages?code=${code}`, context);
-      const data: LanguageOfCorrespondence = await response.json();
-      return Ok(data);
-    } catch (error) {
-      if (error instanceof AppError && error.httpStatusCode === HttpStatusCodes.NOT_FOUND) {
-        return Err(
-          new AppError(
-            `Language of Correspondence with CODE '${code}' not found.`,
-            ErrorCodes.NO_LANGUAGE_OF_CORRESPONDENCE_FOUND,
-          ),
-        );
-      }
-      // Re-throw any other error
-      throw error;
+    type ApiResponse = {
+      content: readonly LanguageOfCorrespondence[];
+    };
+    const response = await apiClient.get<ApiResponse>(`/languages?code=${code}`, context);
+
+    if (response.isErr()) {
+      throw response.unwrapErr();
     }
+    const data = response.unwrap();
+    const correspondenceLanguage = data.content[0]; // Get the first element from the response array
+
+    if (!correspondenceLanguage) {
+      // The request was successful, but no status with that code exists.
+      return Err(new AppError(`${context} not found.`, ErrorCodes.NO_LANGUAGE_OF_CORRESPONDENCE_FOUND));
+    }
+
+    return Ok(correspondenceLanguage);
   },
 
   /**

--- a/frontend/app/.server/domain/services/province-service-mock.ts
+++ b/frontend/app/.server/domain/services/province-service-mock.ts
@@ -1,22 +1,11 @@
-import type { Result, Option } from 'oxide.ts';
-import { Err, Ok } from 'oxide.ts';
-
 import type { LocalizedProvince, Province } from '~/.server/domain/models';
 import type { ProvinceService } from '~/.server/domain/services/province-service';
 import esdcProvincesData from '~/.server/resources/provinces.json';
-import { AppError } from '~/errors/app-error';
-import { ErrorCodes } from '~/errors/error-codes';
 
 export function getMockProvinceService(): ProvinceService {
   return {
     listAll: () => Promise.resolve(listAll()),
-    getById: (id: string) => Promise.resolve(getById(id)),
-    getByCode: (code: string) => Promise.resolve(getByCode(code)),
     listAllLocalized: (language: Language) => Promise.resolve(listAllLocalized(language)),
-    getLocalizedById: (id: string, language: Language) => Promise.resolve(getLocalizedById(id, language)),
-    findLocalizedById: (id: string, language: Language) => Promise.resolve(findLocalizedById(id, language)),
-    getLocalizedByCode: (code: string, language: Language) => Promise.resolve(getLocalizedByCode(code, language)),
-    findLocalizedByCode: (code: string, language: Language) => Promise.resolve(findLocalizedByCode(code, language)),
   };
 }
 
@@ -37,32 +26,6 @@ function listAll(): Province[] {
 }
 
 /**
- * Retrieves a single province by its ID.
- *
- * @param id The ID of the province to retrieve.
- * @returns The province object if found or {AppError} If the province is not found.
- */
-function getById(id: string): Result<Province, AppError> {
-  const result = listAll();
-  const province = result.find((p) => p.id === id);
-
-  return province ? Ok(province) : Err(new AppError(`Province with ID '${id}' not found.`, ErrorCodes.NO_PROVINCE_FOUND));
-}
-
-/**
- * Retrieves a single province by its code.
- *
- * @param code The code of the province to retrieve (ex. 'ON').
- * @returns The province object if found or {AppError} If the province is not found.
- */
-function getByCode(code: string): Result<Province, AppError> {
-  const result = listAll();
-  const province = result.find((p) => p.code === code);
-
-  return province ? Ok(province) : Err(new AppError(`Province with code '${code}' not found.`, ErrorCodes.NO_PROVINCE_FOUND));
-}
-
-/**
  * Retrieves a list of all provinces, localized to the specified language.
  *
  * @param language The language for localization.
@@ -75,60 +38,4 @@ function listAllLocalized(language: Language): LocalizedProvince[] {
     code: province.code,
     name: language === 'fr' ? province.nameFr : province.nameEn,
   }));
-}
-
-/**
- * Retrieves a single localized province by its ID.
- *
- * @param id The ID of the province to retrieve.
- * @param language The language to localize the province name to.
- * @returns The localized province object if found or {AppError} If the province is not found.
- */
-function getLocalizedById(id: string, language: Language): Result<LocalizedProvince, AppError> {
-  const result = getById(id);
-  return result.map((province) => ({
-    id: province.id,
-    code: province.code,
-    name: language === 'fr' ? province.nameFr : province.nameEn,
-  }));
-}
-
-/**
- * Retrieves a single localized province by its ID.
- *
- * @param id The ID of the province to retrieve.
- * @param language The language to localize the province name to.
- * @returns The localized province object if found or undefined If the province is not found.
- */
-function findLocalizedById(id: string, language: Language): Option<LocalizedProvince> {
-  const result = getLocalizedById(id, language);
-  return result.ok();
-}
-
-/**
- * Retrieves a single localized province by its code.
- *
- * @param code The code of the province to retrieve (ex. 'ON').
- * @param language The language to localize the province name to.
- * @returns The localized province object if found or {AppError} If the province is not found.
- */
-function getLocalizedByCode(code: string, language: Language): Result<LocalizedProvince, AppError> {
-  const result = getByCode(code);
-  return result.map((province) => ({
-    id: province.id,
-    code: province.code,
-    name: language === 'fr' ? province.nameFr : province.nameEn,
-  }));
-}
-
-/**
- * Retrieves a single localized province by its code.
- *
- * @param code The code of the province to retrieve (ex. 'ON').
- * @param language The language to localize the province name to.
- * @returns The localized province object if found or undefined If the province is not found.
- */
-function findLocalizedByCode(code: string, language: Language): Option<LocalizedProvince> {
-  const result = getLocalizedByCode(code, language);
-  return result.ok();
 }

--- a/frontend/app/.server/domain/services/province-service.ts
+++ b/frontend/app/.server/domain/services/province-service.ts
@@ -1,20 +1,11 @@
-import type { Result, Option } from 'oxide.ts';
-
 import type { LocalizedProvince, Province } from '~/.server/domain/models';
 import { getDefaultProvinceService } from '~/.server/domain/services/province-service-default';
 import { getMockProvinceService } from '~/.server/domain/services/province-service-mock';
 import { serverEnvironment } from '~/.server/environment';
-import type { AppError } from '~/errors/app-error';
 
 export type ProvinceService = {
   listAll(): Promise<readonly Province[]>;
-  getById(id: string): Promise<Result<Province, AppError>>;
-  getByCode(code: string): Promise<Result<Province, AppError>>;
   listAllLocalized(language: Language): Promise<readonly LocalizedProvince[]>;
-  getLocalizedById(id: string, language: Language): Promise<Result<LocalizedProvince, AppError>>;
-  findLocalizedById(id: string, language: Language): Promise<Option<LocalizedProvince>>;
-  getLocalizedByCode(code: string, language: Language): Promise<Result<LocalizedProvince, AppError>>;
-  findLocalizedByCode(code: string, language: Language): Promise<Option<LocalizedProvince>>;
 };
 
 export function getProvinceService(): ProvinceService {

--- a/frontend/tests/.server/domain/services/branch-service-default.test.ts
+++ b/frontend/tests/.server/domain/services/branch-service-default.test.ts
@@ -69,7 +69,7 @@ describe('getDefaultBranchService', () => {
     const err = result.unwrapErr();
     expect(err).toBeInstanceOf(AppError);
     expect(err.errorCode).toBe(ErrorCodes.NO_BRANCH_FOUND);
-    expect(err.message).toBe("ESDC Branches with ID '999' not found.");
+    expect(err.message).toBe("Get ESDC Branches with ID '999' not found.");
   });
 
   it('findLocalizedById should return Some(LocalizedBranch) if branch exists', async () => {


### PR DESCRIPTION
## Summary

[AB#6419](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6419)
update the default services to pass along the error in Err instead of defining http status code

## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>