### PR TITLE
refactor(frontend): load employee profile from profile/me endpoint

### DIFF
--- a/frontend/app/routes/employee/profile/index.tsx
+++ b/frontend/app/routes/employee/profile/index.tsx
@@ -111,10 +111,15 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
   const currentUrl = new URL(request.url);
   requireAuthentication(context.session, currentUrl);
 
-  // Use the id parameter from the URL to fetch the profile
-  const profileUserId = params.id;
+  const profileResult = await getProfileService().getCurrentUserProfile(context.session.authState.accessToken);
 
-  await requirePrivacyConsentForOwnProfile(context.session, profileUserId, currentUrl);
+  if (profileResult.isNone()) {
+    throw new Response('Profile not found', { status: 404 });
+  }
+
+  const profileData: Profile = profileResult.unwrap();
+
+  await requirePrivacyConsentForOwnProfile(context.session, profileData.profileId.toString(), currentUrl);
 
   const { lang, t } = await getTranslation(request, handle.i18nNamespace);
 
@@ -123,26 +128,20 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 
   // Fetch both the profile user and the profile data
   const [
-    profileResult,
+    currentUser,
     allLocalizedLanguageReferralTypes,
     allClassifications,
     allLocalizedCities,
     allLocalizedEmploymentTenures,
     allWfaStatus,
   ] = await Promise.all([
-    getProfileService().getCurrentUserProfile(context.session.authState.accessToken),
+    getUserService().getUserById(profileData.userId),
     getLanguageReferralTypeService().listAllLocalized(lang),
     getClassificationService().listAllLocalized(lang),
     getCityService().listAllLocalized(lang),
     getEmploymentTenureService().listAllLocalized(lang),
     getWFAStatuses().listAll(),
   ]);
-
-  if (profileResult.isNone()) {
-    throw new Response('Profile not found', { status: 404 });
-  }
-
-  const profileData: Profile = profileResult.unwrap();
 
   const profileUpdatedByUser = profileData.userUpdated ? await getUserService().getUserById(profileData.userId) : undefined;
   const profileUpdatedByUserName = profileUpdatedByUser && `${profileUpdatedByUser.firstName} ${profileUpdatedByUser.lastName}`;
@@ -229,8 +228,8 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 
   return {
     documentTitle: t('app:profile.page-title'),
-    name: `${profileData.personalInformation.givenName} ${profileData.personalInformation.surname}`,
-    email: profileData.personalInformation.workEmail,
+    name: `${currentUser.firstName} ${currentUser.lastName}`, //for first time employee login, the name is not in profile data
+    email: currentUser.businessEmail ?? profileData.personalInformation.workEmail, //for first time employee login, the work email is not in profile data
     amountCompleted: amountCompleted,
     isProfileComplete: isCompletePersonalInformation && isCompleteEmploymentInformation && isCompleteReferralPreferences,
     profileStatus,
@@ -239,9 +238,9 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
       isNew: countCompletedItems(profileData.personalInformation) === 1, // only work email is available
       personalRecordIdentifier: profileData.personalInformation.personalRecordIdentifier,
       preferredLanguage: preferredLanguage,
-      workEmail: profileData.personalInformation.workEmail,
+      workEmail: currentUser.businessEmail ?? profileData.personalInformation.workEmail,
       personalEmail: profileData.personalInformation.personalEmail,
-      workPhone: profileData.personalInformation.workPhone,
+      workPhone: currentUser.businessPhone,
       personalPhone: profileData.personalInformation.personalPhone,
       additionalInformation: profileData.personalInformation.additionalInformation,
     },


### PR DESCRIPTION
## Summary

[AB#6562](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6562/)
load employee profile from profile/me endpoint

## Additional Notes
This pr address the flow on the Profile page Loader, to Call GET profile/me to get the profile data and throwing 404 if not found, and then getting the user from GET /users/me to display the user name, work email and work phone from user data.
Since the route for hr-advisor have it's own employee profile route, so it wouldn't effect anything

<img width="976" height="580" alt="image" src="https://github.com/user-attachments/assets/1d9732d9-dd61-4432-be79-2de7bf65d429" />

## Types of changes

What types of changes does this PR introduce?

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.

- [x] code has been linted and formatted locally

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>
