### PR TITLE
feat(backend): Add SecurityUtils

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/security/SecurityUtils.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/security/SecurityUtils.java
@@ -1,0 +1,109 @@
+package ca.gov.dtsstn.vacman.api.security;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+/**
+ * Utility class for Spring Security.
+ * Provides a streamlined, static interface for common security operations.
+ */
+public final class SecurityUtils {
+
+	/**
+	 * The name of the claim within the JWT that holds the user's unique identifier.
+	 * In Azure AD, this is typically the "oid" (Object ID) claim.
+	 */
+	public static final String USER_ID_CLAIM = "oid";
+
+	private SecurityUtils() { }
+
+	/**
+	 * Get the current {@link Authentication} object from the security context.
+	 *
+	 * @return an {@link Optional} containing the current authentication, or empty if none is present.
+	 */
+	public static Optional<Authentication> getCurrentAuthentication() {
+		return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication());
+	}
+
+	/**
+	 * Get the Entra ID (Object ID) of the current user from the JWT claims.
+	 *
+	 * This method safely extracts the claim specified by {@link #USER_ID_CLAIM} ("oid").
+	 *
+	 * @return an {@link Optional} containing the user's Entra ID as a String if found, otherwise empty.
+	 */
+	public static Optional<String> getCurrentUserEntraId() {
+		return getCurrentAuthentication()
+			.filter(JwtAuthenticationToken.class::isInstance)
+			.map(JwtAuthenticationToken.class::cast)
+			.map(JwtAuthenticationToken::getToken)
+			.map(jwt -> jwt.getClaimAsString(USER_ID_CLAIM));
+	}
+
+	/**
+	 * Check if a user is currently authenticated.
+	 *
+	 * A user is considered authenticated if an authentication object exists in the
+	 * security context and its {@code isAuthenticated()} method returns true.
+	 *
+	 * @return {@code true} if the user is authenticated, {@code false} otherwise.
+	 */
+	public static boolean isAuthenticated() {
+		return getCurrentAuthentication()
+			.map(Authentication::isAuthenticated)
+			.orElse(false);
+	}
+
+	/**
+	 * Checks if the current user has any of the specified authorities.
+	 *
+	 * @param authorities the authorities to check.
+	 * @return {@code true} if the current user has at least one of the given authorities, {@code false} otherwise.
+	 */
+	public static boolean hasCurrentUserAnyOfAuthorities(String... authorities) {
+		var authoritiesToFind = new HashSet<>(Arrays.asList(authorities));
+		return getCurrentAuthentication()
+			.map(SecurityUtils::getAuthorities)
+			.map(authoritiesStream -> authoritiesStream.anyMatch(authoritiesToFind::contains))
+			.orElse(false);
+	}
+
+	/**
+	 * Checks if the current user has none of the specified authorities.
+	 *
+	 * @param authorities the authorities to check.
+	 * @return {@code true} if the current user has none of the given authorities, {@code false} otherwise.
+	 */
+	public static boolean hasCurrentUserNoneOfAuthorities(String... authorities) {
+		return !hasCurrentUserAnyOfAuthorities(authorities);
+	}
+
+	/**
+	 * Checks if the current user has a specific authority.
+	 *
+	 * @param authority the authority to check.
+	 * @return {@code true} if the current user has the authority, {@code false} otherwise.
+	 */
+	public static boolean hasCurrentUserThisAuthority(String authority) {
+		return hasCurrentUserAnyOfAuthorities(authority);
+	}
+
+	/**
+	 * Extracts the authority strings from an {@link Authentication} object.
+	 *
+	 * @param authentication the authentication object.
+	 * @return a {@link Stream} of authority strings.
+	 */
+	private static Stream<String> getAuthorities(Authentication authentication) {
+		return authentication.getAuthorities().stream()
+			.map(GrantedAuthority::getAuthority);
+	}
+}

--- a/backend/src/test/java/ca/gov/dtsstn/vacman/api/security/SecurityUtilsTest.java
+++ b/backend/src/test/java/ca/gov/dtsstn/vacman/api/security/SecurityUtilsTest.java
@@ -1,0 +1,140 @@
+package ca.gov.dtsstn.vacman.api.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+@DisplayName("SecurityUtils tests")
+class SecurityUtilsTest {
+
+	private SecurityContext securityContextMock;
+	private MockedStatic<SecurityContextHolder> securityContextHolderMock;
+
+	@BeforeEach
+	void setUp() {
+		securityContextMock = mock(SecurityContext.class);
+		securityContextHolderMock = Mockito.mockStatic(SecurityContextHolder.class);
+		securityContextHolderMock.when(SecurityContextHolder::getContext).thenReturn(securityContextMock);
+	}
+
+	@AfterEach
+	void tearDown() {
+		securityContextHolderMock.close();
+	}
+
+	@Test
+	void getCurrentAuthenticationReturnsEmptyWhenNoAuthentication() {
+		when(securityContextMock.getAuthentication()).thenReturn(null);
+		assertTrue(SecurityUtils.getCurrentAuthentication().isEmpty());
+	}
+
+	@Test
+	void getCurrentAuthenticationReturnsAuthenticationWhenPresent() {
+		Authentication authentication = mock(Authentication.class);
+		when(securityContextMock.getAuthentication()).thenReturn(authentication);
+		Optional<Authentication> result = SecurityUtils.getCurrentAuthentication();
+		assertTrue(result.isPresent());
+		assertEquals(authentication, result.get());
+	}
+
+	@Test
+	void getCurrentUserEntraIdReturnsEmptyWhenNotJwtAuthenticationToken() {
+		Authentication authentication = mock(Authentication.class);
+		when(securityContextMock.getAuthentication()).thenReturn(authentication);
+		assertTrue(SecurityUtils.getCurrentUserEntraId().isEmpty());
+	}
+
+	@Test
+	void getCurrentUserEntraIdReturnsOidWhenPresent() {
+		Jwt jwt = mock(Jwt.class);
+		when(jwt.getClaimAsString(SecurityUtils.USER_ID_CLAIM)).thenReturn("test-oid");
+		JwtAuthenticationToken jwtAuth = mock(JwtAuthenticationToken.class);
+		when(jwtAuth.getToken()).thenReturn(jwt);
+		when(securityContextMock.getAuthentication()).thenReturn(jwtAuth);
+
+		Optional<String> result = SecurityUtils.getCurrentUserEntraId();
+		assertTrue(result.isPresent());
+		assertEquals("test-oid", result.get());
+	}
+
+	@Test
+	void isAuthenticatedReturnsFalseWhenNoAuthentication() {
+		when(securityContextMock.getAuthentication()).thenReturn(null);
+		assertFalse(SecurityUtils.isAuthenticated());
+	}
+
+	@Test
+	void isAuthenticatedReturnsAuthenticationStatus() {
+		Authentication authentication = mock(Authentication.class);
+		when(authentication.isAuthenticated()).thenReturn(true);
+		when(securityContextMock.getAuthentication()).thenReturn(authentication);
+		assertTrue(SecurityUtils.isAuthenticated());
+
+		when(authentication.isAuthenticated()).thenReturn(false);
+		assertFalse(SecurityUtils.isAuthenticated());
+	}
+
+	@Test
+	void hasCurrentUserAnyOfAuthoritiesReturnsFalseWhenNoAuthentication() {
+		when(securityContextMock.getAuthentication()).thenReturn(null);
+		assertFalse(SecurityUtils.hasCurrentUserAnyOfAuthorities("ROLE_USER"));
+	}
+
+	@Test
+	void hasCurrentUserAnyOfAuthoritiesReturnsTrueIfAnyAuthorityMatches() {
+		Authentication authentication = mock(Authentication.class);
+		GrantedAuthority authority1 = () -> "ROLE_USER";
+		GrantedAuthority authority2 = () -> "ROLE_ADMIN";
+		Collection<GrantedAuthority> authorities = List.of(authority1, authority2);
+		doReturn(authorities).when(authentication).getAuthorities();
+		when(securityContextMock.getAuthentication()).thenReturn(authentication);
+
+		assertTrue(SecurityUtils.hasCurrentUserAnyOfAuthorities("ROLE_USER", "ROLE_OTHER"));
+		assertTrue(SecurityUtils.hasCurrentUserAnyOfAuthorities("ROLE_ADMIN"));
+		assertFalse(SecurityUtils.hasCurrentUserAnyOfAuthorities("ROLE_OTHER"));
+	}
+
+	@Test
+	void hasCurrentUserNoneOfAuthoritiesReturnsTrueIfNoAuthoritiesMatch() {
+		Authentication authentication = mock(Authentication.class);
+		GrantedAuthority authority = () -> "ROLE_USER";
+		Collection<GrantedAuthority> authorities = List.of(authority);
+		doReturn(authorities).when(authentication).getAuthorities();
+		when(securityContextMock.getAuthentication()).thenReturn(authentication);
+
+		assertTrue(SecurityUtils.hasCurrentUserNoneOfAuthorities("ROLE_ADMIN"));
+		assertFalse(SecurityUtils.hasCurrentUserNoneOfAuthorities("ROLE_USER"));
+	}
+
+	@Test
+	void hasCurrentUserThisAuthorityReturnsTrueIfAuthorityPresent() {
+		Authentication authentication = mock(Authentication.class);
+		GrantedAuthority authority = () -> "ROLE_USER";
+		Collection<GrantedAuthority> authorities = List.of(authority);
+		doReturn(authorities).when(authentication).getAuthorities();
+		when(securityContextMock.getAuthentication()).thenReturn(authentication);
+
+		assertTrue(SecurityUtils.hasCurrentUserThisAuthority("ROLE_USER"));
+		assertFalse(SecurityUtils.hasCurrentUserThisAuthority("ROLE_ADMIN"));
+	}
+}


### PR DESCRIPTION
## Summary

This pull request introduces `SecurityUtils`, a new utility class designed to centralize and simplify common Spring Security operations.

This class provides static methods to reliably access the `SecurityContext`, retrieve the current user's authentication details (including their Entra ID/OID), and check user authorities without duplicating code across the application.

## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)