### PR TITLE
fix(frontend): remove Number() conversion from referral preferences page

### DIFF
--- a/frontend/app/routes/employee/profile/referral-preferences.tsx
+++ b/frontend/app/routes/employee/profile/referral-preferences.tsx
@@ -61,17 +61,17 @@ export async function action({ context, params, request }: Route.ActionArgs) {
   const currentUserId = authenticatedSession.authState.idTokenClaims.oid as string;
   const formData = await request.formData();
   const parseResult = v.safeParse(referralPreferencesSchema, {
-    languageReferralTypeIds: formData.getAll('languageReferralTypes').map((val) => Number(val)),
-    classificationIds: formData.getAll('classifications').map((val) => Number(val)),
+    languageReferralTypeIds: formData.getAll('languageReferralTypes').map((val) => val.toString()),
+    classificationIds: formData.getAll('classifications').map((val) => val.toString()),
     workLocationProvince: formString(formData.get('workLocationProvince')),
-    workLocationCitiesIds: formData.getAll('workLocationCities').map((val) => Number(val)),
+    workLocationCitiesIds: formData.getAll('workLocationCities').map((val) => val.toString()),
     availableForReferralInd: formData.get('referralAvailibility')
       ? formData.get('referralAvailibility') === REQUIRE_OPTIONS.yes
       : undefined,
     interestedInAlternationInd: formData.get('alternateOpportunity')
       ? formData.get('alternateOpportunity') === REQUIRE_OPTIONS.yes
       : undefined,
-    employmentTenureIds: formData.getAll('employmentTenures').map((val) => Number(val)),
+    employmentTenureIds: formData.getAll('employmentTenures').map((val) => val.toString()),
   });
 
   if (!parseResult.success) {

--- a/frontend/app/routes/employee/profile/referral-preferences.tsx
+++ b/frontend/app/routes/employee/profile/referral-preferences.tsx
@@ -61,17 +61,17 @@ export async function action({ context, params, request }: Route.ActionArgs) {
   const currentUserId = authenticatedSession.authState.idTokenClaims.oid as string;
   const formData = await request.formData();
   const parseResult = v.safeParse(referralPreferencesSchema, {
-    languageReferralTypeIds: formData.getAll('languageReferralTypes').map((val) => val.toString()),
-    classificationIds: formData.getAll('classifications').map((val) => val.toString()),
+    languageReferralTypeIds: formData.getAll('languageReferralTypes'),
+    classificationIds: formData.getAll('classifications'),
     workLocationProvince: formString(formData.get('workLocationProvince')),
-    workLocationCitiesIds: formData.getAll('workLocationCities').map((val) => val.toString()),
+    workLocationCitiesIds: formData.getAll('workLocationCities'),
     availableForReferralInd: formData.get('referralAvailibility')
       ? formData.get('referralAvailibility') === REQUIRE_OPTIONS.yes
       : undefined,
     interestedInAlternationInd: formData.get('alternateOpportunity')
       ? formData.get('alternateOpportunity') === REQUIRE_OPTIONS.yes
       : undefined,
-    employmentTenureIds: formData.getAll('employmentTenures').map((val) => val.toString()),
+    employmentTenureIds: formData.getAll('employmentTenures'),
   });
 
   if (!parseResult.success) {


### PR DESCRIPTION
This pull request fixes a submission problem with the referall preferences page. It includes a change in the `action` function within the `frontend/app/routes/employee/profile/referral-preferences.tsx` file. The change simplifies how form data is processed by removing the mapping of certain fields to `Number` and instead directly using the values as they are retrieved.

### Simplification of form data processing:

* [`frontend/app/routes/employee/profile/referral-preferences.tsx`](diffhunk://#diff-7d92dd055cee605ad765f0b40f5c5490be9cfedc0b8ce20c4254002a2305eceeL64-R74): Removed `.map((val) => Number(val))` transformations for `languageReferralTypeIds`, `classificationIds`, `workLocationCitiesIds`, and `employmentTenureIds` fields, allowing the form data to be used directly without converting to numbers.