### PR TITLE
Added default/mock calls for saving personal information

### DIFF
--- a/frontend/app/.server/domain/services/profile-service-default.ts
+++ b/frontend/app/.server/domain/services/profile-service-default.ts
@@ -1,7 +1,12 @@
 import { Err, None, Ok, Some } from 'oxide.ts';
 import type { Option, Result } from 'oxide.ts';
 
-import type { Profile, UserEmploymentInformation, UserReferralPreferences } from '~/.server/domain/models';
+import type {
+  Profile,
+  UserEmploymentInformation,
+  UserPersonalInformation,
+  UserReferralPreferences,
+} from '~/.server/domain/models';
 import type { ProfileService } from '~/.server/domain/services/profile-service';
 import { serverEnvironment } from '~/.server/environment';
 import { AppError } from '~/errors/app-error';
@@ -101,7 +106,20 @@ export function getDefaultProfileService(): ProfileService {
         );
       }
     },
-
+    async updatePersonalInformation(
+      activeDirectoryId: string,
+      personalInfo: UserPersonalInformation,
+    ): Promise<Result<void, AppError>> {
+      try {
+        await fetch(`/profiles/${activeDirectoryId}/personal`, {
+          method: 'PUT',
+          body: JSON.stringify(personalInfo),
+        });
+        return Ok(undefined);
+      } catch {
+        return Err(new AppError('Failed to update personal information', ErrorCodes.PROFILE_UPDATE_FAILED));
+      }
+    },
     async updateEmploymentInformation(
       activeDirectoryId: string,
       employmentInfo: UserEmploymentInformation,

--- a/frontend/app/.server/domain/services/profile-service-mock.ts
+++ b/frontend/app/.server/domain/services/profile-service-mock.ts
@@ -1,7 +1,12 @@
 import { None, Some, Err, Ok } from 'oxide.ts';
 import type { Result } from 'oxide.ts';
 
-import type { Profile, UserEmploymentInformation, UserReferralPreferences } from '~/.server/domain/models';
+import type {
+  Profile,
+  UserEmploymentInformation,
+  UserPersonalInformation,
+  UserReferralPreferences,
+} from '~/.server/domain/models';
 import type { ProfileService } from '~/.server/domain/services/profile-service';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
@@ -14,6 +19,40 @@ export function getMockProfileService(): ProfileService {
     },
     registerProfile: (activeDirectoryId: string) => {
       return Promise.resolve(registerProfile(activeDirectoryId));
+    },
+    updatePersonalInformation: (
+      activeDirectoryId: string,
+      personalInfo: UserPersonalInformation,
+    ): Promise<Result<void, AppError>> => {
+      const mockProfile = getProfile(activeDirectoryId);
+
+      if (!mockProfile) {
+        return Promise.resolve(Err(new AppError('Failed to update personal information', ErrorCodes.PROFILE_UPDATE_FAILED)));
+      }
+
+      const userId = activeDirectoryToUserIdMap[activeDirectoryId];
+
+      mockProfiles = mockProfiles.map((profile) =>
+        profile.userId === userId
+          ? {
+              ...profile,
+              personalInformation: {
+                ...profile.personalInformation,
+                surname: personalInfo.surname,
+                givenName: personalInfo.givenName,
+                personalRecordIdentifier: personalInfo.personalRecordIdentifier,
+                preferredLanguageId: personalInfo.preferredLanguageId,
+                workEmail: personalInfo.workEmail,
+                personalEmail: personalInfo.personalEmail,
+                workPhone: personalInfo.workPhone,
+                personalPhone: personalInfo.personalPhone,
+                additionalInformation: personalInfo.additionalInformation,
+              },
+            }
+          : profile,
+      );
+
+      return Promise.resolve(Ok(undefined));
     },
     updateEmploymentInformation: (
       activeDirectoryId: string,

--- a/frontend/app/.server/domain/services/profile-service.ts
+++ b/frontend/app/.server/domain/services/profile-service.ts
@@ -1,6 +1,11 @@
 import type { Option, Result } from 'oxide.ts';
 
-import type { Profile, UserEmploymentInformation, UserReferralPreferences } from '~/.server/domain/models';
+import type {
+  Profile,
+  UserEmploymentInformation,
+  UserPersonalInformation,
+  UserReferralPreferences,
+} from '~/.server/domain/models';
 import { getDefaultProfileService } from '~/.server/domain/services/profile-service-default';
 import { getMockProfileService } from '~/.server/domain/services/profile-service-mock';
 import { serverEnvironment } from '~/.server/environment';
@@ -9,6 +14,7 @@ import type { AppError } from '~/errors/app-error';
 export type ProfileService = {
   getProfile(activeDirectoryId: string): Promise<Option<Profile>>;
   registerProfile(activeDirectoryId: string): Promise<Profile>;
+  updatePersonalInformation(activeDirectoryId: string, personalInfo: UserPersonalInformation): Promise<Result<void, AppError>>;
   updateEmploymentInformation(
     activeDirectoryId: string,
     employmentInfo: UserEmploymentInformation,

--- a/frontend/app/routes/employee/[id]/profile/personal-information.tsx
+++ b/frontend/app/routes/employee/[id]/profile/personal-information.tsx
@@ -58,7 +58,11 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     );
   }
 
-  //TODO: Save form data & work email after validation, workEmail: context.session.authState.idTokenClaims.email
+  const updateResult = await getProfileService().updatePersonalInformation(currentUserId, parseResult.output);
+
+  if (updateResult.isErr()) {
+    throw updateResult.unwrapErr();
+  }
 
   return i18nRedirect('routes/employee/[id]/profile/index.tsx', request, {
     params: { id: currentUserId },

--- a/frontend/tests/.server/routes/index.test.ts
+++ b/frontend/tests/.server/routes/index.test.ts
@@ -72,6 +72,7 @@ vi.mocked(getUserService).mockReturnValue(mockUserService);
 const mockProfileService = {
   getProfile: vi.fn(),
   registerProfile: vi.fn(),
+  updatePersonalInformation: vi.fn(),
   updateEmploymentInformation: vi.fn(),
   updateReferralPreferences: vi.fn(),
   getAllProfiles: vi.fn(),

--- a/frontend/tests/.server/utils/privacy-consent-utils.test.ts
+++ b/frontend/tests/.server/utils/privacy-consent-utils.test.ts
@@ -93,6 +93,7 @@ vi.mocked(getUserService).mockReturnValue(mockUserService);
 const mockProfileService = {
   getProfile: vi.fn(),
   registerProfile: vi.fn(),
+  updatePersonalInformation: vi.fn(),
   updateEmploymentInformation: vi.fn(),
   updateReferralPreferences: vi.fn(),
   getAllProfiles: vi.fn(),

--- a/frontend/tests/.server/utils/profile-access-utils.test.ts
+++ b/frontend/tests/.server/utils/profile-access-utils.test.ts
@@ -30,6 +30,7 @@ vi.mock('~/.server/utils/route-matching-utils');
 const mockProfileService = {
   getProfile: vi.fn(),
   registerProfile: vi.fn(),
+  updatePersonalInformation: vi.fn(),
   updateEmploymentInformation: vi.fn(),
   updateReferralPreferences: vi.fn(),
   getAllProfiles: vi.fn(),

--- a/frontend/tests/.server/utils/profile-utils.test.ts
+++ b/frontend/tests/.server/utils/profile-utils.test.ts
@@ -22,6 +22,7 @@ vi.mock('~/.server/domain/services/profile-service');
 const mockProfileService = {
   getProfile: vi.fn(),
   registerProfile: vi.fn(),
+  updatePersonalInformation: vi.fn(),
   updateEmploymentInformation: vi.fn(),
   updateReferralPreferences: vi.fn(),
   getAllProfiles: vi.fn(),


### PR DESCRIPTION
## Summary

Added default/mock calls for saving personal information in profile-service-default and profile-service-mock
[ADO#6249](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6249)
[ADO#6301](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6301)

## Types of changes

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [x] linked this PR to a related issue (if applicable)
