### PR TITLE
fix(frontend) fix broken employee profile flow

### DIFF
--- a/frontend/app/.server/domain/services/profile-service-default.ts
+++ b/frontend/app/.server/domain/services/profile-service-default.ts
@@ -183,10 +183,14 @@ export function getDefaultProfileService(): ProfileService {
       }
     },
 
-    async submitProfileForReview(activeDirectoryId: string): Promise<Result<Profile, AppError>> {
+    async submitProfileForReview(accessToken: string): Promise<Result<Profile, AppError>> {
       try {
-        const response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}/profiles/${activeDirectoryId}/submit`, {
+        const response = await fetch(`${serverEnvironment.VACMAN_API_BASE_URI}/profiles/submit`, {
           method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${accessToken}`,
+            'Content-Type': 'application/json',
+          },
         });
 
         if (!response.ok) {

--- a/frontend/app/.server/domain/services/profile-service-mock.ts
+++ b/frontend/app/.server/domain/services/profile-service-mock.ts
@@ -47,23 +47,23 @@ export function getMockProfileService(): ProfileService {
 
       return Promise.resolve(Ok(undefined));
     },
-    submitProfileForReview: (activeDirectoryId: string): Promise<Result<Profile, AppError>> => {
-      const mockProfile = getProfile(activeDirectoryId);
+    submitProfileForReview: async (accessToken: string): Promise<Result<Profile, AppError>> => {
+      const user = await getUserService().getCurrentUser(accessToken);
+      const profileOption = await getMockProfileService().getCurrentUserProfile(accessToken);
 
-      if (!mockProfile) {
-        return Promise.resolve(Err(new AppError('Profile not found', ErrorCodes.PROFILE_NOT_FOUND)));
+      if (profileOption.isNone()) {
+        return Err(new AppError(`Failed to find profile.`, ErrorCodes.PROFILE_NOT_FOUND));
       }
 
-      const userId = activeDirectoryToUserIdMap[activeDirectoryId];
-
+      const profile = profileOption.unwrap();
       const updatedProfile: Profile = {
-        ...mockProfile,
+        ...profile,
         profileStatusId: PROFILE_STATUS_ID.pending,
         dateUpdated: new Date().toISOString(),
-        userUpdated: activeDirectoryId,
+        userUpdated: user.networkName,
       };
 
-      mockProfiles = mockProfiles.map((profile) => (profile.userId === userId ? updatedProfile : profile));
+      mockProfiles = mockProfiles.map((p) => (p.profileId === profile.profileId ? updatedProfile : p));
 
       return Promise.resolve(Ok(updatedProfile));
     },
@@ -97,7 +97,7 @@ let mockProfiles: Profile[] = [
     userIdReviewedBy: undefined,
     userIdApprovedBy: undefined,
     priorityLevelId: 1,
-    profileStatusId: PROFILE_STATUS_ID.pending,
+    profileStatusId: PROFILE_STATUS_ID.incomplete,
     privacyConsentInd: true,
     userCreated: 'system',
     dateCreated: '2024-01-01T00:00:00Z',
@@ -141,7 +141,7 @@ let mockProfiles: Profile[] = [
     userIdReviewedBy: undefined,
     userIdApprovedBy: undefined,
     priorityLevelId: 2,
-    profileStatusId: PROFILE_STATUS_ID.pending,
+    profileStatusId: PROFILE_STATUS_ID.incomplete,
     privacyConsentInd: true,
     userCreated: 'system',
     dateCreated: '2024-01-01T00:00:00Z',
@@ -185,7 +185,7 @@ let mockProfiles: Profile[] = [
     userIdReviewedBy: undefined,
     userIdApprovedBy: undefined,
     priorityLevelId: 1,
-    profileStatusId: PROFILE_STATUS_ID.approved,
+    profileStatusId: PROFILE_STATUS_ID.incomplete,
     privacyConsentInd: true,
     userCreated: 'system',
     dateCreated: '2024-02-01T09:00:00Z',
@@ -229,7 +229,7 @@ let mockProfiles: Profile[] = [
     userIdReviewedBy: undefined,
     userIdApprovedBy: undefined,
     priorityLevelId: 2,
-    profileStatusId: PROFILE_STATUS_ID.pending,
+    profileStatusId: PROFILE_STATUS_ID.incomplete,
     privacyConsentInd: false,
     userCreated: 'system',
     dateCreated: '2024-03-15T08:30:00Z',
@@ -273,7 +273,7 @@ let mockProfiles: Profile[] = [
     userIdReviewedBy: undefined,
     userIdApprovedBy: undefined,
     priorityLevelId: 3,
-    profileStatusId: PROFILE_STATUS_ID.approved,
+    profileStatusId: PROFILE_STATUS_ID.incomplete,
     privacyConsentInd: true,
     userCreated: 'system',
     dateCreated: '2024-04-20T11:45:00Z',
@@ -317,7 +317,7 @@ let mockProfiles: Profile[] = [
     userIdReviewedBy: undefined,
     userIdApprovedBy: undefined,
     priorityLevelId: 1,
-    profileStatusId: PROFILE_STATUS_ID.pending,
+    profileStatusId: PROFILE_STATUS_ID.incomplete,
     privacyConsentInd: true,
     userCreated: 'system',
     dateCreated: '2024-06-01T08:00:00Z',
@@ -361,7 +361,7 @@ let mockProfiles: Profile[] = [
     userIdReviewedBy: undefined,
     userIdApprovedBy: undefined,
     priorityLevelId: 2,
-    profileStatusId: PROFILE_STATUS_ID.approved,
+    profileStatusId: PROFILE_STATUS_ID.incomplete,
     privacyConsentInd: true,
     userCreated: 'system',
     dateCreated: '2024-06-02T09:00:00Z',
@@ -449,7 +449,7 @@ let mockProfiles: Profile[] = [
     userIdReviewedBy: undefined,
     userIdApprovedBy: undefined,
     priorityLevelId: 1,
-    profileStatusId: PROFILE_STATUS_ID.approved,
+    profileStatusId: PROFILE_STATUS_ID.incomplete,
     privacyConsentInd: true,
     userCreated: 'system',
     dateCreated: '2024-06-04T11:00:00Z',
@@ -537,7 +537,7 @@ let mockProfiles: Profile[] = [
     userIdReviewedBy: undefined,
     userIdApprovedBy: undefined,
     priorityLevelId: 3,
-    profileStatusId: PROFILE_STATUS_ID.approved,
+    profileStatusId: PROFILE_STATUS_ID.incomplete,
     privacyConsentInd: false,
     userCreated: 'system',
     dateCreated: '2024-06-06T13:00:00Z',
@@ -625,7 +625,7 @@ let mockProfiles: Profile[] = [
     userIdReviewedBy: undefined,
     userIdApprovedBy: undefined,
     priorityLevelId: 2,
-    profileStatusId: PROFILE_STATUS_ID.approved,
+    profileStatusId: PROFILE_STATUS_ID.incomplete,
     privacyConsentInd: true,
     userCreated: 'system',
     dateCreated: '2024-06-08T15:00:00Z',
@@ -713,7 +713,7 @@ let mockProfiles: Profile[] = [
     userIdReviewedBy: undefined,
     userIdApprovedBy: undefined,
     priorityLevelId: 1,
-    profileStatusId: PROFILE_STATUS_ID.approved,
+    profileStatusId: PROFILE_STATUS_ID.incomplete,
     privacyConsentInd: true,
     userCreated: 'system',
     dateCreated: '2024-06-10T17:00:00Z',

--- a/frontend/app/.server/domain/services/profile-service.ts
+++ b/frontend/app/.server/domain/services/profile-service.ts
@@ -10,7 +10,7 @@ export type ProfileService = {
   getProfile(activeDirectoryId: string): Promise<Option<Profile>>;
   registerProfile(accessToken: string): Promise<Profile>;
   updateProfile(accessToken: string, profileId: string, userUpdated: string, data: Profile): Promise<Result<void, AppError>>;
-  submitProfileForReview(activeDirectoryId: string): Promise<Result<Profile, AppError>>;
+  submitProfileForReview(accessToken: string): Promise<Result<Profile, AppError>>;
   getAllProfiles(): Promise<Profile[]>;
   getCurrentUserProfile(accessToken: string): Promise<Option<Profile>>;
   getProfileById(accessToken: string, profileId: string): Promise<Option<Profile>>;

--- a/frontend/tests/.server/domain/services/profile-service-mock.test.ts
+++ b/frontend/tests/.server/domain/services/profile-service-mock.test.ts
@@ -16,7 +16,7 @@ describe('getMockProfileService', () => {
         userIdReviewedBy: undefined,
         userIdApprovedBy: undefined,
         priorityLevelId: 1,
-        profileStatusId: 1,
+        profileStatusId: 3,
         privacyConsentInd: true,
         userCreated: 'system',
         dateCreated: '2024-01-01T00:00:00Z',


### PR DESCRIPTION
## Summary

Somewhere along the way in all of this refactoring, the employee flow kind of a got a bit broken.  This PR changes the starting states of all mock profiles to be `incomplete`, since that best represents reality when there are missing required fields.  After refactoring, the currentUser became Jane Doe who has a profile status of pending approval, thus the submit for review button wasn't displayed in the UI even though she has incomplete data.   This PR also updates `submitProfileForReview` which wasn't working.  

