### PR TITLE
feat(frontend): add profile status card component

### DIFF
--- a/frontend/app/components/profile-card.tsx
+++ b/frontend/app/components/profile-card.tsx
@@ -1,0 +1,120 @@
+import type { JSX, ReactNode, Ref } from 'react';
+
+import type { Params } from 'react-router';
+
+import { faCheck, faPenToSquare, faPlus, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useTranslation } from 'react-i18next';
+
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
+import { InlineLink } from '~/components/links';
+import type { I18nRouteFile } from '~/i18n-routes';
+import { cn } from '~/utils/tailwind-utils';
+
+interface ProfileCardProps {
+  title: string;
+  linkLabel: string;
+  file: I18nRouteFile;
+  isComplete: boolean;
+  isNew: boolean;
+  required: boolean;
+  children: ReactNode;
+  params?: Params;
+  errorState?: boolean;
+  ref?: Ref<HTMLDivElement>;
+  showStatus: boolean;
+}
+
+export function ProfileCard({
+  title,
+  linkLabel,
+  file,
+  isComplete,
+  isNew,
+  required,
+  errorState,
+  children,
+  params,
+  ref,
+  showStatus,
+}: ProfileCardProps): JSX.Element {
+  const { t } = useTranslation('app');
+
+  const labelPrefix = `${isNew ? t('profile.add') : t('profile.edit')}\u0020`;
+  return (
+    <Card ref={ref} className={`${errorState && 'border-b-6 border-[#C90101]'} rounded-md p-4 sm:p-6`}>
+      <CardHeader className="p-0">
+        <div className="mb-6 grid justify-between gap-2 select-none sm:grid-cols-2">
+          <div>
+            <CardTitle className="text-2xl">{title}</CardTitle>
+          </div>
+          <div className="space-x-2 sm:ml-auto">
+            {showStatus &&
+              (isComplete ? (
+                <CompleteTag />
+              ) : (
+                <>
+                  <InProgressTag />
+                  {required && <RequiredTag />}
+                </>
+              ))}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="my-3 space-y-3 p-0">{children}</CardContent>
+
+      <CardFooter
+        className={cn(
+          'mt-3',
+          errorState ? 'bg-red-100' : 'bg-gray-100', // Add background
+          '-mx-4 sm:-mx-6', // Pull horizontally to cancel parent padding
+          '-mb-4 sm:-mb-6', // Pull down to cancel parent bottom padding
+          'px-4 sm:px-6', // Add horizontal padding back for the content
+          'py-4', // Add vertical padding for the contents
+          'rounded-b-xs', // Re-apply bottom roundings
+        )}
+      >
+        {errorState && <p className="pb-4 text-lg font-bold text-[#333333]">{t('profile.field-incomplete')}</p>}
+        <span className="flex items-center gap-x-2">
+          {errorState && <FontAwesomeIcon icon={faTriangleExclamation} className="text-red-800" />}
+          {!errorState && (isNew ? <FontAwesomeIcon icon={faPlus} /> : <FontAwesomeIcon icon={faPenToSquare} />)}
+          <InlineLink className={`${errorState && 'text-red-800'} font-semibold`} file={file} params={params}>
+            {labelPrefix}
+            {linkLabel}
+          </InlineLink>
+        </span>
+      </CardFooter>
+    </Card>
+  );
+}
+
+function CompleteTag(): JSX.Element {
+  const { t } = useTranslation('app');
+
+  return (
+    <span className="flex w-fit items-center gap-2 rounded-2xl border border-green-600 bg-green-600 px-3 py-0.5 text-sm font-semibold text-white">
+      <FontAwesomeIcon icon={faCheck} />
+      {t('profile.complete')}
+    </span>
+  );
+}
+
+function InProgressTag(): JSX.Element {
+  const { t } = useTranslation('app');
+
+  return (
+    <span className="w-fit rounded-2xl border border-blue-400 bg-blue-100 px-3 py-0.5 text-sm font-semibold text-blue-800">
+      {t('profile.in-progress')}
+    </span>
+  );
+}
+
+function RequiredTag(): JSX.Element {
+  const { t } = useTranslation('app');
+
+  return (
+    <span className="rounded-2xl border border-gray-400 bg-gray-100 px-3 py-0.5 text-sm font-semibold text-black">
+      {t('profile.required')}
+    </span>
+  );
+}

--- a/frontend/app/routes/employee/profile/index.tsx
+++ b/frontend/app/routes/employee/profile/index.tsx
@@ -1,11 +1,9 @@
-import type { Ref, JSX, ReactNode } from 'react';
+import type { JSX } from 'react';
 import { useRef } from 'react';
 
-import type { Params, RouteHandle } from 'react-router';
+import type { RouteHandle } from 'react-router';
 import { Form, useActionData, useNavigation } from 'react-router';
 
-import { faCheck, faPenToSquare, faPlus, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
 
 import type { Route } from '../profile/+types/index';
@@ -26,16 +24,13 @@ import { countCompletedItems, omitObjectProperties } from '~/.server/utils/profi
 import { AlertMessage } from '~/components/alert-message';
 import { Button } from '~/components/button';
 import { ButtonLink } from '~/components/button-link';
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { DescriptionList, DescriptionListItem } from '~/components/description-list';
-import { InlineLink } from '~/components/links';
+import { ProfileCard } from '~/components/profile-card';
 import { Progress } from '~/components/progress';
 import { EMPLOYEE_STATUS_CODE, EMPLOYEE_WFA_STATUS } from '~/domain/constants';
 import { getTranslation } from '~/i18n-config.server';
-import type { I18nRouteFile } from '~/i18n-routes';
 import { handle as parentHandle } from '~/routes/layout';
 import { formatDateTime } from '~/utils/date-utils';
-import { cn } from '~/utils/tailwind-utils';
 
 export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace],
@@ -343,6 +338,7 @@ export default function EditProfile({ loaderData, params }: Route.ComponentProps
           params={params}
           errorState={actionData?.personalInfoComplete === false}
           required
+          showStatus
         >
           {loaderData.personalInformation.isNew ? (
             <>
@@ -388,6 +384,7 @@ export default function EditProfile({ loaderData, params }: Route.ComponentProps
           params={params}
           required
           errorState={actionData?.employmentInfoComplete === false}
+          showStatus
         >
           {loaderData.employmentInformation.isNew ? (
             <>{t('app:profile.employment.detail')}</>
@@ -444,6 +441,7 @@ export default function EditProfile({ loaderData, params }: Route.ComponentProps
           params={params}
           required
           errorState={actionData?.referralComplete === false}
+          showStatus
         >
           {loaderData.referralPreferences.isNew ? (
             <>{t('app:profile.referral.detail')}</>
@@ -495,115 +493,10 @@ export default function EditProfile({ loaderData, params }: Route.ComponentProps
   );
 }
 
-interface ProfileCardProps {
-  title: string;
-  linkLabel: string;
-  file: I18nRouteFile;
-  isComplete: boolean;
-  isNew: boolean;
-  required: boolean;
-  children: ReactNode;
-  params?: Params;
-  errorState?: boolean;
-  ref?: Ref<HTMLDivElement>;
-}
-
-// TODO: Consider moving this to a separate file as a reusable component
-function ProfileCard({
-  title,
-  linkLabel,
-  file,
-  isComplete,
-  isNew,
-  required,
-  errorState,
-  children,
-  params,
-  ref,
-}: ProfileCardProps): JSX.Element {
-  const { t } = useTranslation(handle.i18nNamespace);
-
-  const labelPrefix = `${isNew ? t('app:profile.add') : t('app:profile.edit')}\u0020`;
-  return (
-    <Card ref={ref} className={`${errorState && 'border-b-6 border-[#C90101]'} rounded-md p-4 sm:p-6`}>
-      <CardHeader className="p-0">
-        <div className="mb-6 grid justify-between gap-2 select-none sm:grid-cols-2">
-          <div>
-            <CardTitle className="text-2xl">{title}</CardTitle>
-          </div>
-          <div className="space-x-2 sm:ml-auto">
-            {isComplete ? (
-              <CompleteTag />
-            ) : (
-              <>
-                <InProgressTag />
-                {required && <RequiredTag />}
-              </>
-            )}
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent className="my-3 space-y-3 p-0">{children}</CardContent>
-      <CardFooter
-        className={cn(
-          'mt-3',
-          errorState ? 'bg-red-100' : 'bg-gray-100', // Add background
-          '-mx-4 sm:-mx-6', // Pull horizontally to cancel parent padding
-          '-mb-4 sm:-mb-6', // Pull down to cancel parent bottom padding
-          'px-4 sm:px-6', // Add horizontal padding back for the content
-          'py-4', // Add vertical padding for the contents
-          'rounded-b-xs', // Re-apply bottom roundings
-        )}
-      >
-        {errorState && <p className="pb-4 text-lg font-bold text-[#333333]">{t('app:profile.field-incomplete')}</p>}
-        <span className="flex items-center gap-x-2">
-          {errorState && <FontAwesomeIcon icon={faTriangleExclamation} className="text-red-800" />}
-          {!errorState && (isNew ? <FontAwesomeIcon icon={faPlus} /> : <FontAwesomeIcon icon={faPenToSquare} />)}
-          <InlineLink className={`${errorState && 'text-red-800'} font-semibold`} file={file} params={params}>
-            {labelPrefix}
-            {linkLabel}
-          </InlineLink>
-        </span>
-      </CardFooter>
-    </Card>
-  );
-}
-
 function StatusTag({ status }: { status: string }): JSX.Element {
   return (
     <span className="w-fit rounded-2xl border border-blue-400 bg-blue-100 px-3 py-0.5 text-sm font-semibold text-blue-800">
       {status}
-    </span>
-  );
-}
-
-function CompleteTag(): JSX.Element {
-  const { t } = useTranslation(handle.i18nNamespace);
-
-  return (
-    <span className="flex w-fit items-center gap-2 rounded-2xl border border-green-600 bg-green-600 px-3 py-0.5 text-sm font-semibold text-white">
-      <FontAwesomeIcon icon={faCheck} />
-      {t('app:profile.complete')}
-    </span>
-  );
-}
-
-function InProgressTag(): JSX.Element {
-  const { t } = useTranslation(handle.i18nNamespace);
-
-  return (
-    <span className="w-fit rounded-2xl border border-blue-400 bg-blue-100 px-3 py-0.5 text-sm font-semibold text-blue-800">
-      {t('app:profile.in-progress')}
-    </span>
-  );
-}
-
-function RequiredTag(): JSX.Element {
-  const { t } = useTranslation(handle.i18nNamespace);
-
-  return (
-    <span className="rounded-2xl border border-gray-400 bg-gray-100 px-3 py-0.5 text-sm font-semibold text-black">
-      {t('app:profile.required')}
     </span>
   );
 }


### PR DESCRIPTION
## Summary

Add profile status card component. The profile card would be used on Employee profile displayed for employees and hr advisor (hr advisor view employee profile in separate pr). Add the showStatus flag to show/hide the status of the profile section to accommodate the Profile card for both employee and hr advisor routes

## Types of changes

What types of changes does this PR introduce?

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.

- [x] code has been linted and formatted locally

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>
