### PR TITLE
refactor(frontend): update api client

### DIFF
--- a/frontend/app/.server/domain/services/api-client.ts
+++ b/frontend/app/.server/domain/services/api-client.ts
@@ -62,7 +62,12 @@ async function baseFetch(
 
 export const apiClient = {
   /**
-   * Fetches data and parses it as JSON. The response is the only generic type.
+   * Fetches data from a given path and parses it as JSON.
+   * @template TResponseData The expected type of the data in the successful response.
+   * @param {string} path The API endpoint path.
+   * @param {string} context A descriptive string for the action, used in error messages.
+   * @param {string} [token] An optional access token for authorization.
+   * @returns {Promise<Result<TResponseData, AppError>>} A Promise resolving to a Result containing the typed response data or an AppError.
    */
   async get<TResponseData>(path: string, context: string, token?: string): Promise<Result<TResponseData, AppError>> {
     const responseResult = await baseFetch(path, context, 'GET', token);
@@ -85,13 +90,20 @@ export const apiClient = {
   },
 
   /**
-   * Sends data via POST. Uses separate types for the request body and the expected response.
+   * Sends data to a given path using the POST method.
+   * @template TRequestData The type of the data being sent in the request body.
+   * @template TResponseData The expected type of the data in the successful response.
+   * @param {string} path The API endpoint path.
+   * @param {string} context A descriptive string for the action, used in error messages.
+   * @param {string} [token] An optional access token for authorization.
+   * @param {TRequestData} [model] The data to be sent in the request body.
+   * @returns {Promise<Result<TResponseData, AppError>>} A Promise resolving to a Result containing the typed response data or an AppError.
    */
   async post<TRequestData, TResponseData = unknown>(
     path: string,
     context: string,
+    data: TRequestData,
     token?: string,
-    data?: TRequestData,
   ): Promise<Result<TResponseData, AppError>> {
     const responseResult = await baseFetch(path, context, 'POST', token, JSON.stringify(data));
     if (responseResult.isErr()) {
@@ -113,13 +125,20 @@ export const apiClient = {
   },
 
   /**
-   * Sends data via PUT. Uses separate types for the request body and the expected response.
+   * Updates data at a given path using the PUT method.
+   * @template TRequestData The type of the data being sent in the request body.
+   * @template TResponseData The expected type of the data in the successful response.
+   * @param {string} path The API endpoint path.
+   * @param {string} context A descriptive string for the action, used in error messages.
+   * @param {string} [token] An optional access token for authorization.
+   * @param {TRequestData} [model] The data to be sent in the request body.
+   * @returns {Promise<Result<TResponseData, AppError>>} A Promise resolving to a Result containing the typed response data or an AppError.
    */
   async put<TRequestData, TResponseData = unknown>(
     path: string,
     context: string,
+    data: TRequestData,
     token?: string,
-    data?: TRequestData,
   ): Promise<Result<TResponseData, AppError>> {
     const responseResult = await baseFetch(path, context, 'PUT', token, JSON.stringify(data));
     if (responseResult.isErr()) {
@@ -141,13 +160,20 @@ export const apiClient = {
   },
 
   /**
-   * Sends a DELETE request. Allows for an optional request body and an expected response type.
+   * Deletes a resource at a given path.
+   * @template TRequestData The type of the data being sent in the optional request body.
+   * @template TResponseData The expected type of the data in the successful response. Can be `null` for empty responses.
+   * @param {string} path The API endpoint path.
+   * @param {string} context A descriptive string for the action, used in error messages.
+   * @param {string} [token] An optional access token for authorization.
+   * @param {TRequestData} [model] An optional request body to send with the DELETE request.
+   * @returns {Promise<Result<TResponseData, AppError>>} A Promise resolving to a Result containing the typed response data or an AppError.
    */
   async delete<TRequestData, TResponseData = unknown>(
     path: string,
     context: string,
-    token?: string,
     data?: TRequestData,
+    token?: string,
   ): Promise<Result<TResponseData, AppError>> {
     const jsonBody = data ? JSON.stringify(data) : undefined;
     const responseResult = await baseFetch(path, context, 'DELETE', token, jsonBody);

--- a/frontend/app/.server/domain/services/api-client.ts
+++ b/frontend/app/.server/domain/services/api-client.ts
@@ -15,20 +15,30 @@ import type { HttpStatusCode } from '~/errors/http-status-codes';
  * @returns A Promise that resolves to Result containing the raw Response object or an AppError non-successful HTTP responses (e.g., 500, 401).
  * @throws {AppError} for network failures or DNS errors etc.
  */
-async function baseFetch(path: string, context: string): Promise<Result<Response, AppError>> {
+async function baseFetch(
+  path: string,
+  context: string,
+  method: string,
+  token?: string,
+  jsonBody?: string,
+): Promise<Result<Response, AppError>> {
   try {
-    // Sanitize the paths to prevent double slashes.
     const cleanBase = serverEnvironment.VACMAN_API_BASE_URI.endsWith('/')
       ? serverEnvironment.VACMAN_API_BASE_URI.slice(0, -1)
       : serverEnvironment.VACMAN_API_BASE_URI;
 
     const cleanPath = path.startsWith('/') ? path.slice(1) : path;
-
     const finalUrl = `${cleanBase}/${cleanPath}`;
 
-    const response = await fetch(finalUrl);
+    const response = await fetch(finalUrl, {
+      method: method,
+      headers: {
+        'Authorization': token ? `Bearer ${token}` : '',
+        'Content-Type': 'application/json',
+      },
+      body: jsonBody ?? undefined,
+    });
 
-    // Check for non-successful status codes (4xx, 5xx)
     if (!response.ok) {
       return Err(
         new AppError(
@@ -41,7 +51,6 @@ async function baseFetch(path: string, context: string): Promise<Result<Response
 
     return Ok(response);
   } catch (error) {
-    // Network errors, DNS errors, etc.
     return Err(
       new AppError(
         `A network error occurred while trying to ${context.toLowerCase()}: ${String(error)}`,
@@ -53,25 +62,17 @@ async function baseFetch(path: string, context: string): Promise<Result<Response
 
 export const apiClient = {
   /**
-   * Fetches data from a given path and parses it as JSON.
-   * @param T The expected type of the JSON response.
-   * @param path The API endpoint path.
-   * @param context A descriptive string for the action, used in error messages.
-   * @returns A Promise resolving to a Result containing the typed data (T) or an AppError.
+   * Fetches data and parses it as JSON. The response is the only generic type.
    */
-  async get<T>(path: string, context: string): Promise<Result<T, AppError>> {
-    // Get the raw response using our base fetcher
-    const responseResult = await baseFetch(path, context);
-
+  async get<TResponseData>(path: string, context: string, token?: string): Promise<Result<TResponseData, AppError>> {
+    const responseResult = await baseFetch(path, context, 'GET', token);
     if (responseResult.isErr()) {
-      return responseResult; // Pass through network/HTTP errors
+      return responseResult;
     }
 
     const response = responseResult.unwrap();
-
-    // Try to parse the JSON, handling any parsing errors
     try {
-      const data = (await response.json()) as T;
+      const data = (await response.json()) as TResponseData;
       return Ok(data);
     } catch (parsingError) {
       return Err(
@@ -83,5 +84,91 @@ export const apiClient = {
     }
   },
 
-  // TODO: add post, put, delete methods here in the future following the same pattern.
+  /**
+   * Sends data via POST. Uses separate types for the request body and the expected response.
+   */
+  async post<TRequestData, TResponseData>(
+    path: string,
+    context: string,
+    token?: string,
+    model?: TRequestData,
+  ): Promise<Result<TResponseData, AppError>> {
+    const responseResult = await baseFetch(path, context, 'POST', token, JSON.stringify(model));
+    if (responseResult.isErr()) {
+      return responseResult;
+    }
+
+    const response = responseResult.unwrap();
+    try {
+      const data = (await response.json()) as TResponseData;
+      return Ok(data);
+    } catch (parsingError) {
+      return Err(
+        new AppError(
+          `Failed to parse JSON response on '${context.toLowerCase()}': ${String(parsingError)}`,
+          ErrorCodes.VACMAN_API_ERROR,
+        ),
+      );
+    }
+  },
+
+  /**
+   * Sends data via PUT. Uses separate types for the request body and the expected response.
+   */
+  async put<TRequestData, TResponseData>(
+    path: string,
+    context: string,
+    token?: string,
+    model?: TRequestData,
+  ): Promise<Result<TResponseData, AppError>> {
+    const responseResult = await baseFetch(path, context, 'PUT', token, JSON.stringify(model));
+    if (responseResult.isErr()) {
+      return responseResult;
+    }
+
+    const response = responseResult.unwrap();
+    try {
+      const data = (await response.json()) as TResponseData;
+      return Ok(data);
+    } catch (parsingError) {
+      return Err(
+        new AppError(
+          `Failed to parse JSON response on '${context.toLowerCase()}': ${String(parsingError)}`,
+          ErrorCodes.VACMAN_API_ERROR,
+        ),
+      );
+    }
+  },
+
+  /**
+   * Sends a DELETE request. Allows for an optional request body and an expected response type.
+   */
+  async delete<TRequestData, TResponseData>(
+    path: string,
+    context: string,
+    token?: string,
+    model?: TRequestData,
+  ): Promise<Result<TResponseData, AppError>> {
+    const jsonBody = model ? JSON.stringify(model) : undefined;
+    const responseResult = await baseFetch(path, context, 'DELETE', token, jsonBody);
+    if (responseResult.isErr()) {
+      return responseResult;
+    }
+
+    const response = responseResult.unwrap();
+    try {
+      // The JSON from the response should be parsed as the response type.
+      // Handle empty responses, common for DELETE requests.
+      const text = await response.text();
+      const data = text ? (JSON.parse(text) as TResponseData) : (null as TResponseData);
+      return Ok(data);
+    } catch (parsingError) {
+      return Err(
+        new AppError(
+          `Failed to parse JSON response on '${context.toLowerCase()}': ${String(parsingError)}`,
+          ErrorCodes.VACMAN_API_ERROR,
+        ),
+      );
+    }
+  },
 };

--- a/frontend/app/.server/domain/services/api-client.ts
+++ b/frontend/app/.server/domain/services/api-client.ts
@@ -87,13 +87,13 @@ export const apiClient = {
   /**
    * Sends data via POST. Uses separate types for the request body and the expected response.
    */
-  async post<TRequestData, TResponseData>(
+  async post<TRequestData, TResponseData = unknown>(
     path: string,
     context: string,
     token?: string,
-    model?: TRequestData,
+    data?: TRequestData,
   ): Promise<Result<TResponseData, AppError>> {
-    const responseResult = await baseFetch(path, context, 'POST', token, JSON.stringify(model));
+    const responseResult = await baseFetch(path, context, 'POST', token, JSON.stringify(data));
     if (responseResult.isErr()) {
       return responseResult;
     }
@@ -115,13 +115,13 @@ export const apiClient = {
   /**
    * Sends data via PUT. Uses separate types for the request body and the expected response.
    */
-  async put<TRequestData, TResponseData>(
+  async put<TRequestData, TResponseData = unknown>(
     path: string,
     context: string,
     token?: string,
-    model?: TRequestData,
+    data?: TRequestData,
   ): Promise<Result<TResponseData, AppError>> {
-    const responseResult = await baseFetch(path, context, 'PUT', token, JSON.stringify(model));
+    const responseResult = await baseFetch(path, context, 'PUT', token, JSON.stringify(data));
     if (responseResult.isErr()) {
       return responseResult;
     }
@@ -143,13 +143,13 @@ export const apiClient = {
   /**
    * Sends a DELETE request. Allows for an optional request body and an expected response type.
    */
-  async delete<TRequestData, TResponseData>(
+  async delete<TRequestData, TResponseData = unknown>(
     path: string,
     context: string,
     token?: string,
-    model?: TRequestData,
+    data?: TRequestData,
   ): Promise<Result<TResponseData, AppError>> {
-    const jsonBody = model ? JSON.stringify(model) : undefined;
+    const jsonBody = data ? JSON.stringify(data) : undefined;
     const responseResult = await baseFetch(path, context, 'DELETE', token, jsonBody);
     if (responseResult.isErr()) {
       return responseResult;

--- a/frontend/tests/.server/domain/services/non-advertised-appointment-service-default.test.ts
+++ b/frontend/tests/.server/domain/services/non-advertised-appointment-service-default.test.ts
@@ -64,7 +64,7 @@ describe('getDefaultNonAdvertisedAppointmentService', () => {
       expect(result.isOk()).toBe(true);
       expect(result.unwrap()).toEqual(singleMockAppointment);
       expect(fetch).toHaveBeenCalledTimes(1);
-      expect(fetch).toHaveBeenCalledWith('http://localhost:8080/api/v1/codes/non-advertised-appointments');
+      expect(fetch).toHaveBeenCalledWith('http://localhost:8080/api/v1/codes/non-advertised-appointments', expect.anything());
     });
 
     it('should return an Err result with AppError if not found', async () => {


### PR DESCRIPTION
## Summary

as discussed in chat update api client to add access token
Note: run the api locally, and set the ENABLE_LOOKUP_FIELD_SERVICES_MOCK=false in .env file, the code tables still load, so current functionality is still intact

## Types of changes

What types of changes does this PR introduce?

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes

