### PR TITLE
refactor(frontend) add updateProfile service method

### DIFF
--- a/frontend/app/.server/domain/models.ts
+++ b/frontend/app/.server/domain/models.ts
@@ -162,3 +162,8 @@ export type UserReferralPreferences = {
   interestedInAlternationInd?: boolean;
   employmentTenureIds?: number[];
 };
+
+export type ProfileFormData =
+  | { personalInformation: UserPersonalInformation }
+  | { employmentInformation: UserEmploymentInformation }
+  | { referralPreferences: UserReferralPreferences };

--- a/frontend/app/.server/domain/services/profile-service.ts
+++ b/frontend/app/.server/domain/services/profile-service.ts
@@ -1,25 +1,16 @@
 import type { Option, Result } from 'oxide.ts';
 
-import type {
-  Profile,
-  UserEmploymentInformation,
-  UserPersonalInformation,
-  UserReferralPreferences,
-} from '~/.server/domain/models';
+import type { Profile, ProfileFormData } from '~/.server/domain/models';
 import { getDefaultProfileService } from '~/.server/domain/services/profile-service-default';
 import { getMockProfileService } from '~/.server/domain/services/profile-service-mock';
 import { serverEnvironment } from '~/.server/environment';
+import type { AuthenticatedSession } from '~/.server/utils/auth-utils';
 import type { AppError } from '~/errors/app-error';
 
 export type ProfileService = {
   getProfile(activeDirectoryId: string): Promise<Option<Profile>>;
   registerProfile(activeDirectoryId: string): Promise<Profile>;
-  updatePersonalInformation(activeDirectoryId: string, personalInfo: UserPersonalInformation): Promise<Result<void, AppError>>;
-  updateEmploymentInformation(
-    activeDirectoryId: string,
-    employmentInfo: UserEmploymentInformation,
-  ): Promise<Result<void, AppError>>;
-  updateReferralPreferences(activeDirectoryId: string, referralPrefs: UserReferralPreferences): Promise<Result<void, AppError>>;
+  updateProfile(session: AuthenticatedSession, profileId: string, data: ProfileFormData): Promise<Result<void, AppError>>;
   submitProfileForReview(activeDirectoryId: string): Promise<Result<Profile, AppError>>;
   getAllProfiles(): Promise<Profile[]>;
 };

--- a/frontend/app/routes/employee/profile/employment-information.tsx
+++ b/frontend/app/routes/employee/profile/employment-information.tsx
@@ -16,7 +16,7 @@ import { getProvinceService } from '~/.server/domain/services/province-service';
 import { getUserService } from '~/.server/domain/services/user-service';
 import { getWFAStatuses } from '~/.server/domain/services/wfa-status-service';
 import type { AuthenticatedSession } from '~/.server/utils/auth-utils';
-import { hasEmploymentDataChanged } from '~/.server/utils/profile-utils';
+import { hasEmploymentDataChanged, omitObjectProperties } from '~/.server/utils/profile-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { InlineLink } from '~/components/links';
 import { PROFILE_STATUS_ID } from '~/domain/constants';
@@ -50,7 +50,16 @@ export async function action({ context, params, request }: Route.ActionArgs) {
   const profileService = getProfileService();
   const currentProfileOption = await profileService.getProfile(currentUserId);
   const currentProfile = currentProfileOption.unwrap();
-  const updateResult = await profileService.updateEmploymentInformation(currentUserId, parseResult.output);
+  const updateResult = await profileService.updateProfile(authenticatedSession, currentProfile.profileId.toString(), {
+    employmentInformation: omitObjectProperties(parseResult.output, [
+      'wfaEffectiveDateYear',
+      'wfaEffectiveDateMonth',
+      'wfaEffectiveDateDay',
+      'wfaEndDateYear',
+      'wfaEndDateMonth',
+      'wfaEndDateDay',
+    ]),
+  });
   if (updateResult.isErr()) {
     throw updateResult.unwrapErr();
   }

--- a/frontend/app/routes/employee/profile/personal-information.tsx
+++ b/frontend/app/routes/employee/profile/personal-information.tsx
@@ -53,7 +53,12 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     );
   }
 
-  const updateResult = await getProfileService().updatePersonalInformation(currentUserId, parseResult.output);
+  const profileService = getProfileService();
+  const currentProfileOption = await profileService.getProfile(currentUserId);
+  const currentProfile = currentProfileOption.unwrap();
+  const updateResult = await profileService.updateProfile(authenticatedSession, currentProfile.profileId.toString(), {
+    personalInformation: parseResult.output,
+  });
 
   if (updateResult.isErr()) {
     throw updateResult.unwrapErr();

--- a/frontend/app/routes/employee/profile/referral-preferences.tsx
+++ b/frontend/app/routes/employee/profile/referral-preferences.tsx
@@ -58,7 +58,12 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     );
   }
 
-  const updateResult = await getProfileService().updateReferralPreferences(currentUserId, parseResult.output);
+  const profileService = getProfileService();
+  const currentProfileOption = await profileService.getProfile(currentUserId);
+  const currentProfile = currentProfileOption.unwrap();
+  const updateResult = await profileService.updateProfile(authenticatedSession, currentProfile.profileId.toString(), {
+    referralPreferences: parseResult.output,
+  });
 
   if (updateResult.isErr()) {
     throw updateResult.unwrapErr();

--- a/frontend/tests/.server/routes/index.test.ts
+++ b/frontend/tests/.server/routes/index.test.ts
@@ -68,9 +68,7 @@ vi.mocked(getUserService).mockReturnValue(mockUserService);
 const mockProfileService = {
   getProfile: vi.fn(),
   registerProfile: vi.fn(),
-  updatePersonalInformation: vi.fn(),
-  updateEmploymentInformation: vi.fn(),
-  updateReferralPreferences: vi.fn(),
+  updateProfile: vi.fn(),
   submitProfileForReview: vi.fn(),
   getAllProfiles: vi.fn(),
 };

--- a/frontend/tests/.server/utils/privacy-consent-utils.test.ts
+++ b/frontend/tests/.server/utils/privacy-consent-utils.test.ts
@@ -93,9 +93,7 @@ vi.mocked(getUserService).mockReturnValue(mockUserService);
 const mockProfileService = {
   getProfile: vi.fn(),
   registerProfile: vi.fn(),
-  updatePersonalInformation: vi.fn(),
-  updateEmploymentInformation: vi.fn(),
-  updateReferralPreferences: vi.fn(),
+  updateProfile: vi.fn(),
   submitProfileForReview: vi.fn(),
   getAllProfiles: vi.fn(),
 };

--- a/frontend/tests/.server/utils/profile-access-utils.test.ts
+++ b/frontend/tests/.server/utils/profile-access-utils.test.ts
@@ -30,9 +30,7 @@ vi.mock('~/.server/utils/route-matching-utils');
 const mockProfileService = {
   getProfile: vi.fn(),
   registerProfile: vi.fn(),
-  updatePersonalInformation: vi.fn(),
-  updateEmploymentInformation: vi.fn(),
-  updateReferralPreferences: vi.fn(),
+  updateProfile: vi.fn(),
   submitProfileForReview: vi.fn(),
   getAllProfiles: vi.fn(),
 };

--- a/frontend/tests/.server/utils/profile-utils.test.ts
+++ b/frontend/tests/.server/utils/profile-utils.test.ts
@@ -22,9 +22,7 @@ vi.mock('~/.server/domain/services/profile-service');
 const mockProfileService = {
   getProfile: vi.fn(),
   registerProfile: vi.fn(),
-  updatePersonalInformation: vi.fn(),
-  updateEmploymentInformation: vi.fn(),
-  updateReferralPreferences: vi.fn(),
+  updateProfile: vi.fn(),
   submitProfileForReview: vi.fn(),
   getAllProfiles: vi.fn(),
 };


### PR DESCRIPTION
## Summary

AB#6571

- Adds a single `updateProfile` to the profile-service to
- removes the 3 `update*` methods that were tied to the profile question pages
