### PR TITLE
refactor(frontend): remove useEffect to fix scrolling

### DIFF
--- a/frontend/app/components/error-summary.tsx
+++ b/frontend/app/components/error-summary.tsx
@@ -42,14 +42,6 @@ export function ErrorSummary({ className, errors, ...rest }: ErrorSummaryProps):
   const { t } = useTranslation(['gcweb']);
   const sectionRef = useRef<HTMLElement>(null);
 
-  // Scroll and focus on the error summary when errors are updated.
-  useEffect(() => {
-    if (errors.length > 0 && sectionRef.current) {
-      sectionRef.current.scrollIntoView({ behavior: 'smooth' });
-      sectionRef.current.focus();
-    }
-  }, [errors]);
-
   if (errors.length === 0) {
     return null;
   }

--- a/frontend/tests/components/__snapshots__/error-summary.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/error-summary.test.tsx.snap
@@ -1,114 +1,154 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`ActionDataErrorSummary > displays errors from action data > expected html 1`] = `
-<div>
-  <div>
-    <section
-      class="my-5 border-4 border-red-600 p-4"
-      role="alert"
-      tabindex="-1"
+exports[`ActionDataErrorSummary > displays errors from form DOM structure > action-data-error-summary-with-errors 1`] = `
+<html>
+  <head />
+  <body>
+    <input
+      aria-errormessage="username-error"
+      id="username"
+    />
+    <div
+      id="username-error"
     >
-      <h2
-        class="font-lato text-lg font-semibold"
-      >
-        {"key":"gcweb:error-summary.header","options":{"count":1}}
-      </h2>
-      <ol
-        class="mt-1.5 list-decimal space-y-2 pl-7"
-      >
-        <li>
-          <a
-            class="text-red-700 underline hover:decoration-2 focus:decoration-2"
-            data-testid="anchor-link"
-            href="#test-field"
+      Username required
+    </div>
+    <div>
+      <div>
+        <section
+          class="my-5 border-4 border-red-600 p-4"
+          role="alert"
+          tabindex="-1"
+        >
+          <h2
+            class="font-lato text-lg font-semibold"
           >
-            Test error message
-          </a>
-        </li>
-      </ol>
-    </section>
-    <div
-      aria-errormessage="test-error"
-      id="test-field"
-    >
-      Test Field
+            There is 1 error
+          </h2>
+          <ol
+            class="mt-1.5 list-decimal space-y-2 pl-7"
+          >
+            <li>
+              <a
+                class="text-red-700 underline hover:decoration-2 focus:decoration-2"
+                href="#username"
+              >
+                Username required
+              </a>
+            </li>
+          </ol>
+        </section>
+        <form>
+          <input
+            aria-errormessage="username-error"
+            id="username"
+          />
+        </form>
+      </div>
     </div>
-    <div
-      id="test-error"
-    >
-      Test error message
-    </div>
-  </div>
-</div>
+  </body>
+</html>
 `;
 
-exports[`ErrorSummary > should not render an error summary when there are no errors > expected html 1`] = `<div />`;
-
-exports[`ErrorSummary > should render an error summary with 1 error > expected html 1`] = `
-<div>
-  <section
-    class="my-5 border-4 border-red-600 p-4"
-    role="alert"
-    tabindex="-1"
-  >
-    <h2
-      class="font-lato text-lg font-semibold"
-    >
-      {"key":"gcweb:error-summary.header","options":{"count":1}}
-    </h2>
-    <ol
-      class="mt-1.5 list-decimal space-y-2 pl-7"
-    >
-      <li>
-        <a
-          class="text-red-700 underline hover:decoration-2 focus:decoration-2"
-          data-testid="anchor-link"
-          href="#input-test"
-        >
-          Test error 1
-        </a>
-      </li>
-    </ol>
-  </section>
-</div>
+exports[`ActionDataErrorSummary > does not display errors if no invalid inputs in DOM > action-data-error-summary-no-errors 1`] = `
+<html>
+  <head />
+  <body>
+    <div>
+      <div>
+        <form>
+          <input
+            id="foo"
+          />
+        </form>
+      </div>
+    </div>
+  </body>
+</html>
 `;
 
-exports[`ErrorSummary > should render an error summary with 2 errors > expected html 1`] = `
-<div>
-  <section
-    class="my-5 border-4 border-red-600 p-4"
-    role="alert"
-    tabindex="-1"
-  >
-    <h2
-      class="font-lato text-lg font-semibold"
-    >
-      {"key":"gcweb:error-summary.header","options":{"count":2}}
-    </h2>
-    <ol
-      class="mt-1.5 list-decimal space-y-2 pl-7"
-    >
-      <li>
-        <a
-          class="text-red-700 underline hover:decoration-2 focus:decoration-2"
-          data-testid="anchor-link"
-          href="#input-test"
+exports[`ErrorSummary > renders error summary with a single error > renders-single-error 1`] = `
+<html>
+  <head />
+  <body>
+    <div>
+      <section
+        class="my-5 border-4 border-red-600 p-4"
+        role="alert"
+        tabindex="-1"
+      >
+        <h2
+          class="font-lato text-lg font-semibold"
         >
-          Test error 1
-        </a>
-      </li>
-      <li>
-        <a
-          class="text-red-700 underline hover:decoration-2 focus:decoration-2"
-          data-testid="anchor-link"
-          href="#input-test"
+          There is 1 error
+        </h2>
+        <ol
+          class="mt-1.5 list-decimal space-y-2 pl-7"
         >
-          Test error 2
-        </a>
-      </li>
-    </ol>
-  </section>
-</div>
+          <li>
+            <a
+              class="text-red-700 underline hover:decoration-2 focus:decoration-2"
+              href="#email"
+            >
+              Email is invalid
+            </a>
+          </li>
+        </ol>
+      </section>
+    </div>
+  </body>
+</html>
+`;
+
+exports[`ErrorSummary > renders error summary with multiple errors > renders-multiple-errors 1`] = `
+<html>
+  <head />
+  <body>
+    <div>
+      <section
+        class="my-5 border-4 border-red-600 p-4 custom-class"
+        data-testid="error-summary"
+        role="alert"
+        tabindex="-1"
+      >
+        <h2
+          class="font-lato text-lg font-semibold"
+        >
+          There are 2 errors
+        </h2>
+        <ol
+          class="mt-1.5 list-decimal space-y-2 pl-7"
+        >
+          <li>
+            <a
+              class="text-red-700 underline hover:decoration-2 focus:decoration-2"
+              href="#first-name"
+            >
+              First name is required
+            </a>
+          </li>
+          <li>
+            <a
+              class="text-red-700 underline hover:decoration-2 focus:decoration-2"
+              href="#last-name"
+            >
+              Last name is required
+            </a>
+          </li>
+        </ol>
+      </section>
+    </div>
+  </body>
+</html>
+`;
+
+exports[`ErrorSummary > renders null when there are no errors > renders-null-when-no-errors 1`] = `
+<html>
+  <head />
+  <body>
+    <div />
+  </body>
+</html>
 `;
 
 exports[`FetcherErrorSummary > displays errors from fetcher data > expected html 1`] = `
@@ -122,7 +162,7 @@ exports[`FetcherErrorSummary > displays errors from fetcher data > expected html
       <h2
         class="font-lato text-lg font-semibold"
       >
-        {"key":"gcweb:error-summary.header","options":{"count":1}}
+        There is 1 error
       </h2>
       <ol
         class="mt-1.5 list-decimal space-y-2 pl-7"
@@ -130,7 +170,6 @@ exports[`FetcherErrorSummary > displays errors from fetcher data > expected html
         <li>
           <a
             class="text-red-700 underline hover:decoration-2 focus:decoration-2"
-            data-testid="anchor-link"
             href="#test-field"
           >
             Test error message
@@ -164,7 +203,7 @@ exports[`FormErrorSummary > displays errors from form action data > expected htm
       <h2
         class="font-lato text-lg font-semibold"
       >
-        {"key":"gcweb:error-summary.header","options":{"count":1}}
+        There is 1 error
       </h2>
       <ol
         class="mt-1.5 list-decimal space-y-2 pl-7"
@@ -172,7 +211,6 @@ exports[`FormErrorSummary > displays errors from form action data > expected htm
         <li>
           <a
             class="text-red-700 underline hover:decoration-2 focus:decoration-2"
-            data-testid="anchor-link"
             href="#test-field"
           >
             Test error message

--- a/frontend/tests/components/error-summary.test.tsx
+++ b/frontend/tests/components/error-summary.test.tsx
@@ -6,56 +6,109 @@ import { mock } from 'vitest-mock-extended';
 
 import { ActionDataErrorSummary, ErrorSummary, FetcherErrorSummary, FormErrorSummary } from '~/components/error-summary';
 
-// See https://github.com/jsdom/jsdom/issues/1695
-Element.prototype.scrollIntoView = vi.fn();
+// Mock t function for i18next
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown> | undefined) => {
+      if (key === 'gcweb:error-summary.header') {
+        return options && typeof options.count === 'number' && options.count === 1
+          ? 'There is 1 error'
+          : `There are ${options && typeof options.count === 'number' ? options.count : 0} errors`;
+      }
+      return key;
+    },
+  }),
+}));
 
 vi.mock('react-router', () => ({
   useFetcher: vi.fn(),
   useActionData: vi.fn(),
 }));
 
-describe('ErrorSummary', () => {
-  it('should not render an error summary when there are no errors', () => {
-    const { container } = render(<ErrorSummary errors={[]} />);
-    expect(container).toMatchSnapshot('expected html');
-    expect(container.ownerDocument.activeElement !== container.querySelector('section')).toBeTruthy();
-  });
-
-  it('should render an error summary with 1 error', () => {
-    const { container } = render(<ErrorSummary errors={[{ fieldId: 'input-test', errorMessage: 'Test error 1' }]} />);
-    expect(container).toMatchSnapshot('expected html');
-    expect(container.ownerDocument.activeElement === container.querySelector('section')).toBeTruthy();
-  });
-
-  it('should render an error summary with 2 errors', () => {
-    const { container } = render(
-      <ErrorSummary
-        errors={[
-          { fieldId: 'input-test', errorMessage: 'Test error 1' },
-          { fieldId: 'input-test', errorMessage: 'Test error 2' },
-        ]}
-      />,
+// Mock AnchorLink for easier testing
+vi.mock('~/components/links', () => ({
+  AnchorLink: (props: { anchorElementId: string; children: React.ReactNode } & Record<string, unknown>) => {
+    const { anchorElementId, children, ...rest } = props;
+    return (
+      <a href={`#${anchorElementId}`} {...rest}>
+        {children}
+      </a>
     );
-    expect(container).toMatchSnapshot('expected html');
-    expect(container.ownerDocument.activeElement === container.querySelector('section')).toBeTruthy();
+  },
+}));
+
+describe('ErrorSummary', () => {
+  it('renders null when there are no errors', () => {
+    render(<ErrorSummary errors={[]} />);
+    expect(document.documentElement).toMatchSnapshot('renders-null-when-no-errors');
+  });
+
+  it('renders error summary with multiple errors', () => {
+    const errors = [
+      { fieldId: 'first-name', errorMessage: 'First name is required' },
+      { fieldId: 'last-name', errorMessage: 'Last name is required' },
+    ];
+    render(<ErrorSummary errors={errors} className="custom-class" data-testid="error-summary" />);
+    expect(document.documentElement).toMatchSnapshot('renders-multiple-errors');
+  });
+
+  it('renders error summary with a single error', () => {
+    const errors = [{ fieldId: 'email', errorMessage: 'Email is invalid' }];
+    render(<ErrorSummary errors={errors} />);
+    expect(document.documentElement).toMatchSnapshot('renders-single-error');
   });
 });
 
 describe('ActionDataErrorSummary', () => {
-  it('displays errors from action data', () => {
-    const actionData = { errors: { field: ['Test error message'] } };
+  // Helper to setup form DOM structure for error extraction
+  function setupFormDom() {
+    // input with aria-errormessage, error message div
+    const input = document.createElement('input');
+    input.id = 'username';
+    input.setAttribute('aria-errormessage', 'username-error');
 
-    const { container } = render(
-      <ActionDataErrorSummary actionData={actionData}>
-        <div id="test-field" aria-errormessage="test-error">
-          Test Field
-        </div>
-        <div id="test-error">{actionData.errors.field.at(0)}</div>
+    const errorDiv = document.createElement('div');
+    errorDiv.id = 'username-error';
+    errorDiv.textContent = 'Username required';
+
+    document.body.appendChild(input);
+    document.body.appendChild(errorDiv);
+
+    return {
+      input,
+      errorDiv,
+      cleanup: () => {
+        input.remove();
+        errorDiv.remove();
+      },
+    };
+  }
+
+  it('displays errors from form DOM structure', () => {
+    const { cleanup: domCleanup } = setupFormDom();
+
+    render(
+      <ActionDataErrorSummary actionData={{}}>
+        <form>
+          <input id="username" aria-errormessage="username-error" />
+        </form>
       </ActionDataErrorSummary>,
     );
 
-    expect(container).toMatchSnapshot('expected html');
-    expect(container.ownerDocument.activeElement === container.querySelector('section')).toBeTruthy();
+    expect(document.documentElement).toMatchSnapshot('action-data-error-summary-with-errors');
+    domCleanup();
+  });
+
+  it('does not display errors if no invalid inputs in DOM', () => {
+    render(
+      <ActionDataErrorSummary actionData={{}}>
+        <form>
+          <input id="foo" />
+        </form>
+      </ActionDataErrorSummary>,
+    );
+
+    expect(document.documentElement).toMatchSnapshot('action-data-error-summary-no-errors');
   });
 });
 
@@ -75,7 +128,6 @@ describe('FetcherErrorSummary', () => {
     );
 
     expect(container).toMatchSnapshot('expected html');
-    expect(container.ownerDocument.activeElement === container.querySelector('section')).toBeTruthy();
   });
 });
 
@@ -94,6 +146,5 @@ describe('FormErrorSummary', () => {
     );
 
     expect(container).toMatchSnapshot('expected html');
-    expect(container.ownerDocument.activeElement === container.querySelector('section')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

removed useEffect() to fix scrolling or focus retriggering on error summary. 

## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>

## Screenshots (if applicable)

Fixed the scrolling or focus retriggering on error summary. When form is submitted, the error summary at the top of page is not scrolled into focus now, but it is lesser evil I guess... 

[Screencast from 2025-07-17 07-50-08.webm](https://github.com/user-attachments/assets/6342b4f0-fcca-4d98-bb35-15dabb65a227)
