### PR TITLE
bugfix(frontend): fix wfa effective date and wfa end date not showing on the employee profile

### DIFF
--- a/frontend/app/routes/employee/[id]/profile/index.tsx
+++ b/frontend/app/routes/employee/[id]/profile/index.tsx
@@ -129,7 +129,7 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
     workUnitResult && workUnitResult.isSome() ? workUnitResult.unwrap().parent.name : undefined;
   const directorate = workUnitResult && workUnitResult.isSome() ? workUnitResult.unwrap().name : undefined;
   const city = cityResult && cityResult.isSome() ? cityResult.unwrap() : undefined;
-  const wfaStatus = wfaStatusResult ? (wfaStatusResult.isSome() ? wfaStatusResult.unwrap().name : undefined) : undefined;
+  const wfaStatus = wfaStatusResult ? (wfaStatusResult.isSome() ? wfaStatusResult.unwrap() : undefined) : undefined;
   const hrAdvisor =
     profileData.employmentInformation.hrAdvisor &&
     (await getUserService().getUserById(profileData.employmentInformation.hrAdvisor));
@@ -170,7 +170,8 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
       directorate: directorate,
       province: city?.province.name,
       city: city?.name,
-      wfaStatus: wfaStatus,
+      wfaStatus: wfaStatus?.name,
+      wfaStatusCode: wfaStatus?.code,
       wfaEffectiveDate: profileData.employmentInformation.wfaEffectiveDate,
       wfaEndDate: profileData.employmentInformation.wfaEndDate,
       hrAdvisor: hrAdvisor && hrAdvisor.firstName + ' ' + hrAdvisor.lastName,
@@ -327,9 +328,9 @@ export default function EditProfile({ loaderData, params }: Route.ComponentProps
                 <DescriptionListItem term={t('app:employment-information.wfa-status')}>
                   {loaderData.employmentInformation.wfaStatus ?? t('app:profile.not-provided')}
                 </DescriptionListItem>
-                {(loaderData.employmentInformation.wfaStatus === EMPLOYEE_WFA_STATUS.opting ||
-                  loaderData.employmentInformation.wfaStatus === EMPLOYEE_WFA_STATUS.surplusGRJO ||
-                  loaderData.employmentInformation.wfaStatus === EMPLOYEE_WFA_STATUS.surplusOptingOptionA) && (
+                {(loaderData.employmentInformation.wfaStatusCode === EMPLOYEE_WFA_STATUS.opting ||
+                  loaderData.employmentInformation.wfaStatusCode === EMPLOYEE_WFA_STATUS.surplusGRJO ||
+                  loaderData.employmentInformation.wfaStatusCode === EMPLOYEE_WFA_STATUS.surplusOptingOptionA) && (
                   <>
                     <DescriptionListItem term={t('app:employment-information.wfa-effective-date')}>
                       {loaderData.employmentInformation.wfaEffectiveDate ?? t('app:profile.not-provided')}


### PR DESCRIPTION
## Summary

[AB#6477](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6477)
Fix wfa effective date and wfa end date not showing on the employee profile. The constant for wfa status was changed to `code` instead of `id`. Applying the same logic to check the code and then display the dates based on wfa status.

Add this data to the profile mock to view the Employment information, the wfa effective date and wfa end date are not displayed:
employmentInformation: {
      classificationId: '904190000',
      workUnitId: '294550010',
      cityId: '411290002',
      wfaStatusId: '4',
      wfaEffectiveDate: undefined,
      wfaEndDate: undefined,
      hrAdvisor: 5,
    },

## Types of changes

What types of changes does this PR introduce?

- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue

## Screenshots (if applicable)

<img width="459" height="656" alt="image" src="https://github.com/user-attachments/assets/0255a2a1-0cbd-41ec-a454-e2b3ebf8deca" />
