### PR TITLE
refactor(frontend) user service get/register current user

### DIFF
--- a/frontend/app/.server/domain/services/user-service-default.ts
+++ b/frontend/app/.server/domain/services/user-service-default.ts
@@ -69,29 +69,6 @@ export function getDefaultUserService(): UserService {
     },
 
     /**
-     * Registers a new user.
-     * @param user The user data to create.
-     * @returns A promise that resolves to the created user object.
-     * @throws AppError if the request fails or if the server responds with an error status.
-     */
-    async registerUser(user: UserCreate, session: AuthenticatedSession): Promise<User> {
-      const response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}/users`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(user),
-      });
-
-      if (!response.ok) {
-        const errorMessage = `Failed to register user. Server responded with status ${response.status}.`;
-        throw new AppError(errorMessage, ErrorCodes.VACMAN_API_ERROR);
-      }
-
-      return await response.json();
-    },
-
-    /**
      * Updates a user's role identified by their Active Directory ID.
      * @param activeDirectoryId The Active Directory ID of the user to update.
      * @param newRole The new role to assign to the user.
@@ -117,6 +94,39 @@ export function getDefaultUserService(): UserService {
 
       if (!response.ok) {
         const errorMessage = `Failed to update user role. Server responded with status ${response.status}.`;
+        throw new AppError(errorMessage, ErrorCodes.VACMAN_API_ERROR);
+      }
+
+      return await response.json();
+    },
+
+    async getCurrentUser(session: AuthenticatedSession): Promise<User> {
+      const response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}/users/me`, {
+        headers: {
+          Authorization: `Bearer ${session.authState.accessToken}`,
+        },
+      });
+
+      if (!response.ok) {
+        const errorMessage = `Failed to get current user. Server responded with status ${response.status}.`;
+        throw new AppError(errorMessage, ErrorCodes.VACMAN_API_ERROR);
+      }
+
+      return await response.json();
+    },
+
+    async registerCurrentUser(user: UserCreate, session: AuthenticatedSession): Promise<User> {
+      const response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}/users/me`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${session.authState.accessToken}`,
+        },
+        body: JSON.stringify(user),
+      });
+
+      if (!response.ok) {
+        const errorMessage = `Failed to register current user. Server responded with status ${response.status}.`;
         throw new AppError(errorMessage, ErrorCodes.VACMAN_API_ERROR);
       }
 

--- a/frontend/app/.server/domain/services/user-service-mock.ts
+++ b/frontend/app/.server/domain/services/user-service-mock.ts
@@ -28,10 +28,25 @@ export function getMockUserService(): UserService {
         return Promise.reject(error);
       }
     },
-    registerUser: (user: UserCreate, session: AuthenticatedSession) => Promise.resolve(registerUser(user, session)),
     updateUserRole: (activeDirectoryId: string, newRole: string, session: AuthenticatedSession) => {
       try {
         return Promise.resolve(updateUserRole(activeDirectoryId, newRole, session));
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    },
+    getCurrentUser: (session: AuthenticatedSession): Promise<User> => {
+      try {
+        const user = mockUsers[0];
+        if (!user) return Promise.reject(new Error('No mock users available'));
+        return Promise.resolve(user);
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    },
+    registerCurrentUser: (user: UserCreate, session: AuthenticatedSession): Promise<User> => {
+      try {
+        return Promise.resolve(registerCurrentUser(user, session));
       } catch (error) {
         return Promise.reject(error);
       }
@@ -174,7 +189,7 @@ function getUserByActiveDirectoryId(activeDirectoryId: string): User | null {
  * @param session The authenticated session.
  * @returns The created user object with generated metadata.
  */
-function registerUser(userData: UserCreate, session: AuthenticatedSession): User {
+function registerCurrentUser(userData: UserCreate, session: AuthenticatedSession): User {
   // Extract user information from session tokens
   const idTokenClaims = session.authState.idTokenClaims;
 

--- a/frontend/app/.server/domain/services/user-service.ts
+++ b/frontend/app/.server/domain/services/user-service.ts
@@ -8,8 +8,9 @@ export type UserService = {
   getUsersByRole(role: string): Promise<User[]>;
   getUserById(id: number): Promise<User>;
   getUserByActiveDirectoryId(activeDirectoryId: string): Promise<User | null>;
-  registerUser(user: UserCreate, session: AuthenticatedSession): Promise<User>;
   updateUserRole(activeDirectoryId: string, newRole: string, session: AuthenticatedSession): Promise<User>;
+  getCurrentUser(session: AuthenticatedSession): Promise<User>;
+  registerCurrentUser(user: UserCreate, session: AuthenticatedSession): Promise<User>;
 };
 
 export function getUserService(): UserService {

--- a/frontend/app/routes/employee/privacy-consent.tsx
+++ b/frontend/app/routes/employee/privacy-consent.tsx
@@ -32,7 +32,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
       await ensureUserProfile(activeDirectoryId);
     } else {
       // User doesn't exist, register them with privacy consent accepted
-      await userService.registerUser(
+      await userService.registerCurrentUser(
         {
           activeDirectoryId,
           role: 'employee',

--- a/frontend/app/routes/index.tsx
+++ b/frontend/app/routes/index.tsx
@@ -61,7 +61,7 @@ export async function action({ context, request }: Route.ActionArgs) {
       }
     } else {
       // User is not registered, register them as hiring-manager and redirect
-      await userService.registerUser(
+      await userService.registerCurrentUser(
         {
           activeDirectoryId,
           role: 'hiring-manager',

--- a/frontend/tests/.server/domain/services/user-service-integration.test.ts
+++ b/frontend/tests/.server/domain/services/user-service-integration.test.ts
@@ -46,7 +46,7 @@ describe('User Service Integration', () => {
         },
       } as unknown as AuthenticatedSession;
 
-      const registeredUser = await userService.registerUser(newUserData, mockSession);
+      const registeredUser = await userService.registerCurrentUser(newUserData, mockSession);
 
       expect(registeredUser).toMatchObject({
         uuName: 'Test Employee',
@@ -89,7 +89,7 @@ describe('User Service Integration', () => {
         },
       } as unknown as AuthenticatedSession;
 
-      const registeredUser = await userService.registerUser(newUserData, mockSession);
+      const registeredUser = await userService.registerCurrentUser(newUserData, mockSession);
 
       expect(registeredUser).toMatchObject({
         uuName: 'Test Hiring Manager',
@@ -130,7 +130,7 @@ describe('User Service Integration', () => {
       } as unknown as AuthenticatedSession;
 
       // First register a user
-      await userService.registerUser(
+      await userService.registerCurrentUser(
         {
           role: 'employee',
         },

--- a/frontend/tests/.server/domain/services/user-service-mock.test.ts
+++ b/frontend/tests/.server/domain/services/user-service-mock.test.ts
@@ -70,7 +70,7 @@ describe('getMockUserService', () => {
     });
   });
 
-  describe('registerUser', () => {
+  describe('registerCurrentUser', () => {
     it('should create a new user with generated metadata', async () => {
       const userData = {
         role: 'employee',
@@ -103,7 +103,7 @@ describe('getMockUserService', () => {
         },
       } as unknown as AuthenticatedSession;
 
-      const createdUser = await service.registerUser(userData, mockSession);
+      const createdUser = await service.registerCurrentUser(userData, mockSession);
 
       expect(createdUser.id).toBeDefined();
       expect(createdUser.uuName).toBe('Test User');

--- a/frontend/tests/.server/routes/hiring-manager.test.ts
+++ b/frontend/tests/.server/routes/hiring-manager.test.ts
@@ -52,8 +52,9 @@ const mockUserService = {
   getUsersByRole: vi.fn(),
   getUserById: vi.fn(),
   getUserByActiveDirectoryId: vi.fn(),
-  registerUser: vi.fn(),
   updateUserRole: vi.fn(),
+  getCurrentUser: vi.fn(),
+  registerCurrentUser: vi.fn(),
 };
 
 vi.mocked(getUserService).mockReturnValue(mockUserService);

--- a/frontend/tests/.server/routes/index.test.ts
+++ b/frontend/tests/.server/routes/index.test.ts
@@ -63,8 +63,9 @@ const mockUserService = {
   getUsersByRole: vi.fn(),
   getUserById: vi.fn(),
   getUserByActiveDirectoryId: vi.fn(),
-  registerUser: vi.fn(),
   updateUserRole: vi.fn(),
+  getCurrentUser: vi.fn(),
+  registerCurrentUser: vi.fn(),
 };
 
 vi.mocked(getUserService).mockReturnValue(mockUserService);
@@ -143,7 +144,7 @@ describe('Index Dashboard Selection Flow', () => {
       expect(mockProfileService.getProfile).toHaveBeenCalledWith('test-employee-123');
 
       // Verify user was NOT registered yet
-      expect(mockUserService.registerUser).not.toHaveBeenCalled();
+      expect(mockUserService.registerCurrentUser).not.toHaveBeenCalled();
     });
 
     it('should redirect registered employee to employee dashboard', async () => {
@@ -182,7 +183,7 @@ describe('Index Dashboard Selection Flow', () => {
       expect(response.headers.get('Location')).toBe('/en/employee');
 
       // Verify no registration attempted
-      expect(mockUserService.registerUser).not.toHaveBeenCalled();
+      expect(mockUserService.registerCurrentUser).not.toHaveBeenCalled();
     });
   });
 
@@ -204,7 +205,7 @@ describe('Index Dashboard Selection Flow', () => {
       expect(response.headers.get('Location')).toBe('/en/hiring-manager');
 
       // Verify user was registered immediately
-      expect(mockUserService.registerUser).toHaveBeenCalledWith(
+      expect(mockUserService.registerCurrentUser).toHaveBeenCalledWith(
         {
           activeDirectoryId: 'test-manager-123',
           role: 'hiring-manager',
@@ -237,7 +238,7 @@ describe('Index Dashboard Selection Flow', () => {
       expect(response.headers.get('Location')).toBe('/en/hiring-manager');
 
       // Verify no registration attempted
-      expect(mockUserService.registerUser).not.toHaveBeenCalled();
+      expect(mockUserService.registerCurrentUser).not.toHaveBeenCalled();
       // Verify no role update attempted since user is already a hiring manager
       expect(mockUserService.updateUserRole).not.toHaveBeenCalled();
     });
@@ -287,7 +288,7 @@ describe('Index Dashboard Selection Flow', () => {
       );
 
       // Verify no new registration attempted since user already exists
-      expect(mockUserService.registerUser).not.toHaveBeenCalled();
+      expect(mockUserService.registerCurrentUser).not.toHaveBeenCalled();
     });
   });
 
@@ -304,7 +305,7 @@ describe('Index Dashboard Selection Flow', () => {
       expect(response).toBeInstanceOf(Response);
       expect(response.status).toBe(400);
       expect(await response.text()).toBe('Invalid dashboard selection');
-      expect(mockUserService.registerUser).not.toHaveBeenCalled();
+      expect(mockUserService.registerCurrentUser).not.toHaveBeenCalled();
     });
 
     it('should handle missing name gracefully', async () => {
@@ -323,7 +324,7 @@ describe('Index Dashboard Selection Flow', () => {
       expect(response.status).toBe(302);
 
       // Verify user was registered with fallback name
-      expect(mockUserService.registerUser).toHaveBeenCalledWith(
+      expect(mockUserService.registerCurrentUser).toHaveBeenCalledWith(
         {
           activeDirectoryId: 'test-manager-123',
           role: 'hiring-manager',
@@ -380,7 +381,7 @@ describe('Index Dashboard Selection Flow', () => {
       expect(response.status).toBe(302);
       expect(response.headers.get('Location')).toBe('/fr/gestionnaire-embauche');
 
-      expect(mockUserService.registerUser).toHaveBeenCalledWith(
+      expect(mockUserService.registerCurrentUser).toHaveBeenCalledWith(
         {
           activeDirectoryId: 'test-manager-fr-123',
           role: 'hiring-manager',

--- a/frontend/tests/.server/utils/hiring-manager-registration-utils.test.ts
+++ b/frontend/tests/.server/utils/hiring-manager-registration-utils.test.ts
@@ -25,9 +25,10 @@ vi.mock('~/.server/utils/route-utils', () => ({
 const mockUserService = {
   getUsersByRole: vi.fn(),
   getUserByActiveDirectoryId: vi.fn(),
-  registerUser: vi.fn(),
   updateUserRole: vi.fn(),
   getUserById: vi.fn(),
+  getCurrentUser: vi.fn(),
+  registerCurrentUser: vi.fn(),
 };
 
 vi.mocked(getUserService).mockReturnValue(mockUserService);

--- a/frontend/tests/.server/utils/privacy-consent-utils.test.ts
+++ b/frontend/tests/.server/utils/privacy-consent-utils.test.ts
@@ -84,8 +84,9 @@ const mockUserService = {
   getUsersByRole: vi.fn(),
   getUserById: vi.fn(),
   getUserByActiveDirectoryId: vi.fn(),
-  registerUser: vi.fn(),
   updateUserRole: vi.fn(),
+  getCurrentUser: vi.fn(),
+  registerCurrentUser: vi.fn(),
 };
 
 vi.mocked(getUserService).mockReturnValue(mockUserService);
@@ -165,7 +166,7 @@ describe('Privacy Consent Flow', () => {
       expect(response.headers.get('Location')).toBe('/en/employee');
 
       // Verify user was registered with privacy consent
-      expect(mockUserService.registerUser).toHaveBeenCalledWith(
+      expect(mockUserService.registerCurrentUser).toHaveBeenCalledWith(
         {
           activeDirectoryId: 'test-employee-123',
           role: 'employee',
@@ -188,7 +189,7 @@ describe('Privacy Consent Flow', () => {
       expect(response.headers.get('Location')).toBe('/en/');
 
       // Verify user was NOT registered
-      expect(mockUserService.registerUser).not.toHaveBeenCalled();
+      expect(mockUserService.registerCurrentUser).not.toHaveBeenCalled();
     });
 
     it('should redirect back to index for missing action', async () => {
@@ -203,7 +204,7 @@ describe('Privacy Consent Flow', () => {
       expect(response).toBeInstanceOf(Response);
       expect(response.status).toBe(302);
       expect(response.headers.get('Location')).toBe('/en/');
-      expect(mockUserService.registerUser).not.toHaveBeenCalled();
+      expect(mockUserService.registerCurrentUser).not.toHaveBeenCalled();
     });
 
     it('should handle missing employee name gracefully', async () => {
@@ -219,7 +220,7 @@ describe('Privacy Consent Flow', () => {
       expect(response.status).toBe(302);
 
       // Verify user was registered with fallback name
-      expect(mockUserService.registerUser).toHaveBeenCalledWith(
+      expect(mockUserService.registerCurrentUser).toHaveBeenCalledWith(
         {
           activeDirectoryId: 'test-employee-123',
           role: 'employee',
@@ -254,7 +255,7 @@ describe('Privacy Consent Flow', () => {
       expect(response.headers.get('Location')).toBe('/en/employee');
 
       // Verify user was not registered again since they already exist
-      expect(mockUserService.registerUser).not.toHaveBeenCalled();
+      expect(mockUserService.registerCurrentUser).not.toHaveBeenCalled();
       // The ensureUserProfile function would be called but we're not mocking profile services here
     });
 

--- a/frontend/tests/.server/utils/profile-access-utils.test.ts
+++ b/frontend/tests/.server/utils/profile-access-utils.test.ts
@@ -38,10 +38,11 @@ const mockProfileService = {
 };
 const mockUserService = {
   getUserByActiveDirectoryId: vi.fn(),
-  registerUser: vi.fn(),
   updateUserRole: vi.fn(),
   getUsersByRole: vi.fn(),
   getUserById: vi.fn(),
+  getCurrentUser: vi.fn(),
+  registerCurrentUser: vi.fn(),
 };
 const mockRequirePrivacyConsentForOwnProfile = vi.fn();
 const mockExtractUserIdFromProfileRoute = vi.fn();


### PR DESCRIPTION
## Summary

AB#6530

Adds method `getCurrentUser` which calls the `/api/user/me` backend endpoint to fetch the current user.  Updates the register method to match what the backend expects.  I haven't added the implementation in routes/tests since this PR kind of depends of #310, otherwise this PR would overlap and ballon with conflicting changes.

## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades