### PR TITLE
fix(frontend) fix error-summary reset to top

### DIFF
--- a/frontend/app/components/error-summary.tsx
+++ b/frontend/app/components/error-summary.tsx
@@ -119,7 +119,7 @@ export function ActionDataErrorSummary({ actionData, children, ...rest }: Action
   useEffect(() => {
     if (!containerRef.current) return;
     setErrors(collectFormValidationErrors(containerRef.current));
-  }, [actionData, children]);
+  }, [actionData]);
 
   return (
     <div ref={containerRef} {...rest}>


### PR DESCRIPTION
## Summary
The combination of using `FormErrorSummary` and removing `children` from the dependency array in `ActionDataErrorSummary` `useEffect` gets the weird error jumping to the top of the screen to stop.  And yes, the error summary displays this time ;) 
