### PR TITLE
fix(frontend) make updateProfile accept the entire profile not partial data

### DIFF
--- a/frontend/app/.server/domain/models.ts
+++ b/frontend/app/.server/domain/models.ts
@@ -162,8 +162,3 @@ export type UserReferralPreferences = {
   interestedInAlternationInd?: boolean;
   employmentTenureIds?: number[];
 };
-
-export type ProfileFormData =
-  | { personalInformation: UserPersonalInformation }
-  | { employmentInformation: UserEmploymentInformation }
-  | { referralPreferences: UserReferralPreferences };

--- a/frontend/app/.server/domain/services/profile-service-default.ts
+++ b/frontend/app/.server/domain/services/profile-service-default.ts
@@ -1,7 +1,7 @@
 import { Err, None, Ok, Some } from 'oxide.ts';
 import type { Option, Result } from 'oxide.ts';
 
-import type { Profile, ProfileFormData } from '~/.server/domain/models';
+import type { Profile } from '~/.server/domain/models';
 import type { ProfileService } from '~/.server/domain/services/profile-service';
 import { serverEnvironment } from '~/.server/environment';
 import { AppError } from '~/errors/app-error';
@@ -106,13 +106,14 @@ export function getDefaultProfileService(): ProfileService {
       accessToken: string,
       profileId: string,
       userUpdated: string,
-      data: ProfileFormData,
+      data: Profile,
     ): Promise<Result<void, AppError>> {
       try {
         const response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}/profiles/${profileId}`, {
           method: 'PUT',
           headers: {
-            Authorization: `Bearer ${accessToken}`,
+            'Authorization': `Bearer ${accessToken}`,
+            'Content-Type': 'application/json',
           },
           body: JSON.stringify(data),
         });

--- a/frontend/app/.server/domain/services/profile-service-mock.ts
+++ b/frontend/app/.server/domain/services/profile-service-mock.ts
@@ -1,7 +1,7 @@
 import { None, Some, Err, Ok } from 'oxide.ts';
 import type { Result } from 'oxide.ts';
 
-import type { Profile, ProfileFormData } from '~/.server/domain/models';
+import type { Profile } from '~/.server/domain/models';
 import type { ProfileService } from '~/.server/domain/services/profile-service';
 import { PROFILE_STATUS_ID } from '~/domain/constants';
 import { AppError } from '~/errors/app-error';
@@ -20,7 +20,7 @@ export function getMockProfileService(): ProfileService {
       accessToken: string,
       profileId: string,
       userUpdated: string,
-      data: ProfileFormData,
+      data: Profile,
     ): Promise<Result<void, AppError>> => {
       if (!mockProfiles.find((p) => p.profileId.toString() === profileId)) {
         return Promise.resolve(Err(new AppError('Profile not found', ErrorCodes.PROFILE_NOT_FOUND)));

--- a/frontend/app/.server/domain/services/profile-service.ts
+++ b/frontend/app/.server/domain/services/profile-service.ts
@@ -1,6 +1,6 @@
 import type { Option, Result } from 'oxide.ts';
 
-import type { Profile, ProfileFormData } from '~/.server/domain/models';
+import type { Profile } from '~/.server/domain/models';
 import { getDefaultProfileService } from '~/.server/domain/services/profile-service-default';
 import { getMockProfileService } from '~/.server/domain/services/profile-service-mock';
 import { serverEnvironment } from '~/.server/environment';
@@ -9,12 +9,7 @@ import type { AppError } from '~/errors/app-error';
 export type ProfileService = {
   getProfile(activeDirectoryId: string): Promise<Option<Profile>>;
   registerProfile(activeDirectoryId: string): Promise<Profile>;
-  updateProfile(
-    accessToken: string,
-    profileId: string,
-    userUpdated: string,
-    data: ProfileFormData,
-  ): Promise<Result<void, AppError>>;
+  updateProfile(accessToken: string, profileId: string, userUpdated: string, data: Profile): Promise<Result<void, AppError>>;
   submitProfileForReview(activeDirectoryId: string): Promise<Result<Profile, AppError>>;
   getAllProfiles(): Promise<Profile[]>;
 };

--- a/frontend/app/routes/employee/profile/employment-information.tsx
+++ b/frontend/app/routes/employee/profile/employment-information.tsx
@@ -58,6 +58,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     currentProfile.profileId.toString(),
     currentUserId,
     {
+      ...currentProfile,
       employmentInformation: omitObjectProperties(parseResult.output, [
         'wfaEffectiveDateYear',
         'wfaEffectiveDateMonth',

--- a/frontend/app/routes/employee/profile/personal-information.tsx
+++ b/frontend/app/routes/employee/profile/personal-information.tsx
@@ -64,6 +64,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     currentProfile.profileId.toString(),
     currentUserId,
     {
+      ...currentProfile,
       personalInformation: parseResult.output,
     },
   );

--- a/frontend/app/routes/employee/profile/referral-preferences.tsx
+++ b/frontend/app/routes/employee/profile/referral-preferences.tsx
@@ -69,6 +69,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     currentProfile.profileId.toString(),
     currentUserId,
     {
+      ...currentProfile,
       referralPreferences: parseResult.output,
     },
   );


### PR DESCRIPTION
## Summary
[AB#6571](https://dev.azure.com/DTS-STN/4c33b941-c811-479f-b181-dfd5292182ff/_workitems/edit/6571)

update to #344.  The `updateProfile` method should send the entire profile instead of partial data

