### PR TITLE
feat(frontend): add getActiveProfile profile service method

### DIFF
--- a/frontend/app/.server/domain/services/profile-service-default.ts
+++ b/frontend/app/.server/domain/services/profile-service-default.ts
@@ -204,7 +204,7 @@ export function getDefaultProfileService(): ProfileService {
 
     async getActiveProfile(session: AuthenticatedSession): Promise<Profile[]> {
       let response: Response;
-      
+
       try {
         response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}/profiles/me?active=true`, {
           headers: {

--- a/frontend/app/.server/domain/services/profile-service-default.ts
+++ b/frontend/app/.server/domain/services/profile-service-default.ts
@@ -4,7 +4,6 @@ import type { Option, Result } from 'oxide.ts';
 import type { Profile } from '~/.server/domain/models';
 import type { ProfileService } from '~/.server/domain/services/profile-service';
 import { serverEnvironment } from '~/.server/environment';
-import type { AuthenticatedSession } from '~/.server/utils/auth-utils';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
 import type { HttpStatusCode } from '~/errors/http-status-codes';
@@ -60,11 +59,11 @@ export function getDefaultProfileService(): ProfileService {
 
     /**
      * Registers a new profile for a user.
-     * @param activeDirectoryId The Active Directory ID of the user to create a profile for.
+     * @param accessToken The access token of the user to create a profile for.
      * @returns A promise that resolves to the created profile object.
      * @throws AppError if the request fails or if the server responds with an error status.
      */
-    async registerProfile(activeDirectoryId: string): Promise<Profile> {
+    async registerProfile(accessToken: string): Promise<Profile> {
       let response: Response;
 
       try {
@@ -72,21 +71,19 @@ export function getDefaultProfileService(): ProfileService {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
+            'Authorization': `Bearer ${accessToken}`,
           },
-          body: JSON.stringify({ activeDirectoryId }),
         });
       } catch (error) {
         throw new AppError(
-          error instanceof Error
-            ? error.message
-            : `Network error while registering profile for Active Directory ID ${activeDirectoryId}`,
+          error instanceof Error ? error.message : `Network error while registering profile`,
           ErrorCodes.PROFILE_NETWORK_ERROR,
           { httpStatusCode: HttpStatusCodes.SERVICE_UNAVAILABLE },
         );
       }
 
       if (!response.ok) {
-        const errorMessage = `Failed to register profile for Active Directory ID ${activeDirectoryId}. Server responded with status ${response.status}.`;
+        const errorMessage = `Failed to register profile. Server responded with status ${response.status}.`;
         throw new AppError(errorMessage, ErrorCodes.PROFILE_CREATE_FAILED, {
           httpStatusCode: response.status as HttpStatusCode,
         });
@@ -95,11 +92,9 @@ export function getDefaultProfileService(): ProfileService {
       try {
         return await response.json();
       } catch {
-        throw new AppError(
-          `Invalid JSON response while registering profile for Active Directory ID ${activeDirectoryId}`,
-          ErrorCodes.PROFILE_INVALID_RESPONSE,
-          { httpStatusCode: HttpStatusCodes.BAD_GATEWAY },
-        );
+        throw new AppError(`Invalid JSON response while registering profile`, ErrorCodes.PROFILE_INVALID_RESPONSE, {
+          httpStatusCode: HttpStatusCodes.BAD_GATEWAY,
+        });
       }
     },
 
@@ -202,13 +197,13 @@ export function getDefaultProfileService(): ProfileService {
       }
     },
 
-    async getCurrentUserProfile(session: AuthenticatedSession): Promise<Option<Profile>> {
+    async getCurrentUserProfile(accessToken: string): Promise<Option<Profile>> {
       let response: Response;
 
       try {
         response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}/profiles/me?active=true`, {
           headers: {
-            Authorization: `Bearer ${session.authState.accessToken}`,
+            Authorization: `Bearer ${accessToken}`,
           },
         });
       } catch (error) {

--- a/frontend/app/.server/domain/services/profile-service-mock.ts
+++ b/frontend/app/.server/domain/services/profile-service-mock.ts
@@ -3,6 +3,7 @@ import type { Result } from 'oxide.ts';
 
 import type { Profile } from '~/.server/domain/models';
 import type { ProfileService } from '~/.server/domain/services/profile-service';
+import type { AuthenticatedSession } from '~/.server/utils/auth-utils';
 import { PROFILE_STATUS_ID } from '~/domain/constants';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
@@ -61,6 +62,15 @@ export function getMockProfileService(): ProfileService {
     },
     getAllProfiles: () => {
       return Promise.resolve(mockProfiles);
+    },
+    getActiveProfile: (session: AuthenticatedSession) => {
+      // In mock service, return profiles that are incomplete, pending, or approved
+      const activeProfiles = mockProfiles.filter(profile => 
+        profile.profileStatusId === PROFILE_STATUS_ID.incomplete ||
+        profile.profileStatusId === PROFILE_STATUS_ID.pending ||
+        profile.profileStatusId === PROFILE_STATUS_ID.approved
+      );
+      return Promise.resolve(activeProfiles);
     },
   };
 }

--- a/frontend/app/.server/domain/services/profile-service-mock.ts
+++ b/frontend/app/.server/domain/services/profile-service-mock.ts
@@ -65,10 +65,11 @@ export function getMockProfileService(): ProfileService {
     },
     getActiveProfile: (session: AuthenticatedSession) => {
       // In mock service, return profiles that are incomplete, pending, or approved
-      const activeProfiles = mockProfiles.filter(profile => 
-        profile.profileStatusId === PROFILE_STATUS_ID.incomplete ||
-        profile.profileStatusId === PROFILE_STATUS_ID.pending ||
-        profile.profileStatusId === PROFILE_STATUS_ID.approved
+      const activeProfiles = mockProfiles.filter(
+        (profile) =>
+          profile.profileStatusId === PROFILE_STATUS_ID.incomplete ||
+          profile.profileStatusId === PROFILE_STATUS_ID.pending ||
+          profile.profileStatusId === PROFILE_STATUS_ID.approved,
       );
       return Promise.resolve(activeProfiles);
     },

--- a/frontend/app/.server/domain/services/profile-service-mock.ts
+++ b/frontend/app/.server/domain/services/profile-service-mock.ts
@@ -789,8 +789,6 @@ function registerProfile(activeDirectoryId: string): Profile {
     activeDirectoryToUserIdMap[activeDirectoryId] = userId;
   }
 
-  console.log(activeDirectoryToUserIdMap);
-
   // Create new profile
   const newProfile: Profile = {
     profileId: mockProfiles.length + 1,

--- a/frontend/app/.server/domain/services/profile-service-mock.ts
+++ b/frontend/app/.server/domain/services/profile-service-mock.ts
@@ -63,24 +63,25 @@ export function getMockProfileService(): ProfileService {
     getAllProfiles: () => {
       return Promise.resolve(mockProfiles);
     },
-    getActiveProfile: (session: AuthenticatedSession) => {
+    getCurrentUserProfile: (session: AuthenticatedSession) => {
       const activeDirectoryId = session.authState.idTokenClaims.oid as string;
       const userId = activeDirectoryToUserIdMap[activeDirectoryId];
 
-      // If user not found, return empty array
+      // If user not found, return None
       if (!userId) {
-        return Promise.resolve([]);
+        return Promise.resolve(None);
       }
 
-      // Filter for active profiles that belong to the current user
-      const activeProfiles = mockProfiles.filter(
+      // Find the first active profile that belongs to the current user
+      const activeProfile = mockProfiles.find(
         (profile) =>
           profile.userId === userId &&
           (profile.profileStatusId === PROFILE_STATUS_ID.incomplete ||
             profile.profileStatusId === PROFILE_STATUS_ID.pending ||
             profile.profileStatusId === PROFILE_STATUS_ID.approved),
       );
-      return Promise.resolve(activeProfiles);
+
+      return Promise.resolve(activeProfile ? Some(activeProfile) : None);
     },
   };
 }

--- a/frontend/app/.server/domain/services/profile-service.ts
+++ b/frontend/app/.server/domain/services/profile-service.ts
@@ -13,7 +13,7 @@ export type ProfileService = {
   updateProfile(accessToken: string, profileId: string, userUpdated: string, data: Profile): Promise<Result<void, AppError>>;
   submitProfileForReview(activeDirectoryId: string): Promise<Result<Profile, AppError>>;
   getAllProfiles(): Promise<Profile[]>;
-  getActiveProfile(session: AuthenticatedSession): Promise<Profile[]>;
+  getCurrentUserProfile(session: AuthenticatedSession): Promise<Option<Profile>>;
 };
 
 export function getProfileService(): ProfileService {

--- a/frontend/app/.server/domain/services/profile-service.ts
+++ b/frontend/app/.server/domain/services/profile-service.ts
@@ -4,6 +4,7 @@ import type { Profile } from '~/.server/domain/models';
 import { getDefaultProfileService } from '~/.server/domain/services/profile-service-default';
 import { getMockProfileService } from '~/.server/domain/services/profile-service-mock';
 import { serverEnvironment } from '~/.server/environment';
+import type { AuthenticatedSession } from '~/.server/utils/auth-utils';
 import type { AppError } from '~/errors/app-error';
 
 export type ProfileService = {
@@ -12,6 +13,7 @@ export type ProfileService = {
   updateProfile(accessToken: string, profileId: string, userUpdated: string, data: Profile): Promise<Result<void, AppError>>;
   submitProfileForReview(activeDirectoryId: string): Promise<Result<Profile, AppError>>;
   getAllProfiles(): Promise<Profile[]>;
+  getActiveProfile(session: AuthenticatedSession): Promise<Profile[]>;
 };
 
 export function getProfileService(): ProfileService {

--- a/frontend/app/.server/domain/services/profile-service.ts
+++ b/frontend/app/.server/domain/services/profile-service.ts
@@ -4,16 +4,20 @@ import type { Profile } from '~/.server/domain/models';
 import { getDefaultProfileService } from '~/.server/domain/services/profile-service-default';
 import { getMockProfileService } from '~/.server/domain/services/profile-service-mock';
 import { serverEnvironment } from '~/.server/environment';
-import type { AuthenticatedSession } from '~/.server/utils/auth-utils';
 import type { AppError } from '~/errors/app-error';
 
 export type ProfileService = {
   getProfile(activeDirectoryId: string): Promise<Option<Profile>>;
-  registerProfile(activeDirectoryId: string): Promise<Profile>;
-  updateProfile(accessToken: string, profileId: string, userUpdated: string, data: Profile): Promise<Result<void, AppError>>;
+  registerProfile(accessToken: string): Promise<Profile>;
+  updateProfile(
+    accessToken: string,
+    profileId: string,
+    userUpdated: string,
+    data: ProfileFormData,
+  ): Promise<Result<void, AppError>>;
   submitProfileForReview(activeDirectoryId: string): Promise<Result<Profile, AppError>>;
   getAllProfiles(): Promise<Profile[]>;
-  getCurrentUserProfile(session: AuthenticatedSession): Promise<Option<Profile>>;
+  getCurrentUserProfile(accessToken: string): Promise<Option<Profile>>;
 };
 
 export function getProfileService(): ProfileService {

--- a/frontend/app/.server/domain/services/profile-service.ts
+++ b/frontend/app/.server/domain/services/profile-service.ts
@@ -9,12 +9,7 @@ import type { AppError } from '~/errors/app-error';
 export type ProfileService = {
   getProfile(activeDirectoryId: string): Promise<Option<Profile>>;
   registerProfile(accessToken: string): Promise<Profile>;
-  updateProfile(
-    accessToken: string,
-    profileId: string,
-    userUpdated: string,
-    data: ProfileFormData,
-  ): Promise<Result<void, AppError>>;
+  updateProfile(accessToken: string, profileId: string, userUpdated: string, data: Profile): Promise<Result<void, AppError>>;
   submitProfileForReview(activeDirectoryId: string): Promise<Result<Profile, AppError>>;
   getAllProfiles(): Promise<Profile[]>;
   getCurrentUserProfile(accessToken: string): Promise<Option<Profile>>;

--- a/frontend/tests/.server/domain/services/profile-service-default.test.ts
+++ b/frontend/tests/.server/domain/services/profile-service-default.test.ts
@@ -138,8 +138,8 @@ describe('profile-service-default', () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'Authorization': `Bearer ${mockActiveDirectoryId}`,
         },
-        body: JSON.stringify({ activeDirectoryId: mockActiveDirectoryId }),
       });
     });
 
@@ -169,7 +169,7 @@ describe('profile-service-default', () => {
       await expect(profileService.registerProfile(mockActiveDirectoryId)).rejects.toThrow('Network error');
     });
 
-    it('should send correct request body with activeDirectoryId', async () => {
+    it('should send correct request headers with authorization', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: HttpStatusCodes.CREATED,
@@ -178,11 +178,14 @@ describe('profile-service-default', () => {
 
       await profileService.registerProfile(mockActiveDirectoryId);
 
-      const expectedBody = JSON.stringify({ activeDirectoryId: mockActiveDirectoryId });
       expect(mockFetch).toHaveBeenCalledWith(
         `${serverEnvironment.VACMAN_API_BASE_URI}/profiles`,
         expect.objectContaining({
-          body: expectedBody,
+          headers: expect.objectContaining({
+            'Authorization': `Bearer ${mockActiveDirectoryId}`,
+            'Content-Type': 'application/json',
+          }),
+          method: 'POST',
         }),
       );
     });

--- a/frontend/tests/.server/routes/index.test.ts
+++ b/frontend/tests/.server/routes/index.test.ts
@@ -71,6 +71,7 @@ const mockProfileService = {
   updateProfile: vi.fn(),
   submitProfileForReview: vi.fn(),
   getAllProfiles: vi.fn(),
+  getActiveProfile: vi.fn(),
 };
 
 vi.mocked(getProfileService).mockReturnValue(mockProfileService);

--- a/frontend/tests/.server/routes/index.test.ts
+++ b/frontend/tests/.server/routes/index.test.ts
@@ -71,7 +71,7 @@ const mockProfileService = {
   updateProfile: vi.fn(),
   submitProfileForReview: vi.fn(),
   getAllProfiles: vi.fn(),
-  getActiveProfile: vi.fn(),
+  getCurrentUserProfile: vi.fn(),
 };
 
 vi.mocked(getProfileService).mockReturnValue(mockProfileService);

--- a/frontend/tests/.server/utils/privacy-consent-utils.test.ts
+++ b/frontend/tests/.server/utils/privacy-consent-utils.test.ts
@@ -96,7 +96,7 @@ const mockProfileService = {
   updateProfile: vi.fn(),
   submitProfileForReview: vi.fn(),
   getAllProfiles: vi.fn(),
-  getActiveProfile: vi.fn(),
+  getCurrentUserProfile: vi.fn(),
 };
 
 vi.mocked(getProfileService).mockReturnValue(mockProfileService);

--- a/frontend/tests/.server/utils/privacy-consent-utils.test.ts
+++ b/frontend/tests/.server/utils/privacy-consent-utils.test.ts
@@ -96,6 +96,7 @@ const mockProfileService = {
   updateProfile: vi.fn(),
   submitProfileForReview: vi.fn(),
   getAllProfiles: vi.fn(),
+  getActiveProfile: vi.fn(),
 };
 
 vi.mocked(getProfileService).mockReturnValue(mockProfileService);

--- a/frontend/tests/.server/utils/profile-access-utils.test.ts
+++ b/frontend/tests/.server/utils/profile-access-utils.test.ts
@@ -33,7 +33,7 @@ const mockProfileService = {
   updateProfile: vi.fn(),
   submitProfileForReview: vi.fn(),
   getAllProfiles: vi.fn(),
-  getActiveProfile: vi.fn(),
+  getCurrentUserProfile: vi.fn(),
 };
 const mockUserService = {
   getUserByActiveDirectoryId: vi.fn(),

--- a/frontend/tests/.server/utils/profile-access-utils.test.ts
+++ b/frontend/tests/.server/utils/profile-access-utils.test.ts
@@ -33,6 +33,7 @@ const mockProfileService = {
   updateProfile: vi.fn(),
   submitProfileForReview: vi.fn(),
   getAllProfiles: vi.fn(),
+  getActiveProfile: vi.fn(),
 };
 const mockUserService = {
   getUserByActiveDirectoryId: vi.fn(),

--- a/frontend/tests/.server/utils/profile-utils.test.ts
+++ b/frontend/tests/.server/utils/profile-utils.test.ts
@@ -25,6 +25,7 @@ const mockProfileService = {
   updateProfile: vi.fn(),
   submitProfileForReview: vi.fn(),
   getAllProfiles: vi.fn(),
+  getActiveProfile: vi.fn(),
 };
 
 vi.mocked(getProfileService).mockReturnValue(mockProfileService);

--- a/frontend/tests/.server/utils/profile-utils.test.ts
+++ b/frontend/tests/.server/utils/profile-utils.test.ts
@@ -25,7 +25,7 @@ const mockProfileService = {
   updateProfile: vi.fn(),
   submitProfileForReview: vi.fn(),
   getAllProfiles: vi.fn(),
-  getActiveProfile: vi.fn(),
+  getCurrentUserProfile: vi.fn(),
 };
 
 vi.mocked(getProfileService).mockReturnValue(mockProfileService);


### PR DESCRIPTION
This pull request adds support for retrieving the current user's profile to the `ProfileService` interface and its implementations. It introduces a new `getCurrentUserProfile` method, which is implemented for both the default and mock profile services. The change also updates related types and test mocks to ensure consistency and testability.

**Profile service enhancements:**

* Added the `getCurrentUserProfile(session: AuthenticatedSession): Promise<Option<Profile>>` method to the `ProfileService` type definition in `profile-service.ts`, allowing retrieval of the currently authenticated user's profile.
* Implemented `getCurrentUserProfile` in `profile-service-default.ts` to fetch the current user's profile from the backend API, including error handling for network issues, not found responses, and invalid JSON.
* Implemented `getCurrentUserProfile` in `profile-service-mock.ts` to return a mock profile for the authenticated user, or `None` if not found.

**Type and import updates:**

* Updated imports in relevant files to include `AuthenticatedSession` for type safety in the new method. [[1]](diffhunk://#diff-ea09278ac6f5784b74517dddd26c9057c808849c0b0ebebc2aa4de2eddc066b1R12) [[2]](diffhunk://#diff-35798cb8db5aba72a6e498702d258c7f1b85e877d6f9d85eaa8ba6547c34c118R11) [[3]](diffhunk://#diff-8214cacd4e8f4fa2ed434421e15da15239fe1f7026185bb3bccee7ed221d43efR12)

**Testing improvements:**

* Updated all relevant test mocks to include the new `getCurrentUserProfile` method, ensuring tests can stub or spy on this functionality. [[1]](diffhunk://#diff-424084261ba43e1f60c8c6664606381c6e88b99d8de79b78c073842b23b9a779R76) [[2]](diffhunk://#diff-8b30a6cfafd744c05f14162499a1c09e0b412297f5ac72bccf82a764b72f6874R102) [[3]](diffhunk://#diff-c4cf6d0eff71e46547ed3729497ba8846070a63578fbcfe64594006d44ca64f8R38) [[4]](diffhunk://#diff-9123f59af997320e8b1df924ce6758776bcb91c48aaf219fcab9209a69463a98R30)