### PR TITLE
feat(frontend): load profile data for routes

### DIFF
--- a/frontend/app/routes/employee/[id]/profile/validation.server.ts
+++ b/frontend/app/routes/employee/[id]/profile/validation.server.ts
@@ -76,7 +76,7 @@ export const personalInformationSchema = v.object({
     v.pipe(
       v.string('app:personal-information.errors.additional-information-required'),
       v.trim(),
-      v.length(100, 'app:personal-information.errors.additional-information-max-length'),
+      v.maxLength(100, 'app:personal-information.errors.additional-information-max-length'),
     ),
   ),
 });

--- a/frontend/app/utils/phone-utils.ts
+++ b/frontend/app/utils/phone-utils.ts
@@ -1,4 +1,5 @@
-import { isValidPhoneNumber } from 'libphonenumber-js';
+import { isValidPhoneNumber, parsePhoneNumberFromString } from 'libphonenumber-js';
+import type { CountryCode } from 'libphonenumber-js';
 
 /**
  * Validates phone number based on the following conditions:
@@ -35,4 +36,23 @@ export function isValidPhone(phoneNumber: string): boolean {
  */
 export function extractDigits(input: string) {
   return input.match(/\d/g)?.join('') ?? '';
+}
+
+/**
+ * Converts a phone number string to the E.164 international format.
+ *
+ * @param phoneNumber The phone number string to convert (e.g., "613-938-0001").
+ * @param defaultCountry The ISO 3166-1 alpha-2 country code to use as a hint if the number is not in international format (e.g., 'CA', 'US').
+ * @returns The phone number in E.164 format (e.g., "+16139380001") if valid, otherwise undefined.
+ */
+export function toE164(phoneNumber: string | undefined | null, defaultCountry?: CountryCode): string | undefined {
+  if (!phoneNumber) {
+    return undefined;
+  }
+
+  // parsePhoneNumberFromString is more lenient than parsePhoneNumber
+  const phone = parsePhoneNumberFromString(phoneNumber, defaultCountry ?? 'CA');
+
+  // If the phone number is valid, return it in E.164 format. Otherwise, it returns undefined.
+  return phone?.format('E.164');
 }


### PR DESCRIPTION
## Summary

[AB#6245](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6245)
[AB#6252](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6252)
[AB#6263](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6263)

Load profile data for the following routes: 
- Personal information
- Employment information
- Referral preferences

The phone number wasn't loaded on the input phone number, so added a function to convert the string to E164 in phone utils

Changed the input field for work email from `disabled` to `readOnly`, A read-only input field cannot be modified by the user, but its value is still included when the form is submitted.


## Types of changes

What types of changes does this PR introduce?

- [x] ✨ **new feature** -- non-breaking change that adds functionality

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.

- [x] code has been linted and formatted locally

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
