### PR TITLE
refactor(frontend): Use apiClient as base for User Service methods

### DIFF
--- a/frontend/app/.server/domain/services/user-service-default.ts
+++ b/frontend/app/.server/domain/services/user-service-default.ts
@@ -1,7 +1,6 @@
-import type { IDTokenClaims } from '~/.server/auth/auth-strategies';
 import type { User, UserCreate } from '~/.server/domain/models';
+import { apiClient } from '~/.server/domain/services/api-client';
 import type { UserService } from '~/.server/domain/services/user-service';
-import { serverEnvironment } from '~/.server/environment';
 import { AppError } from '~/errors/app-error';
 import { ErrorCodes } from '~/errors/error-codes';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
@@ -11,71 +10,59 @@ export function getDefaultUserService(): UserService {
     /**
      * Retrieves a list of users by their ROLE.
      * @param role The ROLE of the user to retrieve.
+     * @param accessToken The access token for authorization.
      * @returns A promise that resolves to the list of user objects.
      */
-    async getUsersByRole(role: string): Promise<User[]> {
-      const response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}/users?type=${role}`);
+    async getUsersByRole(role: string, accessToken: string): Promise<User[]> {
+      const result = await apiClient.get<User[]>(`/users?type=${role}`, `retrieve users with role ${role}`, accessToken);
 
-      if (!response.ok) {
-        const errorMessage = `Failed to retrieve users with role ${role}. Server responded with status ${response.status}.`;
-        throw new AppError(errorMessage, ErrorCodes.VACMAN_API_ERROR);
+      if (result.isErr()) {
+        throw result.unwrapErr();
       }
 
-      return await response.json();
+      return result.unwrap();
     },
 
     /**
      * Retrieves a user by their ID.
      * @param id The ID of the user to retrieve.
+     * @param accessToken The access token for authorization.
      * @returns A promise that resolves to the user object, or throws an error if not found.
      * @throws AppError if the request fails, if the user is not found, or if the server responds with an error status.
      */
-    async getUserById(id: number): Promise<User> {
-      const response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}/users/${id}`);
+    async getUserById(id: number, accessToken: string): Promise<User> {
+      const result = await apiClient.get<User>(`/users/${id}`, `retrieve user with ID ${id}`, accessToken);
 
-      if (response.status === HttpStatusCodes.NOT_FOUND) {
-        throw new AppError(`User with ID ${id} not found.`, ErrorCodes.VACMAN_API_ERROR);
+      if (result.isErr()) {
+        const error = result.unwrapErr();
+        // Check if it's a 404 error and provide a more specific message
+        if (error.httpStatusCode === HttpStatusCodes.NOT_FOUND) {
+          throw new AppError(`User with ID ${id} not found.`, ErrorCodes.VACMAN_API_ERROR);
+        }
+        throw error;
       }
 
-      if (!response.ok) {
-        const errorMessage = `Failed to retrieve user with ID ${id}. Server responded with status ${response.status}.`;
-        throw new AppError(errorMessage, ErrorCodes.VACMAN_API_ERROR);
-      }
-
-      return await response.json();
+      return result.unwrap();
     },
 
     async getCurrentUser(accessToken: string): Promise<User> {
-      const response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}/users/me`, {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      });
+      const result = await apiClient.get<User>('/users/me', 'get current user', accessToken);
 
-      if (!response.ok) {
-        const errorMessage = `Failed to get current user. Server responded with status ${response.status}.`;
-        throw new AppError(errorMessage, ErrorCodes.VACMAN_API_ERROR);
+      if (result.isErr()) {
+        throw result.unwrapErr();
       }
 
-      return await response.json();
+      return result.unwrap();
     },
 
-    async registerCurrentUser(user: UserCreate, accessToken: string, idTokenClaims: IDTokenClaims): Promise<User> {
-      const response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}/users/me`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${accessToken}`,
-        },
-        body: JSON.stringify(user),
-      });
+    async registerCurrentUser(user: UserCreate, accessToken: string): Promise<User> {
+      const result = await apiClient.post<UserCreate, User>('/users/me', 'register current user', user, accessToken);
 
-      if (!response.ok) {
-        const errorMessage = `Failed to register current user. Server responded with status ${response.status}.`;
-        throw new AppError(errorMessage, ErrorCodes.VACMAN_API_ERROR);
+      if (result.isErr()) {
+        throw result.unwrapErr();
       }
 
-      return await response.json();
+      return result.unwrap();
     },
   };
 }

--- a/frontend/app/.server/domain/services/user-service-mock.ts
+++ b/frontend/app/.server/domain/services/user-service-mock.ts
@@ -1,4 +1,3 @@
-import type { IDTokenClaims } from '~/.server/auth/auth-strategies';
 import type { User, UserCreate } from '~/.server/domain/models';
 import type { UserService } from '~/.server/domain/services/user-service';
 import { AppError } from '~/errors/app-error';
@@ -6,14 +5,14 @@ import { ErrorCodes } from '~/errors/error-codes';
 
 export function getMockUserService(): UserService {
   return {
-    getUsersByRole: (role: string): Promise<User[]> => {
+    getUsersByRole: (role: string, accessToken: string): Promise<User[]> => {
       try {
         return Promise.resolve(getUsersByRole(role));
       } catch (error) {
         return Promise.reject(error);
       }
     },
-    getUserById: (id: number) => {
+    getUserById: (id: number, accessToken: string) => {
       try {
         return Promise.resolve(getUserById(id));
       } catch (error) {
@@ -29,9 +28,9 @@ export function getMockUserService(): UserService {
         return Promise.reject(error);
       }
     },
-    registerCurrentUser: (user: UserCreate, accessToken: string, idTokenClaims: IDTokenClaims): Promise<User> => {
+    registerCurrentUser: (user: UserCreate, accessToken: string): Promise<User> => {
       try {
-        return Promise.resolve(registerCurrentUser(user, accessToken, idTokenClaims));
+        return Promise.resolve(registerCurrentUser(user, accessToken));
       } catch (error) {
         return Promise.reject(error);
       }
@@ -163,9 +162,9 @@ function getUserById(id: number): User {
  * @param session The authenticated session.
  * @returns The created user object with generated metadata.
  */
-function registerCurrentUser(userData: UserCreate, accessToken: string, idTokenClaims: IDTokenClaims): User {
+function registerCurrentUser(userData: UserCreate, accessToken: string): User {
   // Parse the name field to extract first and last name
-  const fullName = idTokenClaims.name ?? '';
+  const fullName = 'Test User';
   const nameParts = fullName.trim().split(/\s+/);
   const firstName = nameParts[0] ?? '';
   const lastName = nameParts.length > 1 ? (nameParts[nameParts.length - 1] ?? '') : '';
@@ -178,19 +177,19 @@ function registerCurrentUser(userData: UserCreate, accessToken: string, idTokenC
   };
 
   // Create the new user with data from session and defaults
-  const activeDirectoryId = idTokenClaims.oid;
+  const activeDirectoryId = 'mock-active-directory-id';
   const newUser: User = {
     id: mockUsers.length + 1,
     role: 'employee',
     networkName: activeDirectoryId,
-    uuName: fullName || `${firstName} ${lastName}`.trim() || 'Unknown User',
+    uuName: fullName,
     firstName: firstName,
     middleName: middleName ?? undefined,
     lastName: lastName,
     initials: generateInitials(firstName, middleName, lastName) || undefined,
     personalRecordIdentifier: undefined, // This would need to be provided by the user
     businessPhone: undefined, // This would need to be provided by the user
-    businessEmail: idTokenClaims.email ?? undefined,
+    businessEmail: 'test.user@canada.ca',
     userCreated: activeDirectoryId,
     dateCreated: new Date().toISOString(),
     userUpdated: activeDirectoryId,

--- a/frontend/app/.server/domain/services/user-service.ts
+++ b/frontend/app/.server/domain/services/user-service.ts
@@ -4,7 +4,7 @@ import { getMockUserService } from '~/.server/domain/services/user-service-mock'
 import { serverEnvironment } from '~/.server/environment';
 
 export type UserService = {
-  getUsersByRole(role: string, accessToken: string): Promise<User[]>;
+  getUsersByRole(role: string, accessToken?: string): Promise<User[]>;
   getUserById(id: number, accessToken: string): Promise<User>;
   getCurrentUser(accessToken: string): Promise<User>;
   registerCurrentUser(user: UserCreate, accessToken: string): Promise<User>;

--- a/frontend/app/.server/domain/services/user-service.ts
+++ b/frontend/app/.server/domain/services/user-service.ts
@@ -1,14 +1,13 @@
-import type { IDTokenClaims } from '~/.server/auth/auth-strategies';
 import type { User, UserCreate } from '~/.server/domain/models';
 import { getDefaultUserService } from '~/.server/domain/services/user-service-default';
 import { getMockUserService } from '~/.server/domain/services/user-service-mock';
 import { serverEnvironment } from '~/.server/environment';
 
 export type UserService = {
-  getUsersByRole(role: string): Promise<User[]>;
-  getUserById(id: number): Promise<User>;
+  getUsersByRole(role: string, accessToken: string): Promise<User[]>;
+  getUserById(id: number, accessToken: string): Promise<User>;
   getCurrentUser(accessToken: string): Promise<User>;
-  registerCurrentUser(user: UserCreate, accessToken: string, idTokenClaims: IDTokenClaims): Promise<User>;
+  registerCurrentUser(user: UserCreate, accessToken: string): Promise<User>;
 };
 
 export function getUserService(): UserService {

--- a/frontend/app/routes/employee/index.tsx
+++ b/frontend/app/routes/employee/index.tsx
@@ -62,7 +62,6 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
       const currentUser = await getUserService().registerCurrentUser(
         { languageId },
         authenticatedSession.authState.accessToken,
-        authenticatedSession.authState.idTokenClaims,
       );
       authenticatedSession.currentUser = currentUser;
     }

--- a/frontend/app/routes/employee/profile/employment-information.tsx
+++ b/frontend/app/routes/employee/profile/employment-information.tsx
@@ -16,6 +16,7 @@ import { getProvinceService } from '~/.server/domain/services/province-service';
 import { getUserService } from '~/.server/domain/services/user-service';
 import { getWFAStatuses } from '~/.server/domain/services/wfa-status-service';
 import { requireAuthentication } from '~/.server/utils/auth-utils';
+import type { AuthenticatedSession } from '~/.server/utils/auth-utils';
 import { hasEmploymentDataChanged, omitObjectProperties } from '~/.server/utils/profile-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { InlineLink } from '~/components/links';
@@ -91,6 +92,9 @@ export async function action({ context, params, request }: Route.ActionArgs) {
 }
 
 export async function loader({ context, request, params }: Route.LoaderArgs) {
+  const currentUrl = new URL(request.url);
+  requireAuthentication(context.session, currentUrl);
+
   // Use the id parameter from the URL to fetch the profile
   const profileUserId = params.id;
   const profileResult = await getProfileService().getProfile(profileUserId);
@@ -102,7 +106,8 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
   const provinces = await getProvinceService().listAllLocalized(lang);
   const cities = await getCityService().listAllLocalized(lang);
   const wfaStatuses = await getWFAStatuses().listAllLocalized(lang);
-  const hrAdvisors = await getUserService().getUsersByRole('hr-advisor');
+  const authenticatedSession = context.session as AuthenticatedSession;
+  const hrAdvisors = await getUserService().getUsersByRole('hr-advisor', authenticatedSession.authState.accessToken);
   const profileData: Profile = profileResult.unwrap();
 
   const workUnitResult =

--- a/frontend/app/routes/employee/profile/index.tsx
+++ b/frontend/app/routes/employee/profile/index.tsx
@@ -135,7 +135,7 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
     allLocalizedEmploymentTenures,
     allWfaStatus,
   ] = await Promise.all([
-    getUserService().getUserById(profileData.userId),
+    getUserService().getUserById(profileData.userId, context.session.authState.accessToken),
     getLanguageReferralTypeService().listAllLocalized(lang),
     getClassificationService().listAllLocalized(lang),
     getCityService().listAllLocalized(lang),
@@ -143,7 +143,9 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
     getWFAStatuses().listAll(),
   ]);
 
-  const profileUpdatedByUser = profileData.userUpdated ? await getUserService().getUserById(profileData.userId) : undefined;
+  const profileUpdatedByUser = profileData.userUpdated
+    ? await getUserService().getUserById(profileData.userId, context.session.authState.accessToken)
+    : undefined;
   const profileUpdatedByUserName = profileUpdatedByUser && `${profileUpdatedByUser.firstName} ${profileUpdatedByUser.lastName}`;
   const profileStatus = (await getProfileStatusService().findLocalizedById(profileData.profileStatusId, lang)).unwrap();
 

--- a/frontend/app/routes/employee/profile/index.tsx
+++ b/frontend/app/routes/employee/profile/index.tsx
@@ -144,7 +144,9 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 
   const profileData: Profile = profileResult.unwrap();
 
-  const profileUpdatedByUser = profileData.userUpdated ? await getUserService().getUserById(profileData.userId) : undefined;
+  const profileUpdatedByUser = profileData.userUpdated
+    ? await getUserService().getUserById(profileData.userId, context.session.authState.accessToken)
+    : undefined;
   const profileUpdatedByUserName = profileUpdatedByUser && `${profileUpdatedByUser.firstName} ${profileUpdatedByUser.lastName}`;
   const profileStatus = (await getProfileStatusService().findLocalizedById(profileData.profileStatusId, lang)).unwrap();
 
@@ -176,7 +178,7 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
   const wfaStatus = wfaStatusResult ? (wfaStatusResult.isSome() ? wfaStatusResult.unwrap() : undefined) : undefined;
   const hrAdvisor =
     profileData.employmentInformation.hrAdvisor &&
-    (await getUserService().getUserById(profileData.employmentInformation.hrAdvisor));
+    (await getUserService().getUserById(profileData.employmentInformation.hrAdvisor, context.session.authState.accessToken));
   const languageReferralTypes = profileData.referralPreferences.languageReferralTypeIds
     ?.map((langId) => allLocalizedLanguageReferralTypes.find((l) => l.id === langId))
     .filter(Boolean);

--- a/frontend/app/routes/hr-advisor/employee-profile/employment-information.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/employment-information.tsx
@@ -14,6 +14,7 @@ import { getProvinceService } from '~/.server/domain/services/province-service';
 import { getUserService } from '~/.server/domain/services/user-service';
 import { getWFAStatuses } from '~/.server/domain/services/wfa-status-service';
 import type { AuthenticatedSession } from '~/.server/utils/auth-utils';
+import { requireAuthentication } from '~/.server/utils/auth-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { InlineLink } from '~/components/links';
 import { getTranslation } from '~/i18n-config.server';
@@ -41,6 +42,9 @@ export function action({ context, params, request }: Route.ActionArgs) {
 }
 
 export async function loader({ context, request, params }: Route.LoaderArgs) {
+  const currentUrl = new URL(request.url);
+  requireAuthentication(context.session, currentUrl);
+
   // Use the id parameter from the URL to fetch the profile
   const profileUserId = params.id;
   const profileResult = await getProfileService().getProfile(profileUserId);
@@ -52,7 +56,8 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
   const provinces = await getProvinceService().listAllLocalized(lang);
   const cities = await getCityService().listAllLocalized(lang);
   const wfaStatuses = await getWFAStatuses().listAllLocalized(lang);
-  const hrAdvisors = await getUserService().getUsersByRole('hr-advisor');
+  const authenticatedSession = context.session as AuthenticatedSession;
+  const hrAdvisors = await getUserService().getUsersByRole('hr-advisor', authenticatedSession.authState.accessToken);
   const profileData: Profile = profileResult.unwrap();
 
   const workUnitResult =

--- a/frontend/tests/.server/domain/services/user-service-integration.test.ts
+++ b/frontend/tests/.server/domain/services/user-service-integration.test.ts
@@ -46,19 +46,15 @@ describe('User Service Integration', () => {
         },
       } as unknown as AuthenticatedSession;
 
-      const registeredUser = await userService.registerCurrentUser(
-        newUserData,
-        mockSession.authState.accessToken,
-        mockSession.authState.idTokenClaims,
-      );
+      const registeredUser = await userService.registerCurrentUser(newUserData, mockSession.authState.accessToken);
 
       expect(registeredUser).toMatchObject({
-        uuName: 'Test Employee',
-        networkName: 'test-employee-123',
+        uuName: 'Test User',
+        networkName: 'mock-active-directory-id',
         role: 'employee',
       });
       expect(registeredUser.id).toBeDefined();
-      expect(registeredUser.userCreated).toBe('test-employee-123');
+      expect(registeredUser.userCreated).toBe('mock-active-directory-id');
       expect(registeredUser.dateCreated).toBeDefined();
     });
 
@@ -94,15 +90,11 @@ describe('User Service Integration', () => {
         },
       } as unknown as AuthenticatedSession;
 
-      const registeredUser = await userService.registerCurrentUser(
-        newUserData,
-        mockSession.authState.accessToken,
-        mockSession.authState.idTokenClaims,
-      );
+      const registeredUser = await userService.registerCurrentUser(newUserData, mockSession.authState.accessToken);
 
       expect(registeredUser).toMatchObject({
-        uuName: 'Test Hiring Manager',
-        networkName: 'test-manager-123',
+        uuName: 'Test User',
+        networkName: 'mock-active-directory-id',
         role: 'employee',
       });
     });

--- a/frontend/tests/.server/domain/services/user-service-mock.test.ts
+++ b/frontend/tests/.server/domain/services/user-service-mock.test.ts
@@ -10,7 +10,7 @@ describe('getMockUserService', () => {
 
   describe('getUserById', () => {
     it('should return a user when given a valid ID', async () => {
-      const user = await service.getUserById(1);
+      const user = await service.getUserById(1, 'mock-access-token');
 
       expect(user).toEqual({
         id: 1,
@@ -32,7 +32,7 @@ describe('getMockUserService', () => {
     });
 
     it('should throw an error when user is not found', async () => {
-      await expect(service.getUserById(999)).rejects.toMatchObject({
+      await expect(service.getUserById(999, 'mock-access-token')).rejects.toMatchObject({
         msg: "User with ID '999' not found.",
         errorCode: ErrorCodes.VACMAN_API_ERROR,
         httpStatusCode: 500,
@@ -75,15 +75,11 @@ describe('getMockUserService', () => {
         },
       } as unknown as AuthenticatedSession;
 
-      const createdUser = await service.registerCurrentUser(
-        userData,
-        mockSession.authState.accessToken,
-        mockSession.authState.idTokenClaims,
-      );
+      const createdUser = await service.registerCurrentUser(userData, mockSession.authState.accessToken);
 
       expect(createdUser.id).toBeDefined();
       expect(createdUser.uuName).toBe('Test User');
-      expect(createdUser.networkName).toBe('test-user-123');
+      expect(createdUser.networkName).toBe('mock-active-directory-id');
       expect(createdUser.role).toBe('employee');
 
       // Check that dates are ISO strings (exact time will vary)


### PR DESCRIPTION
This pull request refactors the `UserService` interface and its implementations to simplify user retrieval and registration logic, enhance consistency, and remove unnecessary dependencies on authentication token claims. The changes affect both the default and mock user services, as well as related tests and usage across the codebase.

### User Service API Refactor

* Updated the `UserService` interface so that `getUsersByRole`, `getUserById`, and `registerCurrentUser` now require an `accessToken` parameter and no longer accept or depend on `IDTokenClaims`. This change is reflected in both the default and mock implementations. [[1]](diffhunk://#diff-0e99b214d616b21343a09e70650b4c92bb0ce12f9b3f675a1624b06c4b74e1a6L1-R10) [[2]](diffhunk://#diff-62c486944910a42d24279df0e88bb23944b577fcad66e84732377e216fd6787dR13-R65) [[3]](diffhunk://#diff-d256ef52f2d88d79c62b837de41c2e4fe3054f338c40718b5f9f08b3e3cc2112L1-R15) [[4]](diffhunk://#diff-d256ef52f2d88d79c62b837de41c2e4fe3054f338c40718b5f9f08b3e3cc2112L32-R33)

### Default User Service Implementation

* Replaced raw `fetch` calls in `user-service-default.ts` with the shared `apiClient` for all API requests, improving error handling and consistency. Error handling now unwraps errors from the API client and throws more specific messages for 404 responses.

### Mock User Service and Test Data

* Simplified mock user creation logic: removed dependency on `IDTokenClaims`, replaced dynamic values with static mock values (e.g., `fullName` is now always `'Test User'`, `activeDirectoryId` is `'mock-active-directory-id'`, and `businessEmail` is `'test.user@canada.ca'`). [[1]](diffhunk://#diff-d256ef52f2d88d79c62b837de41c2e4fe3054f338c40718b5f9f08b3e3cc2112L166-R167) [[2]](diffhunk://#diff-d256ef52f2d88d79c62b837de41c2e4fe3054f338c40718b5f9f08b3e3cc2112L181-R192)

### Test Updates

* Updated all affected tests to match the new service signatures and static mock data, ensuring that calls to user service methods now provide an `accessToken` and expect the new mock values. [[1]](diffhunk://#diff-d5b82c829c72b18e9cdaec50e4565feed533f9c317d49ab5452e586ce348e608L49-R57) [[2]](diffhunk://#diff-d5b82c829c72b18e9cdaec50e4565feed533f9c317d49ab5452e586ce348e608L97-R97) [[3]](diffhunk://#diff-77681149fe76626e80e49f1c9fe87abe4b440ebc1b26db3566410530e724b5dbL13-R13) [[4]](diffhunk://#diff-77681149fe76626e80e49f1c9fe87abe4b440ebc1b26db3566410530e724b5dbL35-R35) [[5]](diffhunk://#diff-77681149fe76626e80e49f1c9fe87abe4b440ebc1b26db3566410530e724b5dbL78-R82)

### Usage Updates

* Removed all references to `IDTokenClaims` in code that interacts with the user service, including route loaders and tests, to align with the new interface.