### PR TITLE
feature(frontend) add currentUser to session

### DIFF
--- a/frontend/app/@types/express-session.ts
+++ b/frontend/app/@types/express-session.ts
@@ -1,6 +1,7 @@
 import 'express-session';
 
 import type { AccessTokenClaims, IDTokenClaims } from '~/.server/auth/auth-strategies';
+import type { User } from '~/.server/domain/models';
 
 declare module 'express-session' {
   interface SessionData {
@@ -16,6 +17,7 @@ declare module 'express-session' {
       returnUrl?: URL;
       state: string;
     };
+    currentUser: User;
   }
 }
 

--- a/frontend/app/routes/index.tsx
+++ b/frontend/app/routes/index.tsx
@@ -1,13 +1,6 @@
-import type { RouteHandle } from 'react-router';
-
 import type { Route } from './+types/index';
 
 import { i18nRedirect } from '~/.server/utils/route-utils';
-import { handle as parentHandle } from '~/routes/layout';
-
-export const handle = {
-  i18nNamespace: [...parentHandle.i18nNamespace],
-} as const satisfies RouteHandle;
 
 export function loader({ context, request }: Route.LoaderArgs) {
   return i18nRedirect('routes/employee/index.tsx', request);


### PR DESCRIPTION
## Summary

[AB#6515](https://dev.azure.com/DTS-STN/4c33b941-c811-479f-b181-dfd5292182ff/_workitems/edit/6515)

Call `getCurrentUser` which is an api call to the backend to `/user/me`, this will either return the current user, or 404.  If a 404 is returned (an error will propagate in our frontend), we make a subsequent call to `registerCurrentUser` which is a call to `/users/me` with a `POST` request.  The returned user is then store in the session.
