### PR TITLE
refactor(frontend): remove getByCode from services

### DIFF
--- a/frontend/app/.server/domain/services/branch-service-mock.ts
+++ b/frontend/app/.server/domain/services/branch-service-mock.ts
@@ -27,10 +27,6 @@ export function getMockBranchService(): BranchService {
       return Promise.resolve(sharedService.getById(id));
     },
 
-    getByCode(code: string) {
-      return Promise.resolve(sharedService.getByCode(code));
-    },
-
     listAllLocalized(language: Language) {
       return Promise.resolve(sharedService.listAllLocalized(language));
     },
@@ -41,14 +37,6 @@ export function getMockBranchService(): BranchService {
 
     findLocalizedById(id: number, language: Language) {
       return Promise.resolve(sharedService.findLocalizedById(id, language));
-    },
-
-    getLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.getLocalizedByCode(code, language));
-    },
-
-    findLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.findLocalizedByCode(code, language));
     },
   };
 }

--- a/frontend/app/.server/domain/services/branch-service.ts
+++ b/frontend/app/.server/domain/services/branch-service.ts
@@ -9,12 +9,9 @@ import type { AppError } from '~/errors/app-error';
 export type BranchService = {
   listAll(): Promise<readonly Branch[]>;
   getById(id: number): Promise<Result<Branch, AppError>>;
-  getByCode(code: string): Promise<Result<Branch, AppError>>;
   listAllLocalized(language: Language): Promise<readonly LocalizedBranch[]>;
   getLocalizedById(id: number, language: Language): Promise<Result<LocalizedBranch, AppError>>;
   findLocalizedById(id: number, language: Language): Promise<Option<LocalizedBranch>>;
-  getLocalizedByCode(code: string, language: Language): Promise<Result<LocalizedBranch, AppError>>;
-  findLocalizedByCode(code: string, language: Language): Promise<Option<LocalizedBranch>>;
 };
 
 export function getBranchService(): BranchService {

--- a/frontend/app/.server/domain/services/city-service-mock.ts
+++ b/frontend/app/.server/domain/services/city-service-mock.ts
@@ -50,10 +50,6 @@ export function getMockCityService(): CityService {
       return Promise.resolve(sharedService.getById(id));
     },
 
-    getByCode(code: string) {
-      return Promise.resolve(sharedService.getByCode(code));
-    },
-
     listAllLocalized(language: Language) {
       return Promise.resolve(sharedService.listAllLocalized(language));
     },
@@ -64,14 +60,6 @@ export function getMockCityService(): CityService {
 
     findLocalizedById(id: number, language: Language) {
       return Promise.resolve(sharedService.findLocalizedById(id, language));
-    },
-
-    getLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.getLocalizedByCode(code, language));
-    },
-
-    findLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.findLocalizedByCode(code, language));
     },
   };
 }

--- a/frontend/app/.server/domain/services/city-service.ts
+++ b/frontend/app/.server/domain/services/city-service.ts
@@ -9,12 +9,9 @@ import type { AppError } from '~/errors/app-error';
 export type CityService = {
   listAll(): Promise<readonly City[]>;
   getById(id: number): Promise<Result<City, AppError>>;
-  getByCode(code: string): Promise<Result<City, AppError>>;
   listAllLocalized(language: Language): Promise<readonly LocalizedCity[]>;
   getLocalizedById(id: number, language: Language): Promise<Result<LocalizedCity, AppError>>;
   findLocalizedById(id: number, language: Language): Promise<Option<LocalizedCity>>;
-  getLocalizedByCode(code: string, language: Language): Promise<Result<LocalizedCity, AppError>>;
-  findLocalizedByCode(code: string, language: Language): Promise<Option<LocalizedCity>>;
 };
 
 export function getCityService(): CityService {

--- a/frontend/app/.server/domain/services/classification-service-mock.ts
+++ b/frontend/app/.server/domain/services/classification-service-mock.ts
@@ -29,10 +29,6 @@ export function getMockClassificationService(): ClassificationService {
       return Promise.resolve(sharedService.getById(id));
     },
 
-    getByCode(code: string) {
-      return Promise.resolve(sharedService.getByCode(code));
-    },
-
     listAllLocalized(language: Language): Promise<readonly LocalizedClassification[]> {
       return Promise.resolve(sharedService.listAllLocalized(language));
     },
@@ -43,14 +39,6 @@ export function getMockClassificationService(): ClassificationService {
 
     findLocalizedById(id: number, language: Language) {
       return Promise.resolve(sharedService.findLocalizedById(id, language));
-    },
-
-    getLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.getLocalizedByCode(code, language));
-    },
-
-    findLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.findLocalizedByCode(code, language));
     },
   };
 }

--- a/frontend/app/.server/domain/services/classification-service.ts
+++ b/frontend/app/.server/domain/services/classification-service.ts
@@ -9,12 +9,9 @@ import type { AppError } from '~/errors/app-error';
 export type ClassificationService = {
   listAll(): Promise<readonly Classification[]>;
   getById(id: number): Promise<Result<Classification, AppError>>;
-  getByCode(code: string): Promise<Result<Classification, AppError>>;
   listAllLocalized(language: Language): Promise<readonly LocalizedClassification[]>;
   getLocalizedById(id: number, language: Language): Promise<Result<LocalizedClassification, AppError>>;
   findLocalizedById(id: number, language: Language): Promise<Option<LocalizedClassification>>;
-  getLocalizedByCode(code: string, language: Language): Promise<Result<LocalizedClassification, AppError>>;
-  findLocalizedByCode(code: string, language: Language): Promise<Option<LocalizedClassification>>;
 };
 
 export function getClassificationService(): ClassificationService {

--- a/frontend/app/.server/domain/services/directorate-service-mock.ts
+++ b/frontend/app/.server/domain/services/directorate-service-mock.ts
@@ -56,10 +56,6 @@ export function getMockDirectorateService(): DirectorateService {
       return Promise.resolve(sharedService.getById(id));
     },
 
-    getByCode(code: string) {
-      return Promise.resolve(sharedService.getByCode(code));
-    },
-
     listAllLocalized(language: Language) {
       return Promise.resolve(sharedService.listAllLocalized(language));
     },
@@ -70,14 +66,6 @@ export function getMockDirectorateService(): DirectorateService {
 
     findLocalizedById(id: number, language: Language) {
       return Promise.resolve(sharedService.findLocalizedById(id, language));
-    },
-
-    getLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.getLocalizedByCode(code, language));
-    },
-
-    findLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.findLocalizedByCode(code, language));
     },
   };
 }

--- a/frontend/app/.server/domain/services/directorate-service.ts
+++ b/frontend/app/.server/domain/services/directorate-service.ts
@@ -9,12 +9,9 @@ import type { AppError } from '~/errors/app-error';
 export type DirectorateService = {
   listAll(): Promise<readonly Directorate[]>;
   getById(id: number): Promise<Result<Directorate, AppError>>;
-  getByCode(code: string): Promise<Result<Directorate, AppError>>;
   listAllLocalized(language: Language): Promise<readonly LocalizedDirectorate[]>;
   getLocalizedById(id: number, language: Language): Promise<Result<LocalizedDirectorate, AppError>>;
   findLocalizedById(id: number, language: Language): Promise<Option<LocalizedDirectorate>>;
-  getLocalizedByCode(code: string, language: Language): Promise<Result<LocalizedDirectorate, AppError>>;
-  findLocalizedByCode(code: string, language: Language): Promise<Option<LocalizedDirectorate>>;
 };
 
 export function getDirectorateService(): DirectorateService {

--- a/frontend/app/.server/domain/services/employment-equity-service-mock.ts
+++ b/frontend/app/.server/domain/services/employment-equity-service-mock.ts
@@ -33,14 +33,6 @@ export function getMockEmploymentEquityService(): EmploymentEquityService {
       return Promise.resolve(sharedService.findById(id));
     },
 
-    getByCode(code: string) {
-      return Promise.resolve(sharedService.getByCode(code));
-    },
-
-    findByCode(code: string) {
-      return Promise.resolve(sharedService.findByCode(code));
-    },
-
     listAllLocalized(language: Language) {
       return Promise.resolve(sharedService.listAllLocalized(language));
     },
@@ -51,14 +43,6 @@ export function getMockEmploymentEquityService(): EmploymentEquityService {
 
     findLocalizedById(id: number, language: Language) {
       return Promise.resolve(sharedService.findLocalizedById(id, language));
-    },
-
-    getLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.getLocalizedByCode(code, language));
-    },
-
-    findLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.findLocalizedByCode(code, language));
     },
   };
 }

--- a/frontend/app/.server/domain/services/employment-equity-service.ts
+++ b/frontend/app/.server/domain/services/employment-equity-service.ts
@@ -10,13 +10,9 @@ export type EmploymentEquityService = {
   listAll(): Promise<readonly EmploymentEquity[]>;
   getById(id: number): Promise<Result<EmploymentEquity, AppError>>;
   findById(id: number): Promise<Option<EmploymentEquity>>;
-  getByCode(code: string): Promise<Result<EmploymentEquity, AppError>>;
-  findByCode(code: string): Promise<Option<EmploymentEquity>>;
   listAllLocalized(language: Language): Promise<readonly LocalizedEmploymentEquity[]>;
   getLocalizedById(id: number, language: Language): Promise<Result<LocalizedEmploymentEquity, AppError>>;
   findLocalizedById(id: number, language: Language): Promise<Option<LocalizedEmploymentEquity>>;
-  getLocalizedByCode(code: string, language: Language): Promise<Result<LocalizedEmploymentEquity, AppError>>;
-  findLocalizedByCode(code: string, language: Language): Promise<Option<LocalizedEmploymentEquity>>;
 };
 
 export function getEmploymentEquityService(): EmploymentEquityService {

--- a/frontend/app/.server/domain/services/employment-opportunity-type-service-mock.ts
+++ b/frontend/app/.server/domain/services/employment-opportunity-type-service-mock.ts
@@ -29,16 +29,8 @@ export function getMockEmploymentOpportunityTypeService(): EmploymentOpportunity
       return Promise.resolve(sharedService.getById(id));
     },
 
-    getByCode(code: string) {
-      return Promise.resolve(sharedService.getByCode(code));
-    },
-
     findById(id: number) {
       return Promise.resolve(sharedService.findById(id));
-    },
-
-    findByCode(code: string) {
-      return Promise.resolve(sharedService.findByCode(code));
     },
 
     listAllLocalized(language: Language): Promise<readonly LocalizedEmploymentOpportunityType[]> {
@@ -51,14 +43,6 @@ export function getMockEmploymentOpportunityTypeService(): EmploymentOpportunity
 
     findLocalizedById(id: number, language: Language) {
       return Promise.resolve(sharedService.findLocalizedById(id, language));
-    },
-
-    getLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.getLocalizedByCode(code, language));
-    },
-
-    findLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.findLocalizedByCode(code, language));
     },
   };
 }

--- a/frontend/app/.server/domain/services/employment-opportunity-type-service.ts
+++ b/frontend/app/.server/domain/services/employment-opportunity-type-service.ts
@@ -9,14 +9,10 @@ import type { AppError } from '~/errors/app-error';
 export type EmploymentOpportunityTypeService = {
   listAll(): Promise<readonly EmploymentOpportunityType[]>;
   getById(id: number): Promise<Result<EmploymentOpportunityType, AppError>>;
-  getByCode(code: string): Promise<Result<EmploymentOpportunityType, AppError>>;
   findById(id: number): Promise<Option<EmploymentOpportunityType>>;
-  findByCode(code: string): Promise<Option<EmploymentOpportunityType>>;
   listAllLocalized(language: Language): Promise<readonly LocalizedEmploymentOpportunityType[]>;
   getLocalizedById(id: number, language: Language): Promise<Result<LocalizedEmploymentOpportunityType, AppError>>;
   findLocalizedById(id: number, language: Language): Promise<Option<LocalizedEmploymentOpportunityType>>;
-  getLocalizedByCode(code: string, language: Language): Promise<Result<LocalizedEmploymentOpportunityType, AppError>>;
-  findLocalizedByCode(code: string, language: Language): Promise<Option<LocalizedEmploymentOpportunityType>>;
 };
 
 export function getEmploymentOpportunityTypeService(): EmploymentOpportunityTypeService {

--- a/frontend/app/.server/domain/services/employment-tenure-service-mock.ts
+++ b/frontend/app/.server/domain/services/employment-tenure-service-mock.ts
@@ -29,10 +29,6 @@ export function getMockEmploymentTenureService(): EmploymentTenureService {
       return Promise.resolve(sharedService.getById(id));
     },
 
-    getByCode(code: string) {
-      return Promise.resolve(sharedService.getByCode(code));
-    },
-
     listAllLocalized(language: Language) {
       return Promise.resolve(sharedService.listAllLocalized(language));
     },
@@ -43,14 +39,6 @@ export function getMockEmploymentTenureService(): EmploymentTenureService {
 
     findLocalizedById(id: number, language: Language) {
       return Promise.resolve(sharedService.findLocalizedById(id, language));
-    },
-
-    getLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.getLocalizedByCode(code, language));
-    },
-
-    findLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.findLocalizedByCode(code, language));
     },
   };
 }

--- a/frontend/app/.server/domain/services/employment-tenure-service.ts
+++ b/frontend/app/.server/domain/services/employment-tenure-service.ts
@@ -9,12 +9,9 @@ import type { AppError } from '~/errors/app-error';
 export type EmploymentTenureService = {
   listAll(): Promise<readonly EmploymentTenure[]>;
   getById(id: number): Promise<Result<EmploymentTenure, AppError>>;
-  getByCode(code: string): Promise<Result<EmploymentTenure, AppError>>;
   listAllLocalized(language: Language): Promise<readonly LocalizedEmploymentTenure[]>;
   getLocalizedById(id: number, language: Language): Promise<Result<LocalizedEmploymentTenure, AppError>>;
   findLocalizedById(id: number, language: Language): Promise<Option<LocalizedEmploymentTenure>>;
-  getLocalizedByCode(code: string, language: Language): Promise<Result<LocalizedEmploymentTenure, AppError>>;
-  findLocalizedByCode(code: string, language: Language): Promise<Option<LocalizedEmploymentTenure>>;
 };
 
 export function getEmploymentTenureService(): EmploymentTenureService {

--- a/frontend/app/.server/domain/services/language-for-correspondence-service-mock.ts
+++ b/frontend/app/.server/domain/services/language-for-correspondence-service-mock.ts
@@ -33,14 +33,6 @@ export function getMockLanguageForCorrespondenceService(): LanguageForCorrespond
       return Promise.resolve(sharedService.findById(id));
     },
 
-    getByCode(code: string) {
-      return Promise.resolve(sharedService.getByCode(code));
-    },
-
-    findByCode(code: string) {
-      return Promise.resolve(sharedService.findByCode(code));
-    },
-
     listAllLocalized(language: Language) {
       return Promise.resolve(sharedService.listAllLocalized(language));
     },
@@ -51,14 +43,6 @@ export function getMockLanguageForCorrespondenceService(): LanguageForCorrespond
 
     findLocalizedById(id: number, language: Language) {
       return Promise.resolve(sharedService.findLocalizedById(id, language));
-    },
-
-    getLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.getLocalizedByCode(code, language));
-    },
-
-    findLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.findLocalizedByCode(code, language));
     },
   };
 }

--- a/frontend/app/.server/domain/services/language-for-correspondence-service.ts
+++ b/frontend/app/.server/domain/services/language-for-correspondence-service.ts
@@ -10,13 +10,9 @@ export type LanguageForCorrespondenceService = {
   listAll(): Promise<readonly LanguageOfCorrespondence[]>;
   getById(id: number): Promise<Result<LanguageOfCorrespondence, AppError>>;
   findById(id: number): Promise<Option<LanguageOfCorrespondence>>;
-  getByCode(code: string): Promise<Result<LanguageOfCorrespondence, AppError>>;
-  findByCode(code: string): Promise<Option<LanguageOfCorrespondence>>;
   listAllLocalized(language: Language): Promise<readonly LocalizedLanguageOfCorrespondence[]>;
   getLocalizedById(id: number, language: Language): Promise<Result<LocalizedLanguageOfCorrespondence, AppError>>;
   findLocalizedById(id: number, language: Language): Promise<Option<LocalizedLanguageOfCorrespondence>>;
-  getLocalizedByCode(code: string, language: Language): Promise<Result<LocalizedLanguageOfCorrespondence, AppError>>;
-  findLocalizedByCode(code: string, language: Language): Promise<Option<LocalizedLanguageOfCorrespondence>>;
 };
 
 export function getLanguageForCorrespondenceService(): LanguageForCorrespondenceService {

--- a/frontend/app/.server/domain/services/language-referral-type-service-mock.ts
+++ b/frontend/app/.server/domain/services/language-referral-type-service-mock.ts
@@ -33,14 +33,6 @@ export function getMockLanguageReferralType(): LanguageReferralTypeService {
       return Promise.resolve(sharedService.findById(id));
     },
 
-    getByCode(code: string) {
-      return Promise.resolve(sharedService.getByCode(code));
-    },
-
-    findByCode(code: string) {
-      return Promise.resolve(sharedService.findByCode(code));
-    },
-
     listAllLocalized(language: Language) {
       return Promise.resolve(sharedService.listAllLocalized(language));
     },
@@ -51,14 +43,6 @@ export function getMockLanguageReferralType(): LanguageReferralTypeService {
 
     findLocalizedById(id: number, language: Language) {
       return Promise.resolve(sharedService.findLocalizedById(id, language));
-    },
-
-    getLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.getLocalizedByCode(code, language));
-    },
-
-    findLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.findLocalizedByCode(code, language));
     },
   };
 }

--- a/frontend/app/.server/domain/services/language-referral-type-service.ts
+++ b/frontend/app/.server/domain/services/language-referral-type-service.ts
@@ -10,13 +10,9 @@ export type LanguageReferralTypeService = {
   listAll(): Promise<readonly LanguageReferralType[]>;
   getById(id: number): Promise<Result<LanguageReferralType, AppError>>;
   findById(id: number): Promise<Option<LanguageReferralType>>;
-  getByCode(code: string): Promise<Result<LanguageReferralType, AppError>>;
-  findByCode(code: string): Promise<Option<LanguageReferralType>>;
   listAllLocalized(language: Language): Promise<readonly LocalizedLanguageReferralType[]>;
   getLocalizedById(id: number, language: Language): Promise<Result<LocalizedLanguageReferralType, AppError>>;
   findLocalizedById(id: number, language: Language): Promise<Option<LocalizedLanguageReferralType>>;
-  getLocalizedByCode(code: string, language: Language): Promise<Result<LocalizedLanguageReferralType, AppError>>;
-  findLocalizedByCode(code: string, language: Language): Promise<Option<LocalizedLanguageReferralType>>;
 };
 
 export function getLanguageReferralTypeService(): LanguageReferralTypeService {

--- a/frontend/app/.server/domain/services/language-requirement-service-mock.ts
+++ b/frontend/app/.server/domain/services/language-requirement-service-mock.ts
@@ -29,16 +29,8 @@ export function getMockLanguageRequirementService(): LanguageRequirementService 
       return Promise.resolve(sharedService.getById(id));
     },
 
-    getByCode(code: string) {
-      return Promise.resolve(sharedService.getByCode(code));
-    },
-
     findById(id: number) {
       return Promise.resolve(sharedService.findById(id));
-    },
-
-    findByCode(code: string) {
-      return Promise.resolve(sharedService.findByCode(code));
     },
 
     listAllLocalized(language: Language): Promise<readonly LocalizedLanguageRequirement[]> {
@@ -51,14 +43,6 @@ export function getMockLanguageRequirementService(): LanguageRequirementService 
 
     findLocalizedById(id: number, language: Language) {
       return Promise.resolve(sharedService.findLocalizedById(id, language));
-    },
-
-    getLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.getLocalizedByCode(code, language));
-    },
-
-    findLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.findLocalizedByCode(code, language));
     },
   };
 }

--- a/frontend/app/.server/domain/services/language-requirement-service.ts
+++ b/frontend/app/.server/domain/services/language-requirement-service.ts
@@ -9,14 +9,10 @@ import type { AppError } from '~/errors/app-error';
 export type LanguageRequirementService = {
   listAll(): Promise<readonly LanguageRequirement[]>;
   getById(id: number): Promise<Result<LanguageRequirement, AppError>>;
-  getByCode(code: string): Promise<Result<LanguageRequirement, AppError>>;
   findById(id: number): Promise<Option<LanguageRequirement>>;
-  findByCode(code: string): Promise<Option<LanguageRequirement>>;
   listAllLocalized(language: Language): Promise<readonly LocalizedLanguageRequirement[]>;
   getLocalizedById(id: number, language: Language): Promise<Result<LocalizedLanguageRequirement, AppError>>;
   findLocalizedById(id: number, language: Language): Promise<Option<LocalizedLanguageRequirement>>;
-  getLocalizedByCode(code: string, language: Language): Promise<Result<LocalizedLanguageRequirement, AppError>>;
-  findLocalizedByCode(code: string, language: Language): Promise<Option<LocalizedLanguageRequirement>>;
 };
 
 export function getLanguageRequirementService(): LanguageRequirementService {

--- a/frontend/app/.server/domain/services/non-advertised-appointment-service-mock.ts
+++ b/frontend/app/.server/domain/services/non-advertised-appointment-service-mock.ts
@@ -24,12 +24,8 @@ export function getMockNonAdvertisedAppointmentService(): NonAdvertisedAppointme
     listAll: () => Promise.resolve(mockService.listAll()),
     getById: (id: number) => Promise.resolve(mockService.getById(id)),
     findById: (id: number) => Promise.resolve(mockService.findById(id)),
-    getByCode: (code: string) => Promise.resolve(mockService.getByCode(code)),
-    findByCode: (code: string) => Promise.resolve(mockService.findByCode(code)),
     listAllLocalized: (language: Language) => Promise.resolve(mockService.listAllLocalized(language)),
     getLocalizedById: (id: number, language: Language) => Promise.resolve(mockService.getLocalizedById(id, language)),
     findLocalizedById: (id: number, language: Language) => Promise.resolve(mockService.findLocalizedById(id, language)),
-    getLocalizedByCode: (code: string, language: Language) => Promise.resolve(mockService.getLocalizedByCode(code, language)),
-    findLocalizedByCode: (code: string, language: Language) => Promise.resolve(mockService.findLocalizedByCode(code, language)),
   };
 }

--- a/frontend/app/.server/domain/services/non-advertised-appointment-service.ts
+++ b/frontend/app/.server/domain/services/non-advertised-appointment-service.ts
@@ -10,13 +10,9 @@ export type NonAdvertisedAppointmentService = {
   listAll(): Promise<readonly NonAdvertisedAppointment[]>;
   getById(id: number): Promise<Result<NonAdvertisedAppointment, AppError>>;
   findById(id: number): Promise<Option<NonAdvertisedAppointment>>;
-  getByCode(code: string): Promise<Result<NonAdvertisedAppointment, AppError>>;
-  findByCode(code: string): Promise<Option<NonAdvertisedAppointment>>;
   listAllLocalized(language: Language): Promise<readonly LocalizedNonAdvertisedAppointment[]>;
   getLocalizedById(id: number, language: Language): Promise<Result<LocalizedNonAdvertisedAppointment, AppError>>;
   findLocalizedById(id: number, language: Language): Promise<Option<LocalizedNonAdvertisedAppointment>>;
-  getLocalizedByCode(code: string, language: Language): Promise<Result<LocalizedNonAdvertisedAppointment, AppError>>;
-  findLocalizedByCode(code: string, language: Language): Promise<Option<LocalizedNonAdvertisedAppointment>>;
 };
 
 export function getNonAdvertisedAppointmentService(): NonAdvertisedAppointmentService {

--- a/frontend/app/.server/domain/services/priority-level-service-mock.ts
+++ b/frontend/app/.server/domain/services/priority-level-service-mock.ts
@@ -29,16 +29,8 @@ export function getMockPriorityLevelService(): PriorityLevelService {
       return Promise.resolve(sharedService.getById(id));
     },
 
-    getByCode(code: string) {
-      return Promise.resolve(sharedService.getByCode(code));
-    },
-
     findById(id: number) {
       return Promise.resolve(sharedService.findById(id));
-    },
-
-    findByCode(code: string) {
-      return Promise.resolve(sharedService.findByCode(code));
     },
 
     listAllLocalized(language: Language): Promise<readonly LocalizedPriorityLevel[]> {
@@ -51,14 +43,6 @@ export function getMockPriorityLevelService(): PriorityLevelService {
 
     findLocalizedById(id: number, language: Language) {
       return Promise.resolve(sharedService.findLocalizedById(id, language));
-    },
-
-    getLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.getLocalizedByCode(code, language));
-    },
-
-    findLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.findLocalizedByCode(code, language));
     },
   };
 }

--- a/frontend/app/.server/domain/services/priority-level-service.ts
+++ b/frontend/app/.server/domain/services/priority-level-service.ts
@@ -9,14 +9,10 @@ import type { AppError } from '~/errors/app-error';
 export type PriorityLevelService = {
   listAll(): Promise<readonly PriorityLevel[]>;
   getById(id: number): Promise<Result<PriorityLevel, AppError>>;
-  getByCode(code: string): Promise<Result<PriorityLevel, AppError>>;
   findById(id: number): Promise<Option<PriorityLevel>>;
-  findByCode(code: string): Promise<Option<PriorityLevel>>;
   listAllLocalized(language: Language): Promise<readonly LocalizedPriorityLevel[]>;
   getLocalizedById(id: number, language: Language): Promise<Result<LocalizedPriorityLevel, AppError>>;
   findLocalizedById(id: number, language: Language): Promise<Option<LocalizedPriorityLevel>>;
-  getLocalizedByCode(code: string, language: Language): Promise<Result<LocalizedPriorityLevel, AppError>>;
-  findLocalizedByCode(code: string, language: Language): Promise<Option<LocalizedPriorityLevel>>;
 };
 
 export function getPriorityLevelService(): PriorityLevelService {

--- a/frontend/app/.server/domain/services/request-status-service-mock.ts
+++ b/frontend/app/.server/domain/services/request-status-service-mock.ts
@@ -29,16 +29,8 @@ export function getMockRequestStatusService(): RequestStatusService {
       return Promise.resolve(sharedService.getById(id));
     },
 
-    getByCode(code: string) {
-      return Promise.resolve(sharedService.getByCode(code));
-    },
-
     findById(id: number) {
       return Promise.resolve(sharedService.findById(id));
-    },
-
-    findByCode(code: string) {
-      return Promise.resolve(sharedService.findByCode(code));
     },
 
     listAllLocalized(language: Language): Promise<readonly LocalizedRequestStatus[]> {
@@ -51,14 +43,6 @@ export function getMockRequestStatusService(): RequestStatusService {
 
     findLocalizedById(id: number, language: Language) {
       return Promise.resolve(sharedService.findLocalizedById(id, language));
-    },
-
-    getLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.getLocalizedByCode(code, language));
-    },
-
-    findLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.findLocalizedByCode(code, language));
     },
   };
 }

--- a/frontend/app/.server/domain/services/request-status-service.ts
+++ b/frontend/app/.server/domain/services/request-status-service.ts
@@ -9,14 +9,10 @@ import type { AppError } from '~/errors/app-error';
 export type RequestStatusService = {
   listAll(): Promise<readonly RequestStatus[]>;
   getById(id: number): Promise<Result<RequestStatus, AppError>>;
-  getByCode(code: string): Promise<Result<RequestStatus, AppError>>;
   findById(id: number): Promise<Option<RequestStatus>>;
-  findByCode(code: string): Promise<Option<RequestStatus>>;
   listAllLocalized(language: Language): Promise<readonly LocalizedRequestStatus[]>;
   getLocalizedById(id: number, language: Language): Promise<Result<LocalizedRequestStatus, AppError>>;
   findLocalizedById(id: number, language: Language): Promise<Option<LocalizedRequestStatus>>;
-  getLocalizedByCode(code: string, language: Language): Promise<Result<LocalizedRequestStatus, AppError>>;
-  findLocalizedByCode(code: string, language: Language): Promise<Option<LocalizedRequestStatus>>;
 };
 
 export function getRequestStatusService(): RequestStatusService {

--- a/frontend/app/.server/domain/services/shared/lookup-service-implementation.ts
+++ b/frontend/app/.server/domain/services/shared/lookup-service-implementation.ts
@@ -1,5 +1,5 @@
 import type { Result, Option } from 'oxide.ts';
-import { Err, Ok } from 'oxide.ts';
+import { Err } from 'oxide.ts';
 
 import type { LookupModel, LocalizedLookupModel } from '~/.server/domain/models';
 import { apiClient } from '~/.server/domain/services/api-client';
@@ -70,43 +70,11 @@ export class LookupServiceImplementation<T extends LookupModel, L extends Locali
   }
 
   /**
-   * Retrieves a single entity by its CODE.
-   */
-  async getByCode(code: string): Promise<Result<T, AppError>> {
-    const context = `get ${this.config.entityName} with CODE '${code}'`;
-    type ApiResponse = {
-      content: readonly T[];
-    };
-    const response = await apiClient.get<ApiResponse>(`${this.config.apiEndpoint}?code=${code}`, context);
-
-    if (response.isErr()) {
-      throw response.unwrapErr();
-    }
-    const data = response.unwrap();
-    const entity = data.content[0]; // Get the first element from the response array
-
-    if (!entity) {
-      // The request was successful, but no entity with that code exists.
-      return Err(new AppError(`${context} not found.`, this.config.notFoundErrorCode));
-    }
-
-    return Ok(entity);
-  }
-
-  /**
    * Finds a single entity by its ID.
    */
   async findById(id: number): Promise<Option<T>> {
     const result = await this.getById(id);
     return result.ok(); // .ok() converts Result<T, E> to Option<T>
-  }
-
-  /**
-   * Finds a single entity by its CODE.
-   */
-  async findByCode(code: string): Promise<Option<T>> {
-    const result = await this.getByCode(code);
-    return result.ok();
   }
 
   // Localized methods
@@ -128,26 +96,10 @@ export class LookupServiceImplementation<T extends LookupModel, L extends Locali
   }
 
   /**
-   * Retrieves a single localized entity by its CODE.
-   */
-  async getLocalizedByCode(code: string, language: Language): Promise<Result<L, AppError>> {
-    const result = await this.getByCode(code);
-    return result.map((entity) => this.config.localizeEntity(entity, language));
-  }
-
-  /**
    * Finds a single localized entity by its ID.
    */
   async findLocalizedById(id: number, language: Language): Promise<Option<L>> {
     const result = await this.getLocalizedById(id, language);
-    return result.ok();
-  }
-
-  /**
-   * Finds a single localized entity by its CODE.
-   */
-  async findLocalizedByCode(code: string, language: Language): Promise<Option<L>> {
-    const result = await this.getLocalizedByCode(code, language);
     return result.ok();
   }
 }

--- a/frontend/app/.server/domain/services/shared/mock-lookup-service-implementation.ts
+++ b/frontend/app/.server/domain/services/shared/mock-lookup-service-implementation.ts
@@ -48,29 +48,10 @@ export class MockLookupServiceImplementation<T extends LookupModel, L extends Lo
   }
 
   /**
-   * Retrieves a single entity by its CODE.
-   */
-  getByCode(code: string): Result<T, AppError> {
-    const entity = this.config.data.find((item) => item.code === code);
-
-    return entity
-      ? Ok(entity)
-      : Err(new AppError(`${this.config.entityName} with CODE '${code}' not found.`, this.config.notFoundErrorCode));
-  }
-
-  /**
    * Finds a single entity by its ID.
    */
   findById(id: number): Option<T> {
     const result = this.getById(id);
-    return result.ok();
-  }
-
-  /**
-   * Finds a single entity by its CODE.
-   */
-  findByCode(code: string): Option<T> {
-    const result = this.getByCode(code);
     return result.ok();
   }
 
@@ -92,26 +73,10 @@ export class MockLookupServiceImplementation<T extends LookupModel, L extends Lo
   }
 
   /**
-   * Retrieves a single localized entity by its CODE.
-   */
-  getLocalizedByCode(code: string, language: Language): Result<L, AppError> {
-    const result = this.getByCode(code);
-    return result.map((entity) => this.config.localizeEntity(entity, language));
-  }
-
-  /**
    * Finds a single localized entity by its ID.
    */
   findLocalizedById(id: number, language: Language): Option<L> {
     const result = this.getLocalizedById(id, language);
-    return result.ok();
-  }
-
-  /**
-   * Finds a single localized entity by its CODE.
-   */
-  findLocalizedByCode(code: string, language: Language): Option<L> {
-    const result = this.getLocalizedByCode(code, language);
     return result.ok();
   }
 }

--- a/frontend/app/.server/domain/services/wfa-status-service-mock.ts
+++ b/frontend/app/.server/domain/services/wfa-status-service-mock.ts
@@ -29,14 +29,6 @@ export function getMockWFAStatusService(): WFAStatusService {
       return Promise.resolve(sharedService.findById(id));
     },
 
-    getByCode(code: string) {
-      return Promise.resolve(sharedService.getByCode(code));
-    },
-
-    findByCode(code: string) {
-      return Promise.resolve(sharedService.findByCode(code));
-    },
-
     listAllLocalized(language: Language) {
       return Promise.resolve(sharedService.listAllLocalized(language));
     },
@@ -47,14 +39,6 @@ export function getMockWFAStatusService(): WFAStatusService {
 
     findLocalizedById(id: number, language: Language) {
       return Promise.resolve(sharedService.findLocalizedById(id, language));
-    },
-
-    getLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.getLocalizedByCode(code, language));
-    },
-
-    findLocalizedByCode(code: string, language: Language) {
-      return Promise.resolve(sharedService.findLocalizedByCode(code, language));
     },
   };
 }

--- a/frontend/app/.server/domain/services/wfa-status-service.ts
+++ b/frontend/app/.server/domain/services/wfa-status-service.ts
@@ -10,13 +10,9 @@ export type WFAStatusService = {
   listAll(): Promise<readonly WFAStatus[]>;
   getById(id: number): Promise<Result<WFAStatus, AppError>>;
   findById(id: number): Promise<Option<WFAStatus>>;
-  getByCode(code: string): Promise<Result<WFAStatus, AppError>>;
-  findByCode(code: string): Promise<Option<WFAStatus>>;
   listAllLocalized(language: Language): Promise<readonly LocalizedWFAStatus[]>;
   getLocalizedById(id: number, language: Language): Promise<Result<LocalizedWFAStatus, AppError>>;
   findLocalizedById(id: number, language: Language): Promise<Option<LocalizedWFAStatus>>;
-  getLocalizedByCode(code: string, language: Language): Promise<Result<LocalizedWFAStatus, AppError>>;
-  findLocalizedByCode(code: string, language: Language): Promise<Option<LocalizedWFAStatus>>;
 };
 
 export function getWFAStatuses(): WFAStatusService {

--- a/frontend/tests/.server/domain/services/employment-equity-service-default.test.ts
+++ b/frontend/tests/.server/domain/services/employment-equity-service-default.test.ts
@@ -96,51 +96,6 @@ describe('getDefaultEmploymentEquityService', () => {
     });
   });
 
-  describe('getByCode', () => {
-    it('should return an Ok result with an employment equity if found', async () => {
-      vi.mocked(fetch).mockResolvedValueOnce({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            content: [singleMockEmploymentEquity],
-          }),
-      } as Response);
-
-      const result = await service.getByCode('WOMEN');
-
-      expect(result.isOk()).toBe(true);
-      expect(result.unwrap()).toEqual(singleMockEmploymentEquity);
-      expect(fetch).toHaveBeenCalledWith('http://localhost:8080/api/v1//codes/employment-equity?code=WOMEN');
-    });
-
-    it('should return an Err result if code not found (empty response)', async () => {
-      vi.mocked(fetch).mockResolvedValueOnce({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            content: [],
-          }),
-      } as Response);
-
-      const result = await service.getByCode('NON_EXISTENT');
-
-      expect(result.isErr()).toBe(true);
-      const error = result.unwrapErr();
-      expect(error).toBeInstanceOf(AppError);
-      expect(error.errorCode).toBe(ErrorCodes.NO_EMPLOYMENT_EQUITY_FOUND);
-    });
-
-    it('should throw AppError on API failure', async () => {
-      vi.mocked(fetch).mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        statusText: 'Internal Server Error',
-      } as Response);
-
-      await expect(service.getByCode('WOMEN')).rejects.toThrow(AppError);
-    });
-  });
-
   describe('findById', () => {
     it('should return Some with an employment equity if found', async () => {
       vi.mocked(fetch).mockResolvedValueOnce({
@@ -176,47 +131,6 @@ describe('getDefaultEmploymentEquityService', () => {
       const result = await service.findById(1);
 
       expect(result.isNone()).toBe(true);
-    });
-  });
-
-  describe('findByCode', () => {
-    it('should return Some with an employment equity if found', async () => {
-      vi.mocked(fetch).mockResolvedValueOnce({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            content: [singleMockEmploymentEquity],
-          }),
-      } as Response);
-
-      const result = await service.findByCode('WOMEN');
-
-      expect(result.isSome()).toBe(true);
-      expect(result.unwrap()).toEqual(singleMockEmploymentEquity);
-    });
-
-    it('should return None if code not found', async () => {
-      vi.mocked(fetch).mockResolvedValueOnce({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            content: [],
-          }),
-      } as Response);
-
-      const result = await service.findByCode('NON_EXISTENT');
-
-      expect(result.isNone()).toBe(true);
-    });
-
-    it('should throw AppError on server error', async () => {
-      vi.mocked(fetch).mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        statusText: 'Internal Server Error',
-      } as Response);
-
-      await expect(service.findByCode('WOMEN')).rejects.toThrow(AppError);
     });
   });
 
@@ -313,46 +227,6 @@ describe('getDefaultEmploymentEquityService', () => {
     });
   });
 
-  describe('getLocalizedByCode', () => {
-    it('should return localized employment equity in English', async () => {
-      vi.mocked(fetch).mockResolvedValueOnce({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            content: [singleMockEmploymentEquity],
-          }),
-      } as Response);
-
-      const result = await service.getLocalizedByCode('WOMEN', 'en');
-
-      expect(result.isOk()).toBe(true);
-      expect(result.unwrap()).toEqual({
-        id: 1,
-        code: 'WOMEN',
-        name: 'Women',
-      });
-    });
-
-    it('should return localized employment equity in French', async () => {
-      vi.mocked(fetch).mockResolvedValueOnce({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            content: [singleMockEmploymentEquity],
-          }),
-      } as Response);
-
-      const result = await service.getLocalizedByCode('WOMEN', 'fr');
-
-      expect(result.isOk()).toBe(true);
-      expect(result.unwrap()).toEqual({
-        id: 1,
-        code: 'WOMEN',
-        name: 'Femmes',
-      });
-    });
-  });
-
   describe('findLocalizedById', () => {
     it('should return Some with localized employment equity in English', async () => {
       vi.mocked(fetch).mockResolvedValueOnce({
@@ -408,70 +282,6 @@ describe('getDefaultEmploymentEquityService', () => {
       const result = await service.findLocalizedById(1, 'en');
 
       expect(result.isNone()).toBe(true);
-    });
-  });
-
-  describe('findLocalizedByCode', () => {
-    it('should return Some with localized employment equity in English', async () => {
-      vi.mocked(fetch).mockResolvedValueOnce({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            content: [singleMockEmploymentEquity],
-          }),
-      } as Response);
-
-      const result = await service.findLocalizedByCode('WOMEN', 'en');
-
-      expect(result.isSome()).toBe(true);
-      expect(result.unwrap()).toEqual({
-        id: 1,
-        code: 'WOMEN',
-        name: 'Women',
-      });
-    });
-
-    it('should return Some with localized employment equity in French', async () => {
-      vi.mocked(fetch).mockResolvedValueOnce({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            content: [singleMockEmploymentEquity],
-          }),
-      } as Response);
-
-      const result = await service.findLocalizedByCode('WOMEN', 'fr');
-
-      expect(result.isSome()).toBe(true);
-      expect(result.unwrap()).toEqual({
-        id: 1,
-        code: 'WOMEN',
-        name: 'Femmes',
-      });
-    });
-
-    it('should return None if employment equity not found', async () => {
-      vi.mocked(fetch).mockResolvedValueOnce({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            content: [],
-          }),
-      } as Response);
-
-      const result = await service.findLocalizedByCode('NON_EXISTENT', 'en');
-
-      expect(result.isNone()).toBe(true);
-    });
-
-    it('should throw AppError on server error', async () => {
-      vi.mocked(fetch).mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        statusText: 'Internal Server Error',
-      } as Response);
-
-      await expect(service.findLocalizedByCode('WOMEN', 'en')).rejects.toThrow(AppError);
     });
   });
 });

--- a/frontend/tests/.server/domain/services/employment-equity-service-mock.test.ts
+++ b/frontend/tests/.server/domain/services/employment-equity-service-mock.test.ts
@@ -72,45 +72,6 @@ describe('getMockEmploymentEquityService', () => {
     });
   });
 
-  describe('getByCode', () => {
-    it('should return an employment equity by code', async () => {
-      const all = await service.listAll();
-      expect(all.length).toBeGreaterThan(0);
-
-      const first = all[0];
-      if (!first) {
-        throw new Error('Expected at least one employment equity in the list');
-      }
-
-      const result = await service.getByCode(first.code);
-
-      expect(result.isOk()).toBe(true);
-      expect(result.unwrap()).toEqual(first);
-    });
-
-    it('should return error if employment equity code not found', async () => {
-      const result = await service.getByCode('NON_EXISTENT');
-
-      expect(result.isErr()).toBe(true);
-      const err = result.unwrapErr();
-      expect(err).toBeInstanceOf(AppError);
-      expect(err.errorCode).toBe(ErrorCodes.NO_EMPLOYMENT_EQUITY_FOUND);
-      expect(err.msg).toContain('not found');
-    });
-
-    it('should work with known codes from test data', async () => {
-      const result = await service.getByCode('WOMEN');
-
-      expect(result.isOk()).toBe(true);
-      if (result.isOk()) {
-        const employmentEquity = result.unwrap();
-        expect(employmentEquity.code).toBe('WOMEN');
-        expect(employmentEquity.nameEn).toBe('Women');
-        expect(employmentEquity.nameFr).toBe('Femmes');
-      }
-    });
-  });
-
   describe('findById', () => {
     it('should find an employment equity by ID using Option', async () => {
       const all = await service.listAll();
@@ -129,29 +90,6 @@ describe('getMockEmploymentEquityService', () => {
 
     it('should return None if employment equity ID not found', async () => {
       const result = await service.findById(25);
-
-      expect(result.isNone()).toBe(true);
-    });
-  });
-
-  describe('findByCode', () => {
-    it('should find an employment equity by code using Option', async () => {
-      const all = await service.listAll();
-      expect(all.length).toBeGreaterThan(0);
-
-      const first = all[0];
-      if (!first) {
-        throw new Error('Expected at least one employment equity in the list');
-      }
-
-      const result = await service.findByCode(first.code);
-
-      expect(result.isSome()).toBe(true);
-      expect(result.unwrap()).toEqual(first);
-    });
-
-    it('should return None if employment equity code not found', async () => {
-      const result = await service.findByCode('NON_EXISTENT');
 
       expect(result.isNone()).toBe(true);
     });
@@ -263,39 +201,6 @@ describe('getMockEmploymentEquityService', () => {
     });
   });
 
-  describe('getLocalizedByCode', () => {
-    it('should return localized employment equity by code in English', async () => {
-      const result = await service.getLocalizedByCode('WOMEN', 'en');
-
-      expect(result.isOk()).toBe(true);
-      if (result.isOk()) {
-        const localized = result.unwrap();
-        expect(localized.code).toBe('WOMEN');
-        expect(localized.name).toBe('Women');
-      }
-    });
-
-    it('should return localized employment equity by code in French', async () => {
-      const result = await service.getLocalizedByCode('WOMEN', 'fr');
-
-      expect(result.isOk()).toBe(true);
-      if (result.isOk()) {
-        const localized = result.unwrap();
-        expect(localized.code).toBe('WOMEN');
-        expect(localized.name).toBe('Femmes');
-      }
-    });
-
-    it('should return error if employment equity code not found', async () => {
-      const result = await service.getLocalizedByCode('NON_EXISTENT', 'en');
-
-      expect(result.isErr()).toBe(true);
-      const err = result.unwrapErr();
-      expect(err).toBeInstanceOf(AppError);
-      expect(err.errorCode).toBe(ErrorCodes.NO_EMPLOYMENT_EQUITY_FOUND);
-    });
-  });
-
   describe('findLocalizedById', () => {
     it('should find localized employment equity by ID using Option', async () => {
       const all = await service.listAll();
@@ -346,63 +251,17 @@ describe('getMockEmploymentEquityService', () => {
     });
   });
 
-  describe('findLocalizedByCode', () => {
-    it('should find localized employment equity by code using Option', async () => {
-      const result = await service.findLocalizedByCode('WOMEN', 'en');
-
-      expect(result.isSome()).toBe(true);
-      if (result.isSome()) {
-        const localized = result.unwrap();
-        expect(localized.code).toBe('WOMEN');
-        expect(localized.name).toBe('Women');
-      }
-    });
-
-    it('should return None if employment equity code not found', async () => {
-      const result = await service.findLocalizedByCode('NON_EXISTENT', 'en');
-
-      expect(result.isNone()).toBe(true);
-    });
-
-    it('should handle both English and French localization', async () => {
-      const resultEn = await service.findLocalizedByCode('WOMEN', 'en');
-      const resultFr = await service.findLocalizedByCode('WOMEN', 'fr');
-
-      expect(resultEn.isSome()).toBe(true);
-      expect(resultFr.isSome()).toBe(true);
-
-      if (resultEn.isSome() && resultFr.isSome()) {
-        const localizedEn = resultEn.unwrap();
-        const localizedFr = resultFr.unwrap();
-
-        expect(localizedEn.name).toBe('Women');
-        expect(localizedFr.name).toBe('Femmes');
-      }
-    });
-  });
-
   describe('error handling consistency', () => {
     it('should use consistent error codes for not found scenarios', async () => {
       const getByIdResult = await service.getById(25);
-      const getByCodeResult = await service.getByCode('NON_EXISTENT');
       const getLocalizedByIdResult = await service.getLocalizedById(25, 'en');
-      const getLocalizedByCodeResult = await service.getLocalizedByCode('NON_EXISTENT', 'en');
 
       expect(getByIdResult.isErr()).toBe(true);
-      expect(getByCodeResult.isErr()).toBe(true);
       expect(getLocalizedByIdResult.isErr()).toBe(true);
-      expect(getLocalizedByCodeResult.isErr()).toBe(true);
 
-      if (
-        getByIdResult.isErr() &&
-        getByCodeResult.isErr() &&
-        getLocalizedByIdResult.isErr() &&
-        getLocalizedByCodeResult.isErr()
-      ) {
+      if (getByIdResult.isErr() && getLocalizedByIdResult.isErr()) {
         expect(getByIdResult.unwrapErr().errorCode).toBe(ErrorCodes.NO_EMPLOYMENT_EQUITY_FOUND);
-        expect(getByCodeResult.unwrapErr().errorCode).toBe(ErrorCodes.NO_EMPLOYMENT_EQUITY_FOUND);
         expect(getLocalizedByIdResult.unwrapErr().errorCode).toBe(ErrorCodes.NO_EMPLOYMENT_EQUITY_FOUND);
-        expect(getLocalizedByCodeResult.unwrapErr().errorCode).toBe(ErrorCodes.NO_EMPLOYMENT_EQUITY_FOUND);
       }
     });
   });
@@ -418,24 +277,16 @@ describe('getMockEmploymentEquityService', () => {
       }
 
       const getByIdResult = await service.getById(first.id);
-      const getByCodeResult = await service.getByCode(first.code);
       const findByIdResult = await service.findById(first.id);
-      const findByCodeResult = await service.findByCode(first.code);
 
       expect(getByIdResult.isOk()).toBe(true);
-      expect(getByCodeResult.isOk()).toBe(true);
       expect(findByIdResult.isSome()).toBe(true);
-      expect(findByCodeResult.isSome()).toBe(true);
 
-      if (getByIdResult.isOk() && getByCodeResult.isOk() && findByIdResult.isSome() && findByCodeResult.isSome()) {
+      if (getByIdResult.isOk() && findByIdResult.isSome()) {
         const employmentEquity1 = getByIdResult.unwrap();
-        const employmentEquity2 = getByCodeResult.unwrap();
-        const employmentEquity3 = findByIdResult.unwrap();
-        const employmentEquity4 = findByCodeResult.unwrap();
+        const employmentEquity2 = findByIdResult.unwrap();
 
         expect(employmentEquity1).toEqual(employmentEquity2);
-        expect(employmentEquity2).toEqual(employmentEquity3);
-        expect(employmentEquity3).toEqual(employmentEquity4);
       }
     });
 
@@ -449,23 +300,15 @@ describe('getMockEmploymentEquityService', () => {
       }
 
       const localizedEnById = await service.getLocalizedById(first.id, 'en');
-      const localizedEnByCode = await service.getLocalizedByCode(first.code, 'en');
       const localizedFrById = await service.getLocalizedById(first.id, 'fr');
-      const localizedFrByCode = await service.getLocalizedByCode(first.code, 'fr');
 
       expect(localizedEnById.isOk()).toBe(true);
-      expect(localizedEnByCode.isOk()).toBe(true);
       expect(localizedFrById.isOk()).toBe(true);
-      expect(localizedFrByCode.isOk()).toBe(true);
 
-      if (localizedEnById.isOk() && localizedEnByCode.isOk() && localizedFrById.isOk() && localizedFrByCode.isOk()) {
+      if (localizedEnById.isOk() && localizedFrById.isOk()) {
         const enById = localizedEnById.unwrap();
-        const enByCode = localizedEnByCode.unwrap();
         const frById = localizedFrById.unwrap();
-        const frByCode = localizedFrByCode.unwrap();
 
-        expect(enById).toEqual(enByCode);
-        expect(frById).toEqual(frByCode);
         expect(enById.name).toBe(first.nameEn);
         expect(frById.name).toBe(first.nameFr);
       }

--- a/frontend/tests/.server/domain/services/non-advertised-appointment-service-default.test.ts
+++ b/frontend/tests/.server/domain/services/non-advertised-appointment-service-default.test.ts
@@ -89,44 +89,6 @@ describe('getDefaultNonAdvertisedAppointmentService', () => {
     });
   });
 
-  describe('getByCode', () => {
-    it('should return an Ok result with a non-advertised appointment if found', async () => {
-      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(mockApiData),
-      });
-
-      const result = await service.getByCode('NONE');
-      expect(result.isOk()).toBe(true);
-      expect(result.unwrap()).toEqual(singleMockAppointment);
-    });
-
-    it('should return an Err result if code not found (empty response)', async () => {
-      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ content: [] }),
-      });
-
-      const result = await service.getByCode('NON_EXISTENT_CODE');
-      expect(result.isErr()).toBe(true);
-
-      const error = result.unwrapErr();
-      expect(error).toBeInstanceOf(AppError);
-      expect(error.errorCode).toBe(ErrorCodes.NO_NON_ADVERTISED_APPOINTMENT_FOUND);
-      expect(error.msg).toContain('not found');
-    });
-
-    it('should throw AppError on API failure', async () => {
-      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        ok: false,
-        status: HttpStatusCodes.INTERNAL_SERVER_ERROR,
-        statusText: 'Internal Server Error',
-      });
-
-      await expect(service.getByCode('NONE')).rejects.toThrow(AppError);
-    });
-  });
-
   describe('findById', () => {
     it('should return Some with a non-advertised appointment if found', async () => {
       (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
@@ -160,39 +122,6 @@ describe('getDefaultNonAdvertisedAppointmentService', () => {
       // findById calls getById which returns Err for server errors, .ok() converts Err to None
       const result = await service.findById(1);
       expect(result.isNone()).toBe(true);
-    });
-  });
-
-  describe('findByCode', () => {
-    it('should return Some with a non-advertised appointment if found', async () => {
-      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(mockApiData),
-      });
-
-      const result = await service.findByCode('NONE');
-      expect(result.isSome()).toBe(true);
-      expect(result.unwrap()).toEqual(singleMockAppointment);
-    });
-
-    it('should return None if code not found', async () => {
-      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ content: [] }),
-      });
-
-      const result = await service.findByCode('NON_EXISTENT_CODE');
-      expect(result.isNone()).toBe(true);
-    });
-
-    it('should throw AppError on server error', async () => {
-      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        ok: false,
-        status: HttpStatusCodes.INTERNAL_SERVER_ERROR,
-        statusText: 'Internal Server Error',
-      });
-
-      await expect(service.findByCode('NONE')).rejects.toThrow(AppError);
     });
   });
 
@@ -282,49 +211,6 @@ describe('getDefaultNonAdvertisedAppointmentService', () => {
     });
   });
 
-  describe('getLocalizedByCode', () => {
-    it('should return localized appointment in English', async () => {
-      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(mockApiData),
-      });
-
-      const result = await service.getLocalizedByCode('NONE', 'en');
-      expect(result.isOk()).toBe(true);
-      expect(result.unwrap()).toEqual({
-        id: 1,
-        code: 'NONE',
-        name: 'Not Applicable',
-      });
-    });
-
-    it('should return localized appointment in French', async () => {
-      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(mockApiData),
-      });
-
-      const result = await service.getLocalizedByCode('NONE', 'fr');
-      expect(result.isOk()).toBe(true);
-      expect(result.unwrap()).toEqual({
-        id: 1,
-        code: 'NONE',
-        name: 'Sans objet',
-      });
-    });
-
-    it('should return Err if code not found', async () => {
-      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ content: [] }),
-      });
-
-      const result = await service.getLocalizedByCode('NON_EXISTENT_CODE', 'en');
-      expect(result.isErr()).toBe(true);
-      expect(result.unwrapErr().errorCode).toBe(ErrorCodes.NO_NON_ADVERTISED_APPOINTMENT_FOUND);
-    });
-  });
-
   describe('findLocalizedById', () => {
     it('should return Some with localized appointment if found', async () => {
       (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
@@ -349,33 +235,6 @@ describe('getDefaultNonAdvertisedAppointmentService', () => {
       });
 
       const result = await service.findLocalizedById(25, 'en');
-      expect(result.isNone()).toBe(true);
-    });
-  });
-
-  describe('findLocalizedByCode', () => {
-    it('should return Some with localized appointment if found', async () => {
-      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(mockApiData),
-      });
-
-      const result = await service.findLocalizedByCode('NONE', 'en');
-      expect(result.isSome()).toBe(true);
-      expect(result.unwrap()).toEqual({
-        id: 1,
-        code: 'NONE',
-        name: 'Not Applicable',
-      });
-    });
-
-    it('should return None if code not found', async () => {
-      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ content: [] }),
-      });
-
-      const result = await service.findLocalizedByCode('NON_EXISTENT_CODE', 'en');
       expect(result.isNone()).toBe(true);
     });
   });

--- a/frontend/tests/.server/domain/services/non-advertised-appointment-service-mock.test.ts
+++ b/frontend/tests/.server/domain/services/non-advertised-appointment-service-mock.test.ts
@@ -65,38 +65,6 @@ describe('getMockNonAdvertisedAppointmentService', () => {
     });
   });
 
-  describe('getByCode', () => {
-    it('should return a non-advertised appointment by code', async () => {
-      const all = await service.listAll();
-      const first = all[0];
-      if (!first) {
-        throw new Error('Expected at least one appointment in the list');
-      }
-
-      const result = await service.getByCode(first.code);
-      expect(result.isOk()).toBe(true);
-      expect(result.unwrap().code).toBe(first.code);
-      expect(result.unwrap().id).toBe(first.id);
-    });
-
-    it('should return error if appointment code not found', async () => {
-      const result = await service.getByCode('NON_EXISTENT_CODE');
-      expect(result.isErr()).toBe(true);
-
-      const err = result.unwrapErr();
-      expect(err).toBeInstanceOf(AppError);
-      expect(err.errorCode).toBe(ErrorCodes.NO_NON_ADVERTISED_APPOINTMENT_FOUND);
-      expect(err.msg).toContain('not found');
-    });
-
-    it('should work with known codes from test data', async () => {
-      // Test with "NONE" which should be in the test data
-      const result = await service.getByCode('NONE');
-      expect(result.isOk()).toBe(true);
-      expect(result.unwrap().code).toBe('NONE');
-    });
-  });
-
   describe('findById', () => {
     it('should find a non-advertised appointment by ID using Option', async () => {
       const appointments = await service.listAll();
@@ -112,25 +80,6 @@ describe('getMockNonAdvertisedAppointmentService', () => {
 
     it('should return None if appointment ID not found', async () => {
       const result = await service.findById(25);
-      expect(result.isNone()).toBe(true);
-    });
-  });
-
-  describe('findByCode', () => {
-    it('should find a non-advertised appointment by code using Option', async () => {
-      const appointments = await service.listAll();
-      const first = appointments[0];
-      if (!first) {
-        throw new Error('Expected at least one appointment in the list');
-      }
-
-      const result = await service.findByCode(first.code);
-      expect(result.isSome()).toBe(true);
-      expect(result.unwrap().code).toBe(first.code);
-    });
-
-    it('should return None if appointment code not found', async () => {
-      const result = await service.findByCode('NON_EXISTENT_CODE');
       expect(result.isNone()).toBe(true);
     });
   });
@@ -221,44 +170,6 @@ describe('getMockNonAdvertisedAppointmentService', () => {
     });
   });
 
-  describe('getLocalizedByCode', () => {
-    it('should return localized appointment by code in English', async () => {
-      const appointments = await service.listAll();
-      const first = appointments[0];
-      if (!first) {
-        throw new Error('Expected at least one appointment in the list');
-      }
-
-      const result = await service.getLocalizedByCode(first.code, 'en');
-      expect(result.isOk()).toBe(true);
-
-      const localized = result.unwrap();
-      expect(localized.code).toBe(first.code);
-      expect(localized.name).toBe(first.nameEn);
-    });
-
-    it('should return localized appointment by code in French', async () => {
-      const appointments = await service.listAll();
-      const first = appointments[0];
-      if (!first) {
-        throw new Error('Expected at least one appointment in the list');
-      }
-
-      const result = await service.getLocalizedByCode(first.code, 'fr');
-      expect(result.isOk()).toBe(true);
-
-      const localized = result.unwrap();
-      expect(localized.code).toBe(first.code);
-      expect(localized.name).toBe(first.nameFr);
-    });
-
-    it('should return error if appointment code not found', async () => {
-      const result = await service.getLocalizedByCode('NON_EXISTENT_CODE', 'en');
-      expect(result.isErr()).toBe(true);
-      expect(result.unwrapErr().errorCode).toBe(ErrorCodes.NO_NON_ADVERTISED_APPOINTMENT_FOUND);
-    });
-  });
-
   describe('findLocalizedById', () => {
     it('should find localized appointment by ID using Option', async () => {
       const appointments = await service.listAll();
@@ -297,64 +208,6 @@ describe('getMockNonAdvertisedAppointmentService', () => {
     });
   });
 
-  describe('findLocalizedByCode', () => {
-    it('should find localized appointment by code using Option', async () => {
-      const appointments = await service.listAll();
-      const first = appointments[0];
-      if (!first) {
-        throw new Error('Expected at least one appointment in the list');
-      }
-
-      const result = await service.findLocalizedByCode(first.code, 'en');
-      expect(result.isSome()).toBe(true);
-
-      const localized = result.unwrap();
-      expect(localized.code).toBe(first.code);
-      expect(localized.name).toBe(first.nameEn);
-    });
-
-    it('should return None if appointment code not found', async () => {
-      const result = await service.findLocalizedByCode('NON_EXISTENT_CODE', 'en');
-      expect(result.isNone()).toBe(true);
-    });
-
-    it('should handle both English and French localization', async () => {
-      const appointments = await service.listAll();
-      const first = appointments[0];
-      if (!first) {
-        throw new Error('Expected at least one appointment in the list');
-      }
-
-      const resultEn = await service.findLocalizedByCode(first.code, 'en');
-      const resultFr = await service.findLocalizedByCode(first.code, 'fr');
-
-      expect(resultEn.isSome()).toBe(true);
-      expect(resultFr.isSome()).toBe(true);
-      expect(resultEn.unwrap().name).toBe(first.nameEn);
-      expect(resultFr.unwrap().name).toBe(first.nameFr);
-    });
-  });
-
-  describe('error handling consistency', () => {
-    it('should use consistent error codes for not found scenarios', async () => {
-      const getByIdError = await service.getById(25);
-      const getByCodeError = await service.getByCode('NON_EXISTENT_CODE');
-      const getLocalizedByIdError = await service.getLocalizedById(25, 'en');
-      const getLocalizedByCodeError = await service.getLocalizedByCode('NON_EXISTENT_CODE', 'en');
-
-      expect(getByIdError.isErr()).toBe(true);
-      expect(getByCodeError.isErr()).toBe(true);
-      expect(getLocalizedByIdError.isErr()).toBe(true);
-      expect(getLocalizedByCodeError.isErr()).toBe(true);
-
-      // All should use the same error code
-      expect(getByIdError.unwrapErr().errorCode).toBe(ErrorCodes.NO_NON_ADVERTISED_APPOINTMENT_FOUND);
-      expect(getByCodeError.unwrapErr().errorCode).toBe(ErrorCodes.NO_NON_ADVERTISED_APPOINTMENT_FOUND);
-      expect(getLocalizedByIdError.unwrapErr().errorCode).toBe(ErrorCodes.NO_NON_ADVERTISED_APPOINTMENT_FOUND);
-      expect(getLocalizedByCodeError.unwrapErr().errorCode).toBe(ErrorCodes.NO_NON_ADVERTISED_APPOINTMENT_FOUND);
-    });
-  });
-
   describe('data integrity', () => {
     it('should maintain data consistency across different methods', async () => {
       const all = await service.listAll();
@@ -365,11 +218,8 @@ describe('getMockNonAdvertisedAppointmentService', () => {
 
       // Get the same appointment through different methods
       const byId = await service.getById(first.id);
-      const byCode = await service.getByCode(first.code);
 
       expect(byId.isOk()).toBe(true);
-      expect(byCode.isOk()).toBe(true);
-      expect(byId.unwrap()).toEqual(byCode.unwrap());
       expect(byId.unwrap()).toEqual(first);
     });
 
@@ -381,11 +231,8 @@ describe('getMockNonAdvertisedAppointmentService', () => {
       }
 
       const localizedById = await service.getLocalizedById(first.id, 'en');
-      const localizedByCode = await service.getLocalizedByCode(first.code, 'en');
 
       expect(localizedById.isOk()).toBe(true);
-      expect(localizedByCode.isOk()).toBe(true);
-      expect(localizedById.unwrap()).toEqual(localizedByCode.unwrap());
     });
   });
 });

--- a/frontend/tests/.server/domain/services/shared/lookup-service-implementation.test.ts
+++ b/frontend/tests/.server/domain/services/shared/lookup-service-implementation.test.ts
@@ -67,17 +67,6 @@ describe('LookupServiceImplementation', () => {
       expect(mockApiClient.get).toHaveBeenCalledWith('/test-endpoint/1', "Get test entity with ID '1'");
     });
 
-    it('should retrieve entity by CODE successfully', async () => {
-      const mockResponse = { content: [mockTestData[0]] };
-      mockApiClient.get.mockResolvedValue(Ok(mockResponse));
-
-      const result = await service.getByCode('TEST1');
-
-      expect(result.isOk()).toBe(true);
-      expect(result.unwrap()).toEqual(mockTestData[0]);
-      expect(mockApiClient.get).toHaveBeenCalledWith('/test-endpoint?code=TEST1', "get test entity with CODE 'TEST1'");
-    });
-
     it('should return localized entities', async () => {
       const mockResponse = { content: mockTestData };
       mockApiClient.get.mockResolvedValue(Ok(mockResponse));
@@ -95,17 +84,6 @@ describe('LookupServiceImplementation', () => {
         code: 'TEST2',
         name: 'Test Deux',
       });
-    });
-
-    it('should handle entity not found by CODE', async () => {
-      const mockResponse = { content: [] };
-      mockApiClient.get.mockResolvedValue(Ok(mockResponse));
-
-      const result = await service.getByCode('NONEXISTENT');
-
-      expect(result.isErr()).toBe(true);
-      expect(result.unwrapErr()).toBeInstanceOf(AppError);
-      expect(result.unwrapErr().message).toContain('not found');
     });
 
     it('should convert Result to Option for find methods', async () => {
@@ -132,12 +110,6 @@ describe('LookupServiceImplementation', () => {
 
     it('should retrieve entity by ID', () => {
       const result = mockService.getById(1);
-      expect(result.isOk()).toBe(true);
-      expect(result.unwrap()).toEqual(mockTestData[0]);
-    });
-
-    it('should retrieve entity by CODE', () => {
-      const result = mockService.getByCode('TEST1');
       expect(result.isOk()).toBe(true);
       expect(result.unwrap()).toEqual(mockTestData[0]);
     });


### PR DESCRIPTION
## Summary

Remove getByCode method from services (for the code tables/lookup tables). As the API isn't filtering the code tables on 'code' field. Also the get by code isn't used anywhere on the frontend.

## Types of changes

What types of changes does this PR introduce?

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>
