### PR TITLE
chore(frontend) remove getUserByActiveDirectoryId

### DIFF
--- a/frontend/app/.server/domain/services/profile-service-mock.ts
+++ b/frontend/app/.server/domain/services/profile-service-mock.ts
@@ -1,6 +1,8 @@
 import { None, Some, Err, Ok } from 'oxide.ts';
 import type { Result } from 'oxide.ts';
 
+import { getUserService } from './user-service';
+
 import type { Profile } from '~/.server/domain/models';
 import type { ProfileService } from '~/.server/domain/services/profile-service';
 import { PROFILE_STATUS_ID } from '~/domain/constants';
@@ -68,18 +70,13 @@ export function getMockProfileService(): ProfileService {
     getAllProfiles: () => {
       return Promise.resolve(mockProfiles);
     },
-    getCurrentUserProfile: (accessToken: string) => {
-      const userId = activeDirectoryToUserIdMap[accessToken];
-
-      if (!userId) {
-        // No user found for this token
-        return Promise.resolve(None);
-      }
+    getCurrentUserProfile: async (accessToken: string) => {
+      const user = await getUserService().getCurrentUser(accessToken);
 
       // Find the active profile for this specific user
       const activeProfile = mockProfiles.find(
         (profile) =>
-          profile.userId === userId &&
+          profile.userId === user.id &&
           (profile.profileStatusId === PROFILE_STATUS_ID.incomplete ||
             profile.profileStatusId === PROFILE_STATUS_ID.pending ||
             profile.profileStatusId === PROFILE_STATUS_ID.approved),

--- a/frontend/app/.server/domain/services/user-service-default.ts
+++ b/frontend/app/.server/domain/services/user-service-default.ts
@@ -45,29 +45,6 @@ export function getDefaultUserService(): UserService {
       return await response.json();
     },
 
-    /**
-     * Retrieves a user by their Active Directory ID.
-     * @param activeDirectoryId The Active Directory ID of the user to retrieve.
-     * @returns A promise that resolves to the user object, or null if not found.
-     * @throws AppError if the request fails or if the server responds with an error status.
-     */
-    async getUserByActiveDirectoryId(activeDirectoryId: string): Promise<User | null> {
-      const response = await fetch(
-        `${serverEnvironment.VACMAN_API_BASE_URI}/users/by-active-directory-id/${encodeURIComponent(activeDirectoryId)}`,
-      );
-
-      if (response.status === HttpStatusCodes.NOT_FOUND) {
-        return null;
-      }
-
-      if (!response.ok) {
-        const errorMessage = `Failed to retrieve user with Active Directory ID ${activeDirectoryId}. Server responded with status ${response.status}.`;
-        throw new AppError(errorMessage, ErrorCodes.VACMAN_API_ERROR);
-      }
-
-      return await response.json();
-    },
-
     async getCurrentUser(accessToken: string): Promise<User> {
       const response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}/users/me`, {
         headers: {

--- a/frontend/app/.server/domain/services/user-service-mock.ts
+++ b/frontend/app/.server/domain/services/user-service-mock.ts
@@ -20,13 +20,6 @@ export function getMockUserService(): UserService {
         return Promise.reject(error);
       }
     },
-    getUserByActiveDirectoryId: (activeDirectoryId: string) => {
-      try {
-        return Promise.resolve(getUserByActiveDirectoryId(activeDirectoryId));
-      } catch (error) {
-        return Promise.reject(error);
-      }
-    },
     getCurrentUser: (accessToken: string): Promise<User> => {
       try {
         const user = mockUsers[0];
@@ -161,17 +154,6 @@ function getUserById(id: number): User {
     throw new AppError(`User with ID '${id}' not found.`, ErrorCodes.VACMAN_API_ERROR);
   }
   return user;
-}
-
-/**
- * Retrieves a user by their Active Directory ID from mock data.
- *
- * @param activeDirectoryId The Active Directory ID of the user to retrieve.
- * @returns The user object if found, null otherwise.
- */
-function getUserByActiveDirectoryId(activeDirectoryId: string): User | null {
-  const user = mockUsers.find((u) => u.networkName === activeDirectoryId);
-  return user ?? null;
 }
 
 /**

--- a/frontend/app/.server/domain/services/user-service.ts
+++ b/frontend/app/.server/domain/services/user-service.ts
@@ -7,7 +7,6 @@ import { serverEnvironment } from '~/.server/environment';
 export type UserService = {
   getUsersByRole(role: string): Promise<User[]>;
   getUserById(id: number): Promise<User>;
-  getUserByActiveDirectoryId(activeDirectoryId: string): Promise<User | null>;
   getCurrentUser(accessToken: string): Promise<User>;
   registerCurrentUser(user: UserCreate, accessToken: string, idTokenClaims: IDTokenClaims): Promise<User>;
 };

--- a/frontend/app/.server/utils/hiring-manager-registration-utils.ts
+++ b/frontend/app/.server/utils/hiring-manager-registration-utils.ts
@@ -23,13 +23,7 @@ const log = LogFactory.getLogger(import.meta.url);
 export async function requireHiringManagerRegistration(session: AuthenticatedSession, currentUrl: URL): Promise<void> {
   // Get user from the database to check hiring manager registration
   const userService = getUserService();
-  const activeDirectoryId = session.authState.idTokenClaims.oid;
-  const user = await userService.getUserByActiveDirectoryId(activeDirectoryId);
-
-  if (!user) {
-    log.debug('User not found in database, redirecting to index to register as hiring manager');
-    throw i18nRedirect('routes/employee/index.tsx', currentUrl);
-  }
+  const user = await userService.getCurrentUser(session.authState.accessToken);
 
   // Check if user has hiring-manager role
   if (user.role !== 'hiring-manager') {

--- a/frontend/app/.server/utils/hr-advisor-registration-utils.ts
+++ b/frontend/app/.server/utils/hr-advisor-registration-utils.ts
@@ -23,13 +23,7 @@ const log = LogFactory.getLogger(import.meta.url);
 export async function requireHrAdvisorRegistration(session: AuthenticatedSession, currentUrl: URL): Promise<void> {
   // Get user from the database to check hr-advisor registration
   const userService = getUserService();
-  const activeDirectoryId = session.authState.idTokenClaims.oid;
-  const user = await userService.getUserByActiveDirectoryId(activeDirectoryId);
-
-  if (!user) {
-    log.debug('User not found in database, redirecting to index to register as hr-advisor');
-    throw i18nRedirect('routes/employee/index.tsx', currentUrl);
-  }
+  const user = await userService.getCurrentUser(session.authState.accessToken);
 
   // Check if user has hr-advisor role
   if (user.role !== 'hr-advisor') {

--- a/frontend/app/.server/utils/profile-access-utils.ts
+++ b/frontend/app/.server/utils/profile-access-utils.ts
@@ -61,14 +61,11 @@ export async function requireProfileAccess(
 
   // If not accessing own profile, check if requester has hiring-manager or hr-advisor role
   const userService = getUserService();
-  const requesterUser = await userService.getUserByActiveDirectoryId(requesterId);
+  // TODO the commented line doesn't make sense.  requesterId is pulled from the session, thus this is an alias for the currentUser?
+  // const requesterUser = await userService.getUserByActiveDirectoryId(requesterId);
 
-  if (!requesterUser) {
-    log.debug(`Requester not found: ${requesterId}`);
-    throw new AppError(`Requester not found in system: ${requesterId}`, ErrorCodes.ACCESS_FORBIDDEN, {
-      httpStatusCode: HttpStatusCodes.FORBIDDEN,
-    });
-  }
+  // TODO verify the logic aftet this line is correct or needed
+  const requesterUser = await userService.getCurrentUser(session.authState.accessToken);
 
   if (requesterUser.role === 'hiring-manager' || requesterUser.role === 'hr-advisor') {
     log.debug(`${requesterUser.role} access granted`);

--- a/frontend/app/routes/employee/profile/employment-information.tsx
+++ b/frontend/app/routes/employee/profile/employment-information.tsx
@@ -51,7 +51,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     );
   }
   const profileService = getProfileService();
-  const currentProfileOption = await profileService.getProfile(currentUserId);
+  const currentProfileOption = await profileService.getCurrentUserProfile(context.session.authState.accessToken);
   const currentProfile = currentProfileOption.unwrap();
   const updateResult = await profileService.updateProfile(
     authenticatedSession.authState.accessToken,

--- a/frontend/app/routes/employee/profile/referral-preferences.tsx
+++ b/frontend/app/routes/employee/profile/referral-preferences.tsx
@@ -62,7 +62,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
   }
 
   const profileService = getProfileService();
-  const currentProfileOption = await profileService.getProfile(currentUserId);
+  const currentProfileOption = await profileService.getCurrentUserProfile(context.session.authState.accessToken);
   const currentProfile = currentProfileOption.unwrap();
   const updateResult = await profileService.updateProfile(
     authenticatedSession.authState.accessToken,

--- a/frontend/app/routes/hr-advisor/employee-profile/index.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/index.tsx
@@ -80,9 +80,7 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 
   const profileData: Profile = profileResult.unwrap();
 
-  const profileUpdatedByUser = profileData.userUpdated
-    ? await getUserService().getUserByActiveDirectoryId(profileData.userUpdated)
-    : undefined;
+  const profileUpdatedByUser = profileData.userUpdated ? await getUserService().getUserById(profileData.userId) : undefined;
   const profileUpdatedByUserName = profileUpdatedByUser && `${profileUpdatedByUser.firstName} ${profileUpdatedByUser.lastName}`;
   const profileStatus = (await getProfileStatusService().findLocalizedById(profileData.profileStatusId, lang)).unwrap();
 

--- a/frontend/tests/.server/domain/services/user-service-mock.test.ts
+++ b/frontend/tests/.server/domain/services/user-service-mock.test.ts
@@ -41,35 +41,6 @@ describe('getMockUserService', () => {
     });
   });
 
-  describe('getUserByActiveDirectoryId', () => {
-    it('should return a user when given a valid Active Directory ID', async () => {
-      const user = await service.getUserByActiveDirectoryId('11111111-1111-1111-1111-111111111111');
-
-      expect(user).toEqual({
-        id: 2,
-        uuName: 'John Doe',
-        networkName: '11111111-1111-1111-1111-111111111111',
-        role: 'employee',
-        userCreated: 'system',
-        dateCreated: '2024-01-01T00:00:00Z',
-        userUpdated: 'system',
-        dateUpdated: '2024-01-01T00:00:00Z',
-        firstName: 'John',
-        middleName: 'Michael',
-        lastName: 'Doe',
-        initials: 'J.M.D.',
-        personalRecordIdentifier: '987654321',
-        businessPhone: '+1-613-555-0102',
-        businessEmail: 'john.doe@canada.ca',
-      });
-    });
-
-    it('should return null when user is not found', async () => {
-      const user = await service.getUserByActiveDirectoryId('nonexistent-id');
-      expect(user).toBeNull();
-    });
-  });
-
   describe('registerCurrentUser', () => {
     it('should create a new user with generated metadata', async () => {
       const userData = {

--- a/frontend/tests/.server/routes/hiring-manager.test.ts
+++ b/frontend/tests/.server/routes/hiring-manager.test.ts
@@ -51,7 +51,6 @@ vi.mock('~/.server/utils/route-utils', () => ({
 const mockUserService = {
   getUsersByRole: vi.fn(),
   getUserById: vi.fn(),
-  getUserByActiveDirectoryId: vi.fn(),
   updateUserRole: vi.fn(),
   getCurrentUser: vi.fn(),
   registerCurrentUser: vi.fn(),
@@ -111,8 +110,8 @@ describe('Hiring Manager Route Protection', () => {
     expect(response).toEqual({
       documentTitle: expect.any(String),
     });
-    // The individual route should NOT call getUserByActiveDirectoryId since registration checks are handled by parent layout
-    expect(mockUserService.getUserByActiveDirectoryId).not.toHaveBeenCalled();
+    // The individual route should NOT call getCurrentUser since registration checks are handled by parent layout
+    expect(mockUserService.getCurrentUser).not.toHaveBeenCalled();
   });
 
   it('should not perform registration checks in individual route (handled by parent layout)', async () => {
@@ -128,7 +127,7 @@ describe('Hiring Manager Route Protection', () => {
     expect(response).toEqual({
       documentTitle: expect.any(String),
     });
-    expect(mockUserService.getUserByActiveDirectoryId).not.toHaveBeenCalled();
+    expect(mockUserService.getCurrentUser).not.toHaveBeenCalled();
   });
 
   it('should work with French locale URLs without performing registration checks', async () => {
@@ -143,6 +142,6 @@ describe('Hiring Manager Route Protection', () => {
     expect(response).toEqual({
       documentTitle: expect.any(String),
     });
-    expect(mockUserService.getUserByActiveDirectoryId).not.toHaveBeenCalled();
+    expect(mockUserService.getCurrentUser).not.toHaveBeenCalled();
   });
 });

--- a/frontend/tests/.server/routes/index.test.ts
+++ b/frontend/tests/.server/routes/index.test.ts
@@ -57,7 +57,6 @@ vi.mock('~/.server/utils/route-utils', () => ({
 const mockUserService = {
   getUsersByRole: vi.fn(),
   getUserById: vi.fn(),
-  getUserByActiveDirectoryId: vi.fn(),
   updateUserRole: vi.fn(),
   getCurrentUser: vi.fn(),
   registerCurrentUser: vi.fn(),
@@ -115,7 +114,7 @@ describe('Index Dashboard Selection Flow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Default: user is not registered
-    mockUserService.getUserByActiveDirectoryId.mockResolvedValue(null);
+    mockUserService.getCurrentUser.mockResolvedValue(null);
     // Default: no profile exists
     mockProfileService.getProfile.mockResolvedValue(None);
   });

--- a/frontend/tests/.server/utils/hiring-manager-registration-utils.test.ts
+++ b/frontend/tests/.server/utils/hiring-manager-registration-utils.test.ts
@@ -24,7 +24,6 @@ vi.mock('~/.server/utils/route-utils', () => ({
 
 const mockUserService = {
   getUsersByRole: vi.fn(),
-  getUserByActiveDirectoryId: vi.fn(),
   updateUserRole: vi.fn(),
   getUserById: vi.fn(),
   getCurrentUser: vi.fn(),
@@ -71,7 +70,7 @@ describe('Hiring Manager Registration Utils', () => {
       const mockSession = createMockSession('test-hiring-manager-123');
       const currentUrl = new URL('http://localhost:3000/en/hiring-manager');
 
-      mockUserService.getUserByActiveDirectoryId.mockResolvedValue({
+      mockUserService.getCurrentUser.mockResolvedValue({
         id: 1,
         name: 'Test Hiring Manager',
         activeDirectoryId: 'test-hiring-manager-123',
@@ -85,7 +84,7 @@ describe('Hiring Manager Registration Utils', () => {
       // Act & Assert - should not throw
       await expect(requireHiringManagerRegistration(mockSession, currentUrl)).resolves.not.toThrow();
 
-      expect(mockUserService.getUserByActiveDirectoryId).toHaveBeenCalledWith('test-hiring-manager-123');
+      expect(mockUserService.getCurrentUser).toHaveBeenCalledWith('mock-access-token');
     });
 
     it('should redirect when user is not found in database', async () => {
@@ -93,12 +92,12 @@ describe('Hiring Manager Registration Utils', () => {
       const mockSession = createMockSession('test-unregistered-user');
       const currentUrl = new URL('http://localhost:3000/en/hiring-manager');
 
-      mockUserService.getUserByActiveDirectoryId.mockResolvedValue(null);
+      mockUserService.getCurrentUser.mockResolvedValue(null);
 
       // Act & Assert - should throw redirect
       await expect(requireHiringManagerRegistration(mockSession, currentUrl)).rejects.toThrow();
 
-      expect(mockUserService.getUserByActiveDirectoryId).toHaveBeenCalledWith('test-unregistered-user');
+      expect(mockUserService.getCurrentUser).toHaveBeenCalledWith('mock-access-token');
     });
 
     it('should redirect when user is not a hiring manager', async () => {
@@ -106,7 +105,7 @@ describe('Hiring Manager Registration Utils', () => {
       const mockSession = createMockSession('test-employee-123');
       const currentUrl = new URL('http://localhost:3000/en/hiring-manager');
 
-      mockUserService.getUserByActiveDirectoryId.mockResolvedValue({
+      mockUserService.getCurrentUser.mockResolvedValue({
         id: 1,
         name: 'Test Employee',
         activeDirectoryId: 'test-employee-123',
@@ -121,7 +120,7 @@ describe('Hiring Manager Registration Utils', () => {
       // Act & Assert - should throw redirect
       await expect(requireHiringManagerRegistration(mockSession, currentUrl)).rejects.toThrow();
 
-      expect(mockUserService.getUserByActiveDirectoryId).toHaveBeenCalledWith('test-employee-123');
+      expect(mockUserService.getCurrentUser).toHaveBeenCalledWith('mock-access-token');
     });
 
     it('should redirect when user has hr-advisor role instead of hiring-manager', async () => {
@@ -129,7 +128,7 @@ describe('Hiring Manager Registration Utils', () => {
       const mockSession = createMockSession('test-hr-advisor-123');
       const currentUrl = new URL('http://localhost:3000/en/hiring-manager');
 
-      mockUserService.getUserByActiveDirectoryId.mockResolvedValue({
+      mockUserService.getCurrentUser.mockResolvedValue({
         id: 1,
         name: 'Test HR Advisor',
         activeDirectoryId: 'test-hr-advisor-123',
@@ -143,7 +142,7 @@ describe('Hiring Manager Registration Utils', () => {
       // Act & Assert - should throw redirect
       await expect(requireHiringManagerRegistration(mockSession, currentUrl)).rejects.toThrow();
 
-      expect(mockUserService.getUserByActiveDirectoryId).toHaveBeenCalledWith('test-hr-advisor-123');
+      expect(mockUserService.getCurrentUser).toHaveBeenCalledWith('mock-access-token');
     });
 
     it('should work with French locale URLs', async () => {
@@ -151,7 +150,7 @@ describe('Hiring Manager Registration Utils', () => {
       const mockSession = createMockSession('test-hiring-manager-fr');
       const currentUrl = new URL('http://localhost:3000/fr/gestionnaire-embauche');
 
-      mockUserService.getUserByActiveDirectoryId.mockResolvedValue({
+      mockUserService.getCurrentUser.mockResolvedValue({
         id: 1,
         name: 'Gestionnaire Test',
         activeDirectoryId: 'test-hiring-manager-fr',
@@ -165,7 +164,7 @@ describe('Hiring Manager Registration Utils', () => {
       // Act & Assert - should not throw
       await expect(requireHiringManagerRegistration(mockSession, currentUrl)).resolves.not.toThrow();
 
-      expect(mockUserService.getUserByActiveDirectoryId).toHaveBeenCalledWith('test-hiring-manager-fr');
+      expect(mockUserService.getCurrentUser).toHaveBeenCalledWith('mock-access-token');
     });
   });
 

--- a/frontend/tests/.server/utils/privacy-consent-utils.test.ts
+++ b/frontend/tests/.server/utils/privacy-consent-utils.test.ts
@@ -82,7 +82,6 @@ vi.mock('~/.server/utils/profile-utils', () => ({
 const mockUserService = {
   getUsersByRole: vi.fn(),
   getUserById: vi.fn(),
-  getUserByActiveDirectoryId: vi.fn(),
   updateUserRole: vi.fn(),
   getCurrentUser: vi.fn(),
   registerCurrentUser: vi.fn(),
@@ -143,7 +142,7 @@ describe('Privacy Consent Flow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Default: user is not registered
-    mockUserService.getUserByActiveDirectoryId.mockResolvedValue(null);
+    mockUserService.getCurrentUser.mockResolvedValue(null);
     // Default: no profile exists
     mockProfileService.getProfile.mockResolvedValue(null);
     // Mock createUserProfile to return a profile with profileId
@@ -240,7 +239,7 @@ describe('Privacy Consent Flow', () => {
       });
 
       // Mock existing user
-      mockUserService.getUserByActiveDirectoryId.mockResolvedValue({
+      mockUserService.getCurrentUser.mockResolvedValue({
         id: 1,
         uuName: 'Existing Employee',
         networkName: 'test-existing-employee-123',

--- a/frontend/tests/.server/utils/profile-access-utils.test.ts
+++ b/frontend/tests/.server/utils/profile-access-utils.test.ts
@@ -37,11 +37,10 @@ const mockProfileService = {
   getCurrentUserProfile: vi.fn(),
 };
 const mockUserService = {
-  getUserByActiveDirectoryId: vi.fn(),
+  getCurrentUser: vi.fn(),
   updateUserRole: vi.fn(),
   getUsersByRole: vi.fn(),
   getUserById: vi.fn(),
-  getCurrentUser: vi.fn(),
   registerCurrentUser: vi.fn(),
 };
 const mockRequirePrivacyConsentForOwnProfile = vi.fn();
@@ -192,25 +191,11 @@ describe('Profile Access Utils', () => {
         // Arrange
         const session = createMockSession('test-manager-456');
         const targetUserId = 'test-employee-123';
-        mockUserService.getUserByActiveDirectoryId.mockResolvedValue(mockHiringManager);
+        mockUserService.getCurrentUser.mockResolvedValue(mockHiringManager);
 
         // Act & Assert - should not throw
         await expect(requireProfileAccess(session, targetUserId)).resolves.not.toThrow();
-        expect(mockUserService.getUserByActiveDirectoryId).toHaveBeenCalledWith('test-manager-456');
-      });
-
-      it('should throw error when requester is not found in system', async () => {
-        // Arrange
-        const session = createMockSession('test-unknown-user');
-        const targetUserId = 'test-employee-123';
-        mockUserService.getUserByActiveDirectoryId.mockResolvedValue(null);
-
-        // Act & Assert
-        await expect(requireProfileAccess(session, targetUserId)).rejects.toThrow(AppError);
-        await expect(requireProfileAccess(session, targetUserId)).rejects.toMatchObject({
-          errorCode: ErrorCodes.ACCESS_FORBIDDEN,
-          httpStatusCode: HttpStatusCodes.FORBIDDEN,
-        });
+        expect(mockUserService.getCurrentUser).toHaveBeenCalledWith('mock-access-token');
       });
     });
 
@@ -219,7 +204,7 @@ describe('Profile Access Utils', () => {
         // Arrange
         const session = createMockSession('test-employee-456');
         const targetUserId = 'test-employee-123';
-        mockUserService.getUserByActiveDirectoryId.mockResolvedValue({
+        mockUserService.getCurrentUser.mockResolvedValue({
           ...mockEmployee,
           activeDirectoryId: 'test-employee-456',
         });
@@ -236,7 +221,7 @@ describe('Profile Access Utils', () => {
         // Arrange
         const session = createMockSession('test-hr-advisor');
         const targetUserId = 'test-employee-123';
-        mockUserService.getUserByActiveDirectoryId.mockResolvedValue({
+        mockUserService.getCurrentUser.mockResolvedValue({
           ...mockEmployee,
           activeDirectoryId: 'test-hr-advisor',
           role: 'hr-advisor',
@@ -244,7 +229,7 @@ describe('Profile Access Utils', () => {
 
         // Act & Assert
         await expect(requireProfileAccess(session, targetUserId)).resolves.not.toThrow();
-        expect(mockUserService.getUserByActiveDirectoryId).toHaveBeenCalledWith('test-hr-advisor');
+        expect(mockUserService.getCurrentUser).toHaveBeenCalledWith('mock-access-token');
       });
     });
   });
@@ -266,7 +251,7 @@ describe('Profile Access Utils', () => {
       // Arrange
       const session = createMockSession('test-employee-456');
       const targetUserId = 'test-employee-123';
-      mockUserService.getUserByActiveDirectoryId.mockResolvedValue({
+      mockUserService.getCurrentUser.mockResolvedValue({
         ...mockEmployee,
         activeDirectoryId: 'test-employee-456',
       });
@@ -320,7 +305,7 @@ describe('Profile Access Utils', () => {
       // Arrange
       const session = createMockSession('test-employee-456');
       const targetUserId = 'test-employee-123';
-      mockUserService.getUserByActiveDirectoryId.mockResolvedValue({
+      mockUserService.getCurrentUser.mockResolvedValue({
         ...mockEmployee,
         activeDirectoryId: 'test-employee-456',
       });
@@ -400,7 +385,7 @@ describe('Profile Access Utils', () => {
       const currentUrl = new URL('http://localhost:3000/en/employee/test-employee-123/profile');
       mockIsProfileRoute.mockReturnValue(true);
       mockExtractUserIdFromProfileRoute.mockReturnValue(Some('test-employee-123'));
-      mockUserService.getUserByActiveDirectoryId.mockResolvedValue({
+      mockUserService.getCurrentUser.mockResolvedValue({
         ...mockEmployee,
         activeDirectoryId: 'test-employee-456',
       });
@@ -420,7 +405,7 @@ describe('Profile Access Utils', () => {
       const session = createMockSession('test-manager-456');
       const targetUserId = 'test-employee-123';
       const currentUrl = new URL('http://localhost:3000/en/employee/test-employee-123/profile');
-      mockUserService.getUserByActiveDirectoryId.mockResolvedValue(mockHiringManager);
+      mockUserService.getCurrentUser.mockResolvedValue(mockHiringManager);
 
       // Act
       const hasAccess = await hasProfileAccess(session, targetUserId, currentUrl);
@@ -429,7 +414,7 @@ describe('Profile Access Utils', () => {
       // Assert
       expect(hasAccess).toBe(true);
       expect(profile).toEqual(mockProfile);
-      expect(mockUserService.getUserByActiveDirectoryId).toHaveBeenCalledWith('test-manager-456');
+      expect(mockUserService.getCurrentUser).toHaveBeenCalledWith('mock-access-token');
     });
 
     it('should handle complete employee self-access flow', async () => {
@@ -447,7 +432,7 @@ describe('Profile Access Utils', () => {
       expect(profile).toEqual(mockProfile);
       expect(mockRequirePrivacyConsentForOwnProfile).toHaveBeenCalledWith(session, targetUserId, currentUrl);
       // User service should not be called for own profile access
-      expect(mockUserService.getUserByActiveDirectoryId).not.toHaveBeenCalled();
+      expect(mockUserService.getCurrentUser).not.toHaveBeenCalled();
     });
 
     it('should handle profile route access check integration', async () => {


### PR DESCRIPTION
## Summary

[AB#6584](https://dev.azure.com/DTS-STN/4c33b941-c811-479f-b181-dfd5292182ff/_workitems/edit/6584)

removes `getUserByActiveDirectoryId`

please review carefully since I've had to call other user service/profile service methods to make these changes work.  