### PR TITLE
refactor(frontend) add clear group functionality to choice tags

### DIFF
--- a/frontend/app/.server/locales/gcweb-en.ts
+++ b/frontend/app/.server/locales/gcweb-en.ts
@@ -105,6 +105,8 @@ export default {
   },
   'choice-tag': {
     'clear-all': 'Clear all',
+    'clear-group': 'Clear group',
+    'clear-group-label': 'Clear group {{groupName}} of items {{items}}',
     'choice-tag-added-aria-label': 'Selected {{item}} added: {{choice}}, Activate to remove selected {{item}}.',
     'clear-all-sr-message': 'All selected {{item}} removed.',
     'removed-choice-tag-sr-message': 'Selected {{item}} removed: {{choice}}',

--- a/frontend/app/.server/locales/gcweb-fr.ts
+++ b/frontend/app/.server/locales/gcweb-fr.ts
@@ -107,6 +107,8 @@ export default {
   },
   'choice-tag': {
     'clear-all': 'Tout effacer',
+    'clear-group': 'Effacer le groupe',
+    'clear-group-label': "Effacer le groupe {{groupName}} d'éléments {{items}}",
     'choice-tag-added-aria-label': '{{item}} sélectionné ajouté!: {{choice}}, Activez pour supprimer l{{item}} sélectionné.',
     'clear-all-sr-message': 'tous les {{item}} sélectionnés ont été supprimés.',
     'removed-choice-tag-sr-message': '{{item}} sélectionné retiré: {{choice}}',

--- a/frontend/app/components/choice-tags.tsx
+++ b/frontend/app/components/choice-tags.tsx
@@ -14,21 +14,28 @@ export interface ChoiceTag {
 
 export type ClearAllEventHandler = () => void;
 export type DeleteEventHandler = (name: string, label: string, value: string, group?: string) => void;
+export type ClearGroupEventHandler = (groupName: string) => void;
 
 export interface ChoiceTagsProps {
   choiceTags: ChoiceTag[];
   onClearAll?: ClearAllEventHandler;
   onDelete?: DeleteEventHandler;
+  onClearGroup?: ClearGroupEventHandler;
 }
 
-export function ChoiceTags({ choiceTags, onClearAll, onDelete }: ChoiceTagsProps) {
+export function ChoiceTags({ choiceTags, onClearAll, onDelete, onClearGroup }: ChoiceTagsProps) {
   const { t } = useTranslation(['gcweb']);
 
   const handleOnDelete = (_event: unknown, choice: ChoiceTag) => {
     if (onDelete) onDelete(choice.name, choice.label, choice.value, choice.group);
   };
+
   const handleOnClearAll = () => {
     if (onClearAll) onClearAll();
+  };
+
+  const handleOnClearGroup = (groupName: string) => {
+    if (onClearGroup) onClearGroup(groupName);
   };
 
   // Group tags by their group name
@@ -37,36 +44,84 @@ export function ChoiceTags({ choiceTags, onClearAll, onDelete }: ChoiceTagsProps
     return { ...groups, [groupName]: [...(groups[groupName] ?? []), tag] };
   }, {});
 
+  // Check if we have any grouped tags (non-empty group names)
+  const hasGroups = Object.keys(groupedTags).some((groupName) => groupName !== '');
+
   return (
     <div id={`selected-${choiceTags[0]?.name ?? 'default'}-wrapper`} className="flex flex-col gap-3">
-      {Object.entries(groupedTags).map(([groupName, tags]) => (
-        <div key={groupName} className="flex flex-col gap-2">
-          {groupName && <h3 className="text-lg font-semibold">{groupName}</h3>}
-          <div className="flex flex-wrap gap-2">
-            {tags.map((choiceTag) => (
-              <div
-                key={choiceTag.value}
-                className="inline-flex items-center justify-center rounded-sm border-2 border-gray-900 bg-blue-100 px-2 py-1 align-middle break-all text-gray-900"
-              >
-                <span>{choiceTag.label}</span>
-                <button
-                  aria-label={t('gcweb:choice-tag.choice-tag-added-aria-label', {
-                    item: choiceTag.name,
-                    choice: choiceTag.label,
-                  })}
-                  onClick={(e) => handleOnDelete(e, choiceTag)}
-                  type="button"
-                >
-                  <FontAwesomeIcon icon={faXmark} className="ml-1" />
-                </button>
+      {hasGroups ? (
+        // Render grouped tags
+        Object.entries(groupedTags).map(
+          ([groupName, tags]) =>
+            groupName &&
+            tags.length > 0 && (
+              <div key={groupName} className="flex flex-col gap-2">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-lg font-semibold">{groupName}</h3>
+                  {tags.length > 1 && (
+                    <Button
+                      variant="link"
+                      size="sm"
+                      onClick={() => handleOnClearGroup(groupName)}
+                      className="text-blue-600 hover:text-blue-800"
+                      aria-label={t('gcweb:choice-tag.clear-group-label', {
+                        items: tags[0]?.name,
+                        groupName,
+                      })}
+                    >
+                      {t('gcweb:choice-tag.clear-group')}
+                    </Button>
+                  )}
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {tags.map((choiceTag) => (
+                    <div
+                      key={choiceTag.value}
+                      className="inline-flex items-center justify-center rounded-sm border-2 border-gray-900 bg-blue-100 px-2 py-1 align-middle break-all text-gray-900"
+                    >
+                      <span>{choiceTag.label}</span>
+                      <button
+                        aria-label={t('gcweb:choice-tag.choice-tag-added-aria-label', {
+                          item: choiceTag.name,
+                          choice: choiceTag.label,
+                        })}
+                        onClick={(e) => handleOnDelete(e, choiceTag)}
+                        type="button"
+                      >
+                        <FontAwesomeIcon icon={faXmark} className="ml-1" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
               </div>
-            ))}
-          </div>
+            ),
+        )
+      ) : (
+        // Render ungrouped tags
+        <div className="flex flex-wrap gap-2">
+          {choiceTags.map((choiceTag) => (
+            <div
+              key={choiceTag.value}
+              className="inline-flex items-center justify-center rounded-sm border-2 border-gray-900 bg-blue-100 px-2 py-1 align-middle break-all text-gray-900"
+            >
+              <span>{choiceTag.label}</span>
+              <button
+                aria-label={t('gcweb:choice-tag.choice-tag-added-aria-label', {
+                  item: choiceTag.name,
+                  choice: choiceTag.label,
+                })}
+                onClick={(e) => handleOnDelete(e, choiceTag)}
+                type="button"
+              >
+                <FontAwesomeIcon icon={faXmark} className="ml-1" />
+              </button>
+            </div>
+          ))}
         </div>
-      ))}
+      )}
       {choiceTags.length > 1 && (
         <div className="self-start">
-          <Button variant="primary" id="clear-all-button" onClick={() => handleOnClearAll()}>
+          <Button variant="primary" id="clear-all-button" onClick={handleOnClearAll}>
             {t('gcweb:choice-tag.clear-all')}
           </Button>
         </div>

--- a/frontend/app/routes/employee/[id]/profile/referral-preferences.tsx
+++ b/frontend/app/routes/employee/[id]/profile/referral-preferences.tsx
@@ -216,11 +216,9 @@ export default function PersonalDetails({ loaderData, actionData, params }: Rout
   };
 
   // Choice tags for cities
-  const citiesChoiceTags: ChoiceTag[] = [];
-
-  selectedCities?.forEach((city) => {
+  const citiesChoiceTags: ChoiceTag[] = (selectedCities ?? []).map((city) => {
     const selectedC = loaderData.cities.find((c) => String(c.id) === city);
-    citiesChoiceTags.push({ label: selectedC?.name ?? city, name: 'city', value: city, group: selectedC?.province.name });
+    return { label: selectedC?.name ?? city, name: 'city', value: city, group: selectedC?.province.name };
   });
 
   /**
@@ -236,6 +234,16 @@ export default function PersonalDetails({ loaderData, actionData, params }: Rout
   const handleOnClearAllCities: ChoiceTagClearAllEventHandler = () => {
     setSrAnnouncement(t('gcweb:choice-tag.clear-all-sr-message', { item: 'cities' }));
     setSelectedCities([]);
+  };
+
+  const handleOnClearCityGroup = (groupName: string) => {
+    setSrAnnouncement(t('gcweb:choice-tag.clear-group-label', { items: 'cities', groupName }));
+    setSelectedCities((prev) =>
+      prev?.filter((cityId) => {
+        const city = loaderData.cities.find((c) => String(c.id) === cityId);
+        return city?.province.name !== groupName;
+      }),
+    );
   };
 
   return (
@@ -315,6 +323,7 @@ export default function PersonalDetails({ loaderData, actionData, params }: Rout
                   choiceTags={citiesChoiceTags}
                   onClearAll={handleOnClearAllCities}
                   onDelete={handleOnDeleteCityTag}
+                  onClearGroup={handleOnClearCityGroup}
                 />
               )}
 


### PR DESCRIPTION
## Summary

Adds 'clear group' functionality to the `ChoiceTags` for when the user only wants to clear grouped choices.

<img width="804" height="751" alt="image" src="https://github.com/user-attachments/assets/5f6ce622-b81b-4c5f-8731-9e411becfb74" />

## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades
