### PR TITLE
refactor(frontend): register profile service use api client

### DIFF
--- a/frontend/app/.server/domain/services/profile-service.ts
+++ b/frontend/app/.server/domain/services/profile-service.ts
@@ -8,7 +8,7 @@ import type { AppError } from '~/errors/app-error';
 
 export type ProfileService = {
   getProfile(activeDirectoryId: string): Promise<Option<Profile>>;
-  registerProfile(accessToken: string): Promise<Profile>;
+  registerProfile(accessToken: string): Promise<Result<Profile, AppError>>;
   updateProfile(accessToken: string, profileId: string, userUpdated: string, data: Profile): Promise<Result<void, AppError>>;
   submitProfileForReview(activeDirectoryId: string): Promise<Result<Profile, AppError>>;
   getAllProfiles(): Promise<Profile[]>;

--- a/frontend/app/routes/employee/profile/privacy-consent.tsx
+++ b/frontend/app/routes/employee/profile/privacy-consent.tsx
@@ -25,8 +25,14 @@ export async function action({ context, request }: ActionFunctionArgs) {
   const activeDirectoryId = context.session.authState.idTokenClaims.oid;
 
   // TODO move profile creation to /employee/index after user creation then use profileService.updateProfile (needs to be created first) to indicate the consent in true
-  const profile = await createUserProfile(activeDirectoryId);
+  const profileResult = await createUserProfile(activeDirectoryId);
 
+  if (profileResult.isErr()) {
+    const error = profileResult.unwrapErr();
+    throw error;
+  }
+
+  const profile = profileResult.unwrap();
   const profileService = getProfileService();
 
   const updatePrivacyConsent: Profile = {

--- a/frontend/tests/.server/utils/privacy-consent-utils.test.ts
+++ b/frontend/tests/.server/utils/privacy-consent-utils.test.ts
@@ -4,8 +4,10 @@
 import type { AppLoadContext } from 'react-router';
 import { redirect } from 'react-router';
 
+import { Ok } from 'oxide.ts';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
+import type { Profile } from '~/.server/domain/models';
 import { getProfileService } from '~/.server/domain/services/profile-service';
 import { getUserService } from '~/.server/domain/services/user-service';
 import type { AuthenticatedSession } from '~/.server/utils/auth-utils';
@@ -99,6 +101,46 @@ const mockProfileService = {
   getCurrentUserProfile: vi.fn(),
 };
 
+const mockProfile: Profile = {
+  profileId: 1,
+  userId: 1,
+  profileStatusId: 1,
+  privacyConsentInd: true,
+  userCreated: 'system',
+  dateCreated: new Date().toISOString(),
+  personalInformation: {
+    surname: 'Doe',
+    givenName: 'John',
+    personalRecordIdentifier: '123456789',
+    preferredLanguageId: undefined,
+    workEmail: 'work.email@example.ca',
+    personalEmail: 'personal.email@example.com',
+    workPhone: undefined,
+    personalPhone: '613-938-0001',
+    additionalInformation: 'Looking for opportunities in software development.',
+  },
+  employmentInformation: {
+    substantivePosition: undefined,
+    branchOrServiceCanadaRegion: undefined,
+    directorate: undefined,
+    province: undefined,
+    cityId: undefined,
+    wfaStatus: undefined,
+    wfaEffectiveDate: undefined,
+    wfaEndDate: undefined,
+    hrAdvisor: undefined,
+  },
+  referralPreferences: {
+    languageReferralTypeIds: [864190000],
+    classificationIds: [905190000, 905190001],
+    workLocationProvince: 1,
+    workLocationCitiesIds: [411290001, 411290002],
+    availableForReferralInd: true,
+    interestedInAlternationInd: false,
+    employmentTenureIds: [664190000, 664190001, 664190003],
+  },
+};
+
 vi.mocked(getProfileService).mockReturnValue(mockProfileService);
 
 const mockSafeGetUserProfile = vi.fn();
@@ -146,45 +188,7 @@ describe('Privacy Consent Flow', () => {
     // Default: no profile exists
     mockProfileService.getProfile.mockResolvedValue(null);
     // Mock createUserProfile to return a profile with profileId
-    vi.mocked(createUserProfile).mockResolvedValue({
-      profileId: 1,
-      userId: 1,
-      profileStatusId: 1,
-      privacyConsentInd: true,
-      userCreated: 'system',
-      dateCreated: new Date().toISOString(),
-      personalInformation: {
-        surname: 'Doe',
-        givenName: 'John',
-        personalRecordIdentifier: '123456789',
-        preferredLanguageId: undefined,
-        workEmail: 'work.email@example.ca',
-        personalEmail: 'personal.email@example.com',
-        workPhone: undefined,
-        personalPhone: '613-938-0001',
-        additionalInformation: 'Looking for opportunities in software development.',
-      },
-      employmentInformation: {
-        substantivePosition: undefined,
-        branchOrServiceCanadaRegion: undefined,
-        directorate: undefined,
-        province: undefined,
-        cityId: undefined,
-        wfaStatus: undefined,
-        wfaEffectiveDate: undefined,
-        wfaEndDate: undefined,
-        hrAdvisor: undefined,
-      },
-      referralPreferences: {
-        languageReferralTypeIds: [864190000],
-        classificationIds: [905190000, 905190001],
-        workLocationProvince: 1,
-        workLocationCitiesIds: [411290001, 411290002],
-        availableForReferralInd: true,
-        interestedInAlternationInd: false,
-        employmentTenureIds: [664190000, 664190001, 664190003],
-      },
-    });
+    vi.mocked(createUserProfile).mockResolvedValue(Ok(mockProfile));
     // Default: safeGetUserProfile returns null
     mockSafeGetUserProfile.mockResolvedValue(null);
   });


### PR DESCRIPTION
## Summary

[AB#6595](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6595/)
register profile service use api client

## Types of changes

What types of changes does this PR introduce?

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>