### PR TITLE
chore(frontend) update getUsersByRole default impl

### DIFF
--- a/frontend/app/.server/domain/services/user-service-default.ts
+++ b/frontend/app/.server/domain/services/user-service-default.ts
@@ -14,7 +14,7 @@ export function getDefaultUserService(): UserService {
      * @returns A promise that resolves to the list of user objects.
      */
     async getUsersByRole(role: string): Promise<User[]> {
-      const response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}/users?role=${role}`);
+      const response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}/users?${role}=true`);
 
       if (!response.ok) {
         const errorMessage = `Failed to retrieve users with role ${role}. Server responded with status ${response.status}.`;


### PR DESCRIPTION
## Summary

[AB#6575](https://dev.azure.com/DTS-STN/4c33b941-c811-479f-b181-dfd5292182ff/_workitems/edit/6575)

The backend expects `/users?{role}=true`

Technically we're only handling `hr-advisors` for this iteration, so the route could just hardcode that, but in the spirit of making the least amount of changes, this does the job.

