### PR TITLE
refactor(frontend): componentize referral preferences

### DIFF
--- a/frontend/app/domain/constants.ts
+++ b/frontend/app/domain/constants.ts
@@ -19,3 +19,8 @@ export const PROFILE_STATUS_ID = {
   incomplete: 3,
   archived: 4,
 } as const;
+
+export const REQUIRE_OPTIONS = {
+  yes: 'yes',
+  no: 'no',
+} as const;

--- a/frontend/app/routes/employee/profile/referral-preferences.tsx
+++ b/frontend/app/routes/employee/profile/referral-preferences.tsx
@@ -1,7 +1,5 @@
-import { useState } from 'react';
-
 import type { RouteHandle } from 'react-router';
-import { data, Form } from 'react-router';
+import { data } from 'react-router';
 
 import { useTranslation } from 'react-i18next';
 import * as v from 'valibot';
@@ -17,35 +15,14 @@ import { getProfileService } from '~/.server/domain/services/profile-service';
 import { getProvinceService } from '~/.server/domain/services/province-service';
 import type { AuthenticatedSession } from '~/.server/utils/auth-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
-import { Button } from '~/components/button';
-import { ButtonLink } from '~/components/button-link';
-import type {
-  ChoiceTag,
-  DeleteEventHandler as ChoiceTagDeleteEventHandler,
-  ClearAllEventHandler as ChoiceTagClearAllEventHandler,
-} from '~/components/choice-tags';
-import { ChoiceTags } from '~/components/choice-tags';
-import { Collapsible } from '~/components/collapsible';
-import { FormErrorSummary } from '~/components/error-summary';
-import { InputCheckboxes } from '~/components/input-checkboxes';
-import { InputHelp } from '~/components/input-help';
-import { InputLegend } from '~/components/input-legend';
-import { InputMultiSelect } from '~/components/input-multiselect';
-import { InputRadios } from '~/components/input-radios';
-import type { InputRadiosProps } from '~/components/input-radios';
-import { InputSelect } from '~/components/input-select';
 import { InlineLink } from '~/components/links';
+import { REQUIRE_OPTIONS } from '~/domain/constants';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/layout';
+import { ReferralPreferencesForm } from '~/routes/page-components/employees/referral-preferences/form';
 import { referralPreferencesSchema } from '~/routes/page-components/employees/validation.server';
 import { formString } from '~/utils/string-utils';
-import { extractValidationKey } from '~/utils/validation-utils';
-
-const REQUIRE_OPTIONS = {
-  yes: 'Yes', //
-  no: 'No',
-} as const;
 
 export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace],
@@ -133,251 +110,23 @@ export default function PersonalDetails({ loaderData, actionData, params }: Rout
   const { t } = useTranslation(handle.i18nNamespace);
   const errors = actionData?.errors;
 
-  const [referralAvailibility, setReferralAvailibility] = useState(loaderData.defaultValues.availableForReferralInd);
-  const [alternateOpportunity, setAlternateOpportunity] = useState(loaderData.defaultValues.interestedInAlternationInd);
-  const [selectedClassifications, setSelectedClassifications] = useState(
-    loaderData.defaultValues.classificationIds?.map(String) ?? [],
-  );
-  const [selectedCities, setSelectedCities] = useState(loaderData.defaultValues.workLocationCitiesIds?.map(String) ?? []);
-  const [province, setProvince] = useState(
-    loaderData.defaultValues.workLocationProvince ? String(loaderData.defaultValues.workLocationProvince) : undefined,
-  );
-  const [srAnnouncement, setSrAnnouncement] = useState(''); //screen reader announcement
-
-  const languageReferralTypeOptions = loaderData.languageReferralTypes.map((langReferral) => ({
-    value: String(langReferral.id),
-    children: langReferral.name,
-    defaultChecked: loaderData.defaultValues.languageReferralTypeIds?.includes(langReferral.id) ?? false,
-  }));
-  const classificationOptions = loaderData.classifications.map((classification) => ({
-    value: String(classification.id),
-    label: classification.name,
-  }));
-  const provinceOptions = [{ id: 'select-option', name: '' }, ...loaderData.provinces].map(({ id, name }) => ({
-    value: id === 'select-option' ? '' : String(id),
-    children: id === 'select-option' ? t('app:form.select-option') : name,
-  }));
-  const cityOptions = loaderData.cities
-    .filter((c) => c.province.id === Number(province))
-    .map((city) => ({
-      value: String(city.id),
-      label: city.name,
-      group: city.province.name,
-    }));
-  const referralAvailibilityOptions: InputRadiosProps['options'] = [
-    {
-      children: t('gcweb:input-option.yes'),
-      value: REQUIRE_OPTIONS.yes,
-      defaultChecked: referralAvailibility === true,
-      onChange: ({ target }) => setReferralAvailibility(target.value === REQUIRE_OPTIONS.yes),
-    },
-    {
-      children: t('gcweb:input-option.no'),
-      value: REQUIRE_OPTIONS.no,
-      defaultChecked: referralAvailibility === false,
-      onChange: ({ target }) => setReferralAvailibility(target.value === REQUIRE_OPTIONS.yes),
-    },
-  ];
-  const alternateOpportunityOptions: InputRadiosProps['options'] = [
-    {
-      children: t('gcweb:input-option.yes'),
-      value: REQUIRE_OPTIONS.yes,
-      defaultChecked: alternateOpportunity === true,
-      onChange: ({ target }) => setAlternateOpportunity(target.value === REQUIRE_OPTIONS.yes),
-    },
-    {
-      children: t('gcweb:input-option.no'),
-      value: REQUIRE_OPTIONS.no,
-      defaultChecked: alternateOpportunity === false,
-      onChange: ({ target }) => setAlternateOpportunity(target.value === REQUIRE_OPTIONS.yes),
-    },
-  ];
-  const employmentTenureOptions = loaderData.employmentTenures.map((employmentTenures) => ({
-    value: String(employmentTenures.id),
-    children: employmentTenures.name,
-    defaultChecked: loaderData.defaultValues.employmentTenureIds?.includes(employmentTenures.id) ?? false,
-  }));
-
-  // Choice tags for classification
-  const classificationChoiceTags: ChoiceTag[] = selectedClassifications
-    .map((classification) => {
-      const selectedC = loaderData.classifications.find((c) => c.id === Number(classification));
-      return { label: selectedC?.name ?? classification, name: 'classification', value: classification };
-    })
-    .toSorted((a, b) => String(a.label).localeCompare(String(b.label)));
-
-  /**
-   * Removes a classification from `classification group(s) and level(s)` and announces the removal to screen readers.
-   */
-  const handleOnDeleteClassificationTag: ChoiceTagDeleteEventHandler = (name, label, value) => {
-    setSrAnnouncement(t('gcweb:choice-tag.removed-choice-tag-sr-message', { item: name, choice: label }));
-    setSelectedClassifications((prev) => prev.filter((classificationId) => classificationId !== value));
-  };
-
-  const handleOnClearAllClassifications: ChoiceTagClearAllEventHandler = () => {
-    setSrAnnouncement(t('gcweb:choice-tag.clear-all-sr-message', { item: 'classifications' }));
-    setSelectedClassifications([]);
-  };
-
-  // Choice tags for cities
-  const citiesChoiceTags: ChoiceTag[] = selectedCities.map((city) => {
-    const selectedC = loaderData.cities.find((c) => c.id === Number(city));
-    return { label: selectedC?.name ?? city, name: 'city', value: city, group: selectedC?.province.name };
-  });
-
-  /**
-   * Removes a city from `work locations` and announces the removal to screen readers.
-   */
-  const handleOnDeleteCityTag: ChoiceTagDeleteEventHandler = (name, label, value, group) => {
-    setSrAnnouncement(
-      t('gcweb:choice-tag.removed-choice-tag-sr-message', { item: name, choice: group ? group + ' - ' + label : label }),
-    );
-    setSelectedCities((prev) => prev.filter((cityId) => cityId !== value));
-  };
-
-  const handleOnClearAllCities: ChoiceTagClearAllEventHandler = () => {
-    setSrAnnouncement(t('gcweb:choice-tag.clear-all-sr-message', { item: 'cities' }));
-    setSelectedCities([]);
-  };
-
-  const handleOnClearCityGroup = (groupName: string) => {
-    setSrAnnouncement(t('gcweb:choice-tag.clear-group-label', { items: 'cities', groupName }));
-    setSelectedCities((prev) =>
-      prev.filter((cityId) => {
-        const city = loaderData.cities.find((c) => c.id === Number(cityId));
-        return city?.province.name !== groupName;
-      }),
-    );
-  };
-
   return (
     <>
       <InlineLink className="mt-6 block" file="routes/employee/profile/index.tsx" params={params} id="back-button">
         {`< ${t('app:profile.back')}`}
       </InlineLink>
       <div className="max-w-prose">
-        <h1 className="my-5 text-3xl">{t('app:referral-preferences.page-title')}</h1>
-        <FormErrorSummary>
-          <Form method="post" noValidate>
-            <div className="space-y-6">
-              <InputCheckboxes
-                id="languageReferralTypesId"
-                errorMessage={t(extractValidationKey(errors?.languageReferralTypeIds))}
-                legend={t('app:referral-preferences.language-referral-type')}
-                name="languageReferralTypes"
-                options={languageReferralTypeOptions}
-                helpMessagePrimary={t('app:form.select-all-that-apply')}
-                required
-              />
-              <InputMultiSelect
-                id="classificationsId"
-                name="classifications"
-                label={t('app:referral-preferences.classification')}
-                options={classificationOptions}
-                value={selectedClassifications}
-                onChange={(values) => setSelectedClassifications(values)}
-                placeholder={t('app:form.select-all-that-apply')}
-                helpMessage={t('app:referral-preferences.classification-group-help-message-primary')}
-                errorMessage={t(extractValidationKey(errors?.classificationIds))}
-                required
-              />
-
-              {classificationChoiceTags.length > 0 && (
-                <ChoiceTags
-                  choiceTags={classificationChoiceTags}
-                  onClearAll={handleOnClearAllClassifications}
-                  onDelete={handleOnDeleteClassificationTag}
-                />
-              )}
-
-              <fieldset id="workLocationFieldset" className="space-y-2">
-                <InputLegend id="workLocationLegend" required>
-                  {t('app:referral-preferences.work-location')}
-                </InputLegend>
-                <InputHelp id="workLocationHelpMessage">{t('app:form.select-all-that-apply')}</InputHelp>
-                <InputSelect
-                  className="w-full sm:w-1/2"
-                  id="workLocationProvinceId"
-                  name="workLocationProvince"
-                  label={t('app:referral-preferences.province')}
-                  options={provinceOptions}
-                  errorMessage={t(extractValidationKey(errors?.workLocationProvince))}
-                  value={province ?? ''}
-                  onChange={({ target }) => setProvince(target.value || undefined)}
-                />
-                {province && (
-                  <>
-                    <InputMultiSelect
-                      id="workLocationCitiesId"
-                      name="workLocationCities"
-                      errorMessage={t(extractValidationKey(errors?.workLocationCitiesIds))}
-                      options={cityOptions}
-                      value={selectedCities}
-                      onChange={(values) => setSelectedCities(values)}
-                      placeholder={t('app:form.select-all-that-apply')}
-                      label={t('app:referral-preferences.city')}
-                      className="w-full sm:w-1/2"
-                    />
-                  </>
-                )}
-              </fieldset>
-
-              {citiesChoiceTags.length > 0 && (
-                <ChoiceTags
-                  choiceTags={citiesChoiceTags}
-                  onClearAll={handleOnClearAllCities}
-                  onDelete={handleOnDeleteCityTag}
-                  onClearGroup={handleOnClearCityGroup}
-                />
-              )}
-
-              <span aria-live="polite" aria-atomic="true" className="sr-only">
-                {srAnnouncement}
-              </span>
-
-              <InputRadios
-                id="referralAvailibilityId"
-                legend={t('app:referral-preferences.referral-availibility')}
-                name="referralAvailibility"
-                options={referralAvailibilityOptions}
-                required
-                errorMessage={t(extractValidationKey(errors?.availableForReferralInd))}
-                helpMessagePrimary={t('app:referral-preferences.referral-availibility-help-message-primary')}
-              />
-              <InputRadios
-                id="alternateOpportunityId"
-                legend={t('app:referral-preferences.alternate-opportunity')}
-                name="alternateOpportunity"
-                options={alternateOpportunityOptions}
-                required
-                errorMessage={t(extractValidationKey(errors?.interestedInAlternationInd))}
-                helpMessagePrimary={
-                  <Collapsible summary={t('app:referral-preferences.what-is-alternation')}>
-                    {t('app:referral-preferences.alternation-description-text')}
-                  </Collapsible>
-                }
-              />
-              <InputCheckboxes
-                id="employmentTenuresId"
-                errorMessage={t(extractValidationKey(errors?.employmentTenureIds))}
-                legend={t('app:referral-preferences.employment-tenure')}
-                name="employmentTenures"
-                options={employmentTenureOptions}
-                helpMessagePrimary={t('app:form.select-all-that-apply')}
-                required
-              />
-
-              <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-                <Button name="action" variant="primary" id="save-button">
-                  {t('app:form.save')}
-                </Button>
-                <ButtonLink file="routes/employee/profile/index.tsx" params={params} id="cancel-button" variant="alternative">
-                  {t('app:form.cancel')}
-                </ButtonLink>
-              </div>
-            </div>
-          </Form>
-        </FormErrorSummary>
+        <ReferralPreferencesForm
+          cancelLink={'routes/employee/profile/index.tsx'}
+          formValues={loaderData.defaultValues}
+          formErrors={errors}
+          languageReferralTypes={loaderData.languageReferralTypes}
+          classifications={loaderData.classifications}
+          employmentTenures={loaderData.employmentTenures}
+          provinces={loaderData.provinces}
+          cities={loaderData.cities}
+          params={params}
+        />
       </div>
     </>
   );

--- a/frontend/app/routes/page-components/employees/referral-preferences/form.tsx
+++ b/frontend/app/routes/page-components/employees/referral-preferences/form.tsx
@@ -1,0 +1,306 @@
+import { useState } from 'react';
+import type { JSX } from 'react';
+
+import { Form } from 'react-router';
+import type { Params } from 'react-router';
+
+import { useTranslation } from 'react-i18next';
+
+import type {
+  LocalizedCity,
+  LocalizedClassification,
+  LocalizedEmploymentTenure,
+  LocalizedLanguageReferralType,
+  LocalizedProvince,
+  UserReferralPreferences,
+} from '~/.server/domain/models';
+import { Button } from '~/components/button';
+import { ButtonLink } from '~/components/button-link';
+import type {
+  ChoiceTag,
+  DeleteEventHandler as ChoiceTagDeleteEventHandler,
+  ClearAllEventHandler as ChoiceTagClearAllEventHandler,
+} from '~/components/choice-tags';
+import { ChoiceTags } from '~/components/choice-tags';
+import { Collapsible } from '~/components/collapsible';
+import { FormErrorSummary } from '~/components/error-summary';
+import { InputCheckboxes } from '~/components/input-checkboxes';
+import { InputHelp } from '~/components/input-help';
+import { InputLegend } from '~/components/input-legend';
+import { InputMultiSelect } from '~/components/input-multiselect';
+import { InputRadios } from '~/components/input-radios';
+import type { InputRadiosProps } from '~/components/input-radios';
+import { InputSelect } from '~/components/input-select';
+import { REQUIRE_OPTIONS } from '~/domain/constants';
+import type { I18nRouteFile } from '~/i18n-routes';
+import type { Errors } from '~/routes/page-components/employees/validation.server';
+import { extractValidationKey } from '~/utils/validation-utils';
+
+interface ReferralPreferencesFormProps {
+  cancelLink: I18nRouteFile;
+  formValues: Partial<UserReferralPreferences> | undefined;
+  formErrors?: Errors;
+  languageReferralTypes: readonly LocalizedLanguageReferralType[];
+  classifications: readonly LocalizedClassification[];
+  employmentTenures: readonly LocalizedEmploymentTenure[];
+  provinces: readonly LocalizedProvince[];
+  cities: readonly LocalizedCity[];
+  params: Params;
+}
+
+export function ReferralPreferencesForm({
+  cancelLink,
+  formValues,
+  formErrors,
+  languageReferralTypes,
+  classifications,
+  employmentTenures,
+  provinces,
+  cities,
+  params,
+}: ReferralPreferencesFormProps): JSX.Element {
+  const { t: tApp } = useTranslation('app');
+  const { t: tGcweb } = useTranslation('gcweb');
+
+  const [referralAvailibility, setReferralAvailibility] = useState(formValues?.availableForReferralInd);
+  const [alternateOpportunity, setAlternateOpportunity] = useState(formValues?.interestedInAlternationInd);
+  const [selectedClassifications, setSelectedClassifications] = useState(formValues?.classificationIds?.map(String) ?? []);
+  const [selectedCities, setSelectedCities] = useState(formValues?.workLocationCitiesIds?.map(String) ?? []);
+  const [province, setProvince] = useState(
+    formValues?.workLocationProvince ? String(formValues.workLocationProvince) : undefined,
+  );
+  const [srAnnouncement, setSrAnnouncement] = useState(''); //screen reader announcement
+
+  const languageReferralTypeOptions = languageReferralTypes.map((langReferral) => ({
+    value: String(langReferral.id),
+    children: langReferral.name,
+    defaultChecked: formValues?.languageReferralTypeIds?.includes(langReferral.id) ?? false,
+  }));
+  const classificationOptions = classifications.map((classification) => ({
+    value: String(classification.id),
+    label: classification.name,
+  }));
+  const provinceOptions = [{ id: 'select-option', name: '' }, ...provinces].map(({ id, name }) => ({
+    value: id === 'select-option' ? '' : String(id),
+    children: id === 'select-option' ? tApp('form.select-option') : name,
+  }));
+  const cityOptions = cities
+    .filter((c) => c.province.id === Number(province))
+    .map((city) => ({
+      value: String(city.id),
+      label: city.name,
+      group: city.province.name,
+    }));
+  const referralAvailibilityOptions: InputRadiosProps['options'] = [
+    {
+      children: tGcweb('input-option.yes'),
+      value: REQUIRE_OPTIONS.yes,
+      defaultChecked: referralAvailibility === true,
+      onChange: ({ target }) => setReferralAvailibility(target.value === REQUIRE_OPTIONS.yes),
+    },
+    {
+      children: tGcweb('input-option.no'),
+      value: REQUIRE_OPTIONS.no,
+      defaultChecked: referralAvailibility === false,
+      onChange: ({ target }) => setReferralAvailibility(target.value === REQUIRE_OPTIONS.yes),
+    },
+  ];
+  const alternateOpportunityOptions: InputRadiosProps['options'] = [
+    {
+      children: tGcweb('input-option.yes'),
+      value: REQUIRE_OPTIONS.yes,
+      defaultChecked: alternateOpportunity === true,
+      onChange: ({ target }) => setAlternateOpportunity(target.value === REQUIRE_OPTIONS.yes),
+    },
+    {
+      children: tGcweb('input-option.no'),
+      value: REQUIRE_OPTIONS.no,
+      defaultChecked: alternateOpportunity === false,
+      onChange: ({ target }) => setAlternateOpportunity(target.value === REQUIRE_OPTIONS.yes),
+    },
+  ];
+  const employmentTenureOptions = employmentTenures.map((employmentTenures) => ({
+    value: String(employmentTenures.id),
+    children: employmentTenures.name,
+    defaultChecked: formValues?.employmentTenureIds?.includes(employmentTenures.id) ?? false,
+  }));
+
+  // Choice tags for classification
+  const classificationChoiceTags: ChoiceTag[] = selectedClassifications
+    .map((classification) => {
+      const selectedC = classifications.find((c) => c.id === Number(classification));
+      return { label: selectedC?.name ?? classification, name: 'classification', value: classification };
+    })
+    .toSorted((a, b) => String(a.label).localeCompare(String(b.label)));
+
+  /**
+   * Removes a classification from `classification group(s) and level(s)` and announces the removal to screen readers.
+   */
+  const handleOnDeleteClassificationTag: ChoiceTagDeleteEventHandler = (name, label, value) => {
+    setSrAnnouncement(tGcweb('choice-tag.removed-choice-tag-sr-message', { item: name, choice: label }));
+    setSelectedClassifications((prev) => prev.filter((classificationId) => classificationId !== value));
+  };
+
+  const handleOnClearAllClassifications: ChoiceTagClearAllEventHandler = () => {
+    setSrAnnouncement(tGcweb('choice-tag.clear-all-sr-message', { item: 'classifications' }));
+    setSelectedClassifications([]);
+  };
+
+  // Choice tags for cities
+  const citiesChoiceTags: ChoiceTag[] = selectedCities.map((city) => {
+    const selectedC = cities.find((c) => c.id === Number(city));
+    return { label: selectedC?.name ?? city, name: 'city', value: city, group: selectedC?.province.name };
+  });
+
+  /**
+   * Removes a city from `work locations` and announces the removal to screen readers.
+   */
+  const handleOnDeleteCityTag: ChoiceTagDeleteEventHandler = (name, label, value, group) => {
+    setSrAnnouncement(
+      tGcweb('choice-tag.removed-choice-tag-sr-message', { item: name, choice: group ? group + ' - ' + label : label }),
+    );
+    setSelectedCities((prev) => prev.filter((cityId) => cityId !== value));
+  };
+
+  const handleOnClearAllCities: ChoiceTagClearAllEventHandler = () => {
+    setSrAnnouncement(tGcweb('choice-tag.clear-all-sr-message', { item: 'cities' }));
+    setSelectedCities([]);
+  };
+
+  const handleOnClearCityGroup = (groupName: string) => {
+    setSrAnnouncement(tGcweb('choice-tag.clear-group-label', { items: 'cities', groupName }));
+    setSelectedCities((prev) =>
+      prev.filter((cityId) => {
+        const city = cities.find((c) => c.id === Number(cityId));
+        return city?.province.name !== groupName;
+      }),
+    );
+  };
+
+  return (
+    <>
+      <h1 className="my-5 text-3xl">{tApp('referral-preferences.page-title')}</h1>
+      <FormErrorSummary>
+        <Form method="post" noValidate>
+          <div className="space-y-6">
+            <InputCheckboxes
+              id="languageReferralTypesId"
+              errorMessage={tApp(extractValidationKey(formErrors?.languageReferralTypeIds))}
+              legend={tApp('referral-preferences.language-referral-type')}
+              name="languageReferralTypes"
+              options={languageReferralTypeOptions}
+              helpMessagePrimary={tApp('form.select-all-that-apply')}
+              required
+            />
+            <InputMultiSelect
+              id="classificationsId"
+              name="classifications"
+              label={tApp('referral-preferences.classification')}
+              options={classificationOptions}
+              value={selectedClassifications}
+              onChange={(values) => setSelectedClassifications(values)}
+              placeholder={tApp('form.select-all-that-apply')}
+              helpMessage={tApp('referral-preferences.classification-group-help-message-primary')}
+              errorMessage={tApp(extractValidationKey(formErrors?.classificationIds))}
+              required
+            />
+
+            {classificationChoiceTags.length > 0 && (
+              <ChoiceTags
+                choiceTags={classificationChoiceTags}
+                onClearAll={handleOnClearAllClassifications}
+                onDelete={handleOnDeleteClassificationTag}
+              />
+            )}
+
+            <fieldset id="workLocationFieldset" className="space-y-2">
+              <InputLegend id="workLocationLegend" required>
+                {tApp('referral-preferences.work-location')}
+              </InputLegend>
+              <InputHelp id="workLocationHelpMessage">{tApp('form.select-all-that-apply')}</InputHelp>
+              <InputSelect
+                className="w-full sm:w-1/2"
+                id="workLocationProvinceId"
+                name="workLocationProvince"
+                label={tApp('referral-preferences.province')}
+                options={provinceOptions}
+                errorMessage={tApp(extractValidationKey(formErrors?.workLocationProvince))}
+                value={province ?? ''}
+                onChange={({ target }) => setProvince(target.value || undefined)}
+              />
+              {province && (
+                <>
+                  <InputMultiSelect
+                    id="workLocationCitiesId"
+                    name="workLocationCities"
+                    errorMessage={tApp(extractValidationKey(formErrors?.workLocationCitiesIds))}
+                    options={cityOptions}
+                    value={selectedCities}
+                    onChange={(values) => setSelectedCities(values)}
+                    placeholder={tApp('form.select-all-that-apply')}
+                    label={tApp('referral-preferences.city')}
+                    className="w-full sm:w-1/2"
+                  />
+                </>
+              )}
+            </fieldset>
+
+            {citiesChoiceTags.length > 0 && (
+              <ChoiceTags
+                choiceTags={citiesChoiceTags}
+                onClearAll={handleOnClearAllCities}
+                onDelete={handleOnDeleteCityTag}
+                onClearGroup={handleOnClearCityGroup}
+              />
+            )}
+
+            <span aria-live="polite" aria-atomic="true" className="sr-only">
+              {srAnnouncement}
+            </span>
+
+            <InputRadios
+              id="referralAvailibilityId"
+              legend={tApp('referral-preferences.referral-availibility')}
+              name="referralAvailibility"
+              options={referralAvailibilityOptions}
+              required
+              errorMessage={tApp(extractValidationKey(formErrors?.availableForReferralInd))}
+              helpMessagePrimary={tApp('referral-preferences.referral-availibility-help-message-primary')}
+            />
+            <InputRadios
+              id="alternateOpportunityId"
+              legend={tApp('referral-preferences.alternate-opportunity')}
+              name="alternateOpportunity"
+              options={alternateOpportunityOptions}
+              required
+              errorMessage={tApp(extractValidationKey(formErrors?.interestedInAlternationInd))}
+              helpMessagePrimary={
+                <Collapsible summary={tApp('referral-preferences.what-is-alternation')}>
+                  {tApp('referral-preferences.alternation-description-text')}
+                </Collapsible>
+              }
+            />
+            <InputCheckboxes
+              id="employmentTenuresId"
+              errorMessage={tApp(extractValidationKey(formErrors?.employmentTenureIds))}
+              legend={tApp('referral-preferences.employment-tenure')}
+              name="employmentTenures"
+              options={employmentTenureOptions}
+              helpMessagePrimary={tApp('form.select-all-that-apply')}
+              required
+            />
+
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <Button name="action" variant="primary" id="save-button">
+                {tApp('form.save')}
+              </Button>
+              <ButtonLink file={cancelLink} params={params} id="cancel-button" variant="alternative">
+                {tApp('form.cancel')}
+              </ButtonLink>
+            </div>
+          </div>
+        </Form>
+      </FormErrorSummary>
+    </>
+  );
+}

--- a/frontend/app/routes/page-components/employees/validation.server.ts
+++ b/frontend/app/routes/page-components/employees/validation.server.ts
@@ -31,6 +31,8 @@ const hrAdvisors = await getUserService().getUsersByRole('hr-advisor');
 const allLanguageReferralTypes = await getLanguageReferralTypeService().listAll();
 const allEmploymentTenures = await getEmploymentTenureService().listAll();
 
+export type Errors = Readonly<Record<string, [string, ...string[]] | undefined>>;
+
 export const personalInformationSchema = v.object({
   surname: v.pipe(
     v.string('app:personal-information.errors.surname-required'),


### PR DESCRIPTION
## Summary

Add a page component for Employee referral preferences screen, so that it can be used on employee route as well as on the hr advisor route, ensuring the functionality is same.

## Types of changes

What types of changes does this PR introduce?

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.

- [x] code has been linted and formatted locally

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>
