### PR TITLE
refactor(frontend): update the api path for code tables

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -52,7 +52,7 @@ ENABLE_PROFILE_SERVICES_MOCK=
 # Vacman API configuration
 #################################################
 
-# The base URL to use for the vacman API call (default: http://localhost:8080/api/v1/codes)
+# The base URL to use for the vacman API call (default: http://localhost:8080/api/v1)
 VACMAN_API_BASE_URI=
 
 

--- a/frontend/app/.server/domain/services/branch-service-default.ts
+++ b/frontend/app/.server/domain/services/branch-service-default.ts
@@ -40,7 +40,7 @@ export const branchService: BranchService = {
       content: readonly Branch[];
     };
     const context = 'list all esdc branches';
-    const response = await apiClient.get<ApiResponse>('/work-units', context);
+    const response = await apiClient.get<ApiResponse>('/codes/work-units', context);
 
     if (response.isErr()) {
       throw response.unwrapErr();
@@ -60,7 +60,7 @@ export const branchService: BranchService = {
    */
   async getById(id: string): Promise<Result<Branch, AppError>> {
     const context = `Get ESDC Branches with ID '${id}'`;
-    const response = await apiClient.get<Branch>(`/work-units/${id}`, context);
+    const response = await apiClient.get<Branch>(`/codes/work-units/${id}`, context);
 
     if (response.isErr()) {
       const apiFetchError = response.unwrapErr();
@@ -87,7 +87,7 @@ export const branchService: BranchService = {
     type ApiResponse = {
       content: readonly Branch[];
     };
-    const response = await apiClient.get<ApiResponse>(`/work-units?code=${code}`, context);
+    const response = await apiClient.get<ApiResponse>(`/codes/work-units?code=${code}`, context);
     if (response.isErr()) {
       throw response.unwrapErr();
     }

--- a/frontend/app/.server/domain/services/city-service-default.ts
+++ b/frontend/app/.server/domain/services/city-service-default.ts
@@ -35,7 +35,7 @@ export const cityService: CityService = {
       content: readonly City[];
     };
     const context = 'list all cities';
-    const response = await apiClient.get<ApiResponse>('/cities', context);
+    const response = await apiClient.get<ApiResponse>('/codes/cities', context);
 
     if (response.isErr()) {
       throw response.unwrapErr();
@@ -55,7 +55,7 @@ export const cityService: CityService = {
   async getById(id: string): Promise<Result<City, AppError>> {
     const context = `Get City with ID '${id}'`;
 
-    const response = await apiClient.get<City>(`/cities/${id}`, context);
+    const response = await apiClient.get<City>(`/codes/cities/${id}`, context);
 
     if (response.isErr()) {
       const apiFetchError = response.unwrapErr();
@@ -83,7 +83,7 @@ export const cityService: CityService = {
     type ApiResponse = {
       content: readonly City[];
     };
-    const response = await apiClient.get<ApiResponse>(`/cities?code=${code}`, context);
+    const response = await apiClient.get<ApiResponse>(`/codes/cities?code=${code}`, context);
     if (response.isErr()) {
       throw response.unwrapErr();
     }

--- a/frontend/app/.server/domain/services/classification-service-default.ts
+++ b/frontend/app/.server/domain/services/classification-service-default.ts
@@ -30,7 +30,7 @@ export const classificationService: ClassificationService = {
       content: readonly Classification[];
     };
     const context = 'list all esdc classification groups and levels';
-    const response = await apiClient.get<ApiResponse>('/classifications', context);
+    const response = await apiClient.get<ApiResponse>('/codes/classifications', context);
 
     if (response.isErr()) {
       throw response.unwrapErr();
@@ -50,7 +50,7 @@ export const classificationService: ClassificationService = {
   async getById(id: string): Promise<Result<Classification, AppError>> {
     const context = `Get Classification with ID '${id}'`;
 
-    const response = await apiClient.get<Classification>(`/classifications/${id}`, context);
+    const response = await apiClient.get<Classification>(`/codes/classifications/${id}`, context);
     if (response.isErr()) {
       const apiFetchError = response.unwrapErr();
 
@@ -76,7 +76,7 @@ export const classificationService: ClassificationService = {
     type ApiResponse = {
       content: readonly Classification[];
     };
-    const response = await apiClient.get<ApiResponse>(`/classifications?code=${code}`, context);
+    const response = await apiClient.get<ApiResponse>(`/codes/classifications?code=${code}`, context);
     if (response.isErr()) {
       throw response.unwrapErr();
     }

--- a/frontend/app/.server/domain/services/directorate-service-default.ts
+++ b/frontend/app/.server/domain/services/directorate-service-default.ts
@@ -55,7 +55,7 @@ export const directorateService: DirectorateService = {
       content: readonly Directorate[];
     };
     const context = 'list all esdc directorates';
-    const response = await apiClient.get<ApiResponse>('/work-units', context);
+    const response = await apiClient.get<ApiResponse>('/codes/work-units', context);
 
     if (response.isErr()) {
       throw response.unwrapErr();
@@ -75,7 +75,7 @@ export const directorateService: DirectorateService = {
    */
   async getById(id: string): Promise<Result<Directorate, AppError>> {
     const context = `Get ESDC Directorate with ID '${id}'`;
-    const response = await apiClient.get<Directorate>(`/work-units/${id}`, context);
+    const response = await apiClient.get<Directorate>(`/codes/work-units/${id}`, context);
 
     if (response.isErr()) {
       const apiFetchError = response.unwrapErr();
@@ -107,7 +107,7 @@ export const directorateService: DirectorateService = {
     type ApiResponse = {
       content: readonly Directorate[];
     };
-    const response = await apiClient.get<ApiResponse>(`/work-units?code=${code}`, context);
+    const response = await apiClient.get<ApiResponse>(`/codes/work-units?code=${code}`, context);
     if (response.isErr()) {
       throw response.unwrapErr();
     }

--- a/frontend/app/.server/domain/services/employment-tenure-service-default.ts
+++ b/frontend/app/.server/domain/services/employment-tenure-service-default.ts
@@ -30,7 +30,7 @@ export const employmentTenureService: EmploymentTenureService = {
       content: readonly EmploymentTenure[];
     };
     const context = 'list all employment tenures';
-    const response = await apiClient.get<ApiResponse>('/employment-tenures', context);
+    const response = await apiClient.get<ApiResponse>('/codes/employment-tenures', context);
 
     if (response.isErr()) {
       throw response.unwrapErr();
@@ -50,7 +50,7 @@ export const employmentTenureService: EmploymentTenureService = {
   async getById(id: string): Promise<Result<EmploymentTenure, AppError>> {
     const context = `Get Employment tenure with ID '${id}'`;
 
-    const response = await apiClient.get<EmploymentTenure>(`/employment-tenures/${id}`, context);
+    const response = await apiClient.get<EmploymentTenure>(`/codes/employment-tenures/${id}`, context);
 
     if (response.isErr()) {
       const apiFetchError = response.unwrapErr();
@@ -77,7 +77,7 @@ export const employmentTenureService: EmploymentTenureService = {
     type ApiResponse = {
       content: readonly EmploymentTenure[];
     };
-    const response = await apiClient.get<ApiResponse>(`/employment-tenures?code=${code}`, context);
+    const response = await apiClient.get<ApiResponse>(`/codes/employment-tenures?code=${code}`, context);
 
     if (response.isErr()) {
       throw response.unwrapErr();

--- a/frontend/app/.server/domain/services/language-for-correspondence-service-default.ts
+++ b/frontend/app/.server/domain/services/language-for-correspondence-service-default.ts
@@ -33,7 +33,7 @@ export const languageForCorrespondenceService: LanguageForCorrespondenceService 
       content: readonly LanguageOfCorrespondence[];
     };
     const context = 'list all language of correspondence';
-    const response = await apiClient.get<ApiResponse>('/languages', context);
+    const response = await apiClient.get<ApiResponse>('/codes/languages', context);
 
     if (response.isErr()) {
       throw response.unwrapErr();
@@ -53,7 +53,7 @@ export const languageForCorrespondenceService: LanguageForCorrespondenceService 
   async getById(id: string): Promise<Result<LanguageOfCorrespondence, AppError>> {
     const context = `Get Language of correspondence with ID '${id}'`;
 
-    const response = await apiClient.get<LanguageOfCorrespondence>(`/languages/${id}`, context);
+    const response = await apiClient.get<LanguageOfCorrespondence>(`/codes/languages/${id}`, context);
 
     if (response.isErr()) {
       const apiFetchError = response.unwrapErr();
@@ -80,7 +80,7 @@ export const languageForCorrespondenceService: LanguageForCorrespondenceService 
     type ApiResponse = {
       content: readonly LanguageOfCorrespondence[];
     };
-    const response = await apiClient.get<ApiResponse>(`/languages?code=${code}`, context);
+    const response = await apiClient.get<ApiResponse>(`/codes/languages?code=${code}`, context);
 
     if (response.isErr()) {
       throw response.unwrapErr();

--- a/frontend/app/.server/domain/services/language-referral-type-service-default.ts
+++ b/frontend/app/.server/domain/services/language-referral-type-service-default.ts
@@ -33,7 +33,7 @@ export const languageReferralTypeService: LanguageReferralTypeService = {
       content: readonly LanguageReferralType[];
     };
     const context = 'list all language referral types';
-    const response = await apiClient.get<ApiResponse>('/language-referral-types', context);
+    const response = await apiClient.get<ApiResponse>('/codes/language-referral-types', context);
 
     if (response.isErr()) {
       throw response.unwrapErr();
@@ -52,7 +52,7 @@ export const languageReferralTypeService: LanguageReferralTypeService = {
    */
   async getById(id: string): Promise<Result<LanguageReferralType, AppError>> {
     const context = `Get Language referral type with ID '${id}'`;
-    const response = await apiClient.get<LanguageReferralType>(`/language-referral-types/${id}`, context);
+    const response = await apiClient.get<LanguageReferralType>(`/codes/language-referral-types/${id}`, context);
 
     if (response.isErr()) {
       const apiFetchError = response.unwrapErr();
@@ -79,7 +79,7 @@ export const languageReferralTypeService: LanguageReferralTypeService = {
     type ApiResponse = {
       content: readonly LanguageReferralType[];
     };
-    const response = await apiClient.get<ApiResponse>(`/language-referral-types?code=${code}`, context);
+    const response = await apiClient.get<ApiResponse>(`/codes/language-referral-types?code=${code}`, context);
 
     if (response.isErr()) {
       throw response.unwrapErr();

--- a/frontend/app/.server/domain/services/province-service-default.ts
+++ b/frontend/app/.server/domain/services/province-service-default.ts
@@ -24,7 +24,7 @@ export const provinceService: ProvinceService = {
       content: readonly Province[];
     };
     const context = 'list all provinces';
-    const response = await apiClient.get<ApiResponse>('/provinces', context);
+    const response = await apiClient.get<ApiResponse>('/codes/provinces', context);
 
     if (response.isErr()) {
       throw response.unwrapErr();

--- a/frontend/app/.server/domain/services/wfa-status-service-default.ts
+++ b/frontend/app/.server/domain/services/wfa-status-service-default.ts
@@ -30,7 +30,7 @@ export const wfaStatusService: WFAStatusService = {
       content: readonly WFAStatus[];
     };
     const context = 'list all wfa statuses';
-    const response = await apiClient.get<ApiResponse>('/wfa-statuses', context);
+    const response = await apiClient.get<ApiResponse>('/codes/wfa-statuses', context);
 
     if (response.isErr()) {
       throw response.unwrapErr();
@@ -50,7 +50,7 @@ export const wfaStatusService: WFAStatusService = {
   async getById(id: string): Promise<Result<WFAStatus, AppError>> {
     const context = `Get WFA Statuses with ID '${id}'`;
 
-    const response = await apiClient.get<WFAStatus>(`/work-units/${id}`, context);
+    const response = await apiClient.get<WFAStatus>(`/codes/wfa-statuses/${id}`, context);
 
     if (response.isErr()) {
       const apiFetchError = response.unwrapErr();
@@ -77,7 +77,7 @@ export const wfaStatusService: WFAStatusService = {
     type ApiResponse = {
       content: readonly WFAStatus[];
     };
-    const response = await apiClient.get<ApiResponse>(`/wfa-statuses?code=${code}`, context);
+    const response = await apiClient.get<ApiResponse>(`/codes/wfa-statuses?code=${code}`, context);
 
     if (response.isErr()) {
       throw response.unwrapErr();


### PR DESCRIPTION
## Summary

update the api path for code tables only. All the code tables are behind path /codes, while rest of the endpoints are not.

## Types of changes

What types of changes does this PR introduce?

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure

