### PR TITLE
refactor(frontend): Profile change - UI change in different state

### DIFF
--- a/frontend/app/.server/locales/app-en.ts
+++ b/frontend/app/.server/locales/app-en.ts
@@ -18,6 +18,8 @@ export default {
   'profile': {
     'about-para-1':
       'This profile outlines your current position, referral preferences, and qualifications. Complete all sections and submit for approval.',
+    'about-para-1-pending':
+      'This profile outlines your current position, referral preferences, and qualifications. You can make edits at any time. Changes to certain fields will require re-approval.',
     'about-para-2': 'Your progress is saved automatically.',
     'edit': 'Edit',
     'add': 'Add',

--- a/frontend/app/.server/locales/app-fr.ts
+++ b/frontend/app/.server/locales/app-fr.ts
@@ -20,6 +20,8 @@ export default {
   'profile': {
     'about-para-1':
       'Ce profil décrit votre position actuelle, vos préférences de référence et vos qualifications. Complétez toutes les sections et soumettez pour approbation.',
+    'about-para-1-pending':
+      'Ce profil décrit votre poste actuel, vos préférences en matière de présentation de candidature et vos qualifications. Remplissez toutes les sections et soumettez-les pour approbation.',
     'about-para-2': 'Vos progrès sont enregistrés automatiquement.',
     'edit': 'Modifier les',
     'add': 'Ajouter des',

--- a/frontend/app/routes/employee/profile/index.tsx
+++ b/frontend/app/routes/employee/profile/index.tsx
@@ -30,7 +30,7 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/componen
 import { DescriptionList, DescriptionListItem } from '~/components/description-list';
 import { InlineLink } from '~/components/links';
 import { Progress } from '~/components/progress';
-import { EMPLOYEE_WFA_STATUS } from '~/domain/constants';
+import { EMPLOYEE_STATUS_CODE, EMPLOYEE_WFA_STATUS } from '~/domain/constants';
 import { getTranslation } from '~/i18n-config.server';
 import type { I18nRouteFile } from '~/i18n-routes';
 import { handle as parentHandle } from '~/routes/layout';
@@ -298,16 +298,23 @@ export default function EditProfile({ loaderData, params }: Route.ComponentProps
       </div>
       <div className="justify-between md:grid md:grid-cols-2">
         <div className="max-w-prose">
-          <p className="mt-12">{t('app:profile.about-para-1')}</p>
+          <p className="mt-12">
+            {loaderData.profileStatus.code === EMPLOYEE_STATUS_CODE.pending
+              ? t('app:profile.about-para-1-pending')
+              : t('app:profile.about-para-1')}
+          </p>
           <p className="mt-4">{t('app:profile.about-para-2')}</p>
         </div>
         <Form className="mt-6 flex place-content-end space-x-5 md:mt-auto" method="post" noValidate>
+          {/* TODO: save and exit button should show in edit state, check ADO task 6297 */}
           <ButtonLink variant="alternative" file="routes/employee/index.tsx" id="save" disabled={navigation.state !== 'idle'}>
             {t('app:form.save-and-exit')}
           </ButtonLink>
-          <Button name="action" variant="primary" id="submit" disabled={navigation.state !== 'idle'}>
-            {t('app:form.submit')}
-          </Button>
+          {loaderData.profileStatus.code === EMPLOYEE_STATUS_CODE.incomplete && (
+            <Button name="action" variant="primary" id="submit" disabled={navigation.state !== 'idle'}>
+              {t('app:form.submit')}
+            </Button>
+          )}
         </Form>
       </div>
 
@@ -319,7 +326,13 @@ export default function EditProfile({ loaderData, params }: Route.ComponentProps
         />
       )}
 
-      <Progress className="mt-8 mb-8" label={t('app:profile.profile-completion-progress')} value={loaderData.amountCompleted} />
+      {loaderData.profileStatus.code === EMPLOYEE_STATUS_CODE.incomplete && (
+        <Progress
+          className="mt-8 mb-8"
+          label={t('app:profile.profile-completion-progress')}
+          value={loaderData.amountCompleted}
+        />
+      )}
       <div className="mt-8 max-w-prose space-y-10">
         <ProfileCard
           title={t('app:profile.personal-information.title')}


### PR DESCRIPTION
## Summary

AB#6303

Show different text on the profile page; hide progress bar and submit button when when the profile status changed to pending approval

## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
_(check all that apply by placing an `x` in the relevant boxes)_

- [ ] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
