### PR TITLE
refactor(frontend): update the employee name and work email source

### DIFF
--- a/frontend/app/.server/domain/services/profile-service-mock.ts
+++ b/frontend/app/.server/domain/services/profile-service-mock.ts
@@ -808,6 +808,8 @@ function registerProfile(activeDirectoryId: string): Profile {
     userUpdated: undefined,
     dateUpdated: undefined,
     personalInformation: {
+      surname: 'Doe',
+      givenName: 'John',
       personalRecordIdentifier: '123456789',
       preferredLanguageId: undefined,
       workEmail: 'work.email@example.ca',

--- a/frontend/app/routes/employee/[id]/profile/index.tsx
+++ b/frontend/app/routes/employee/[id]/profile/index.tsx
@@ -110,13 +110,10 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
   // Use the id parameter from the URL to fetch the profile
   const profileUserId = params.id;
 
-  // Get the user service
-  const userService = getUserService();
   const { lang, t } = await getTranslation(request, handle.i18nNamespace);
 
   // Fetch both the profile user and the profile data
   const [
-    profileUser,
     profileResult,
     allLocalizedLanguageReferralTypes,
     allClassifications,
@@ -124,7 +121,6 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
     allLocalizedEmploymentTenures,
     allWfaStatus,
   ] = await Promise.all([
-    userService.getUserByActiveDirectoryId(profileUserId),
     getProfileService().getProfile(profileUserId),
     getLanguageReferralTypeService().listAllLocalized(lang),
     getClassificationService().listAllLocalized(lang),
@@ -214,8 +210,8 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 
   return {
     documentTitle: t('app:index.about'),
-    name: profileUser?.uuName ?? 'Unknown User',
-    email: profileUser?.businessEmail ?? profileData.personalInformation.workEmail,
+    name: profileData.personalInformation.givenName + ' ' + profileData.personalInformation.surname,
+    email: profileData.personalInformation.workEmail,
     amountCompleted: amountCompleted,
     isProfileComplete: isCompletePersonalInformation && isCompleteEmploymentInformation && isCompleteReferralPreferences,
     personalInformation: {
@@ -223,7 +219,7 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
       isNew: countCompletedItems(profileData.personalInformation) === 1, // only work email is available
       personalRecordIdentifier: profileData.personalInformation.personalRecordIdentifier,
       preferredLanguage: preferredLanguage,
-      workEmail: profileUser?.businessEmail ?? profileData.personalInformation.workEmail,
+      workEmail: profileData.personalInformation.workEmail,
       personalEmail: profileData.personalInformation.personalEmail,
       workPhone: profileData.personalInformation.workPhone,
       personalPhone: profileData.personalInformation.personalPhone,


### PR DESCRIPTION
## Summary

Updated the source of employee name and work email on profile view. Currently the Employee profile is displaying the name and work email of the logged-in user. The Employee Profile can be viewed by Employee, HR Advisor and Hiring manager. So, updating the name and work email address to reflect the name and work email of the employee profile being viewed.

## Types of changes

What types of changes does this PR introduce?

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.

- [x] code has been linted and formatted locally


<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

<img width="944" height="953" alt="image" src="https://github.com/user-attachments/assets/26797bb6-dcff-4e38-a3c1-3be24590c891" />
