### PR TITLE
fix(frontend) make sort classifications in referral-preferences

### DIFF
--- a/frontend/app/routes/employee/[id]/profile/referral-preferences.tsx
+++ b/frontend/app/routes/employee/[id]/profile/referral-preferences.tsx
@@ -195,12 +195,12 @@ export default function PersonalDetails({ loaderData, actionData, params }: Rout
   }));
 
   // Choice tags for classification
-  const classificationChoiceTags: ChoiceTag[] = [];
-
-  selectedClassifications?.forEach((classification) => {
-    const selectedC = loaderData.classifications.find((c) => c.id === classification);
-    classificationChoiceTags.push({ label: selectedC?.name ?? classification, name: 'classification', value: classification });
-  });
+  const classificationChoiceTags: ChoiceTag[] = (selectedClassifications ?? [])
+    .map((classification) => {
+      const selectedC = loaderData.classifications.find((c) => c.id === classification);
+      return { label: selectedC?.name ?? classification, name: 'classification', value: classification };
+    })
+    .toSorted((a, b) => a.label.localeCompare(b.label));
 
   /**
    * Removes a classification from `classification group(s) and level(s)` and announces the removal to screen readers.


### PR DESCRIPTION
## Summary

Adds sort order to the classifications selected by the user which makes visually easier to process and group information.  Sorts only on the choice tags so as to eliminate unexpected side effects in the fetched data.

<img width="1022" height="489" alt="image" src="https://github.com/user-attachments/assets/74f1924c-5258-4089-ba9f-94c3f4f43a7d" />

