### PR TITLE
chore(frontend) update meta function to fix deprecation warning

### DIFF
--- a/frontend/app/routes/employee/index.tsx
+++ b/frontend/app/routes/employee/index.tsx
@@ -1,12 +1,14 @@
 import type { JSX } from 'react';
 
-import type { RouteHandle, LoaderFunctionArgs, ActionFunctionArgs, MetaFunction } from 'react-router';
+import type { RouteHandle, LoaderFunctionArgs, ActionFunctionArgs } from 'react-router';
 import { Form } from 'react-router';
 
 import type { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { faChevronRight, faUser } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useTranslation } from 'react-i18next';
+
+import type { Route } from './+types';
 
 import { getUserService } from '~/.server/domain/services/user-service';
 import { requireAuthentication } from '~/.server/utils/auth-utils';
@@ -22,6 +24,10 @@ import { getLanguage } from '~/utils/i18n-utils';
 export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace],
 } as const satisfies RouteHandle;
+
+export function meta({ loaderData }: Route.MetaArgs) {
+  return [{ title: loaderData?.documentTitle }];
+}
 
 export async function action({ context, request }: ActionFunctionArgs) {
   requireAuthentication(context.session, request);
@@ -72,10 +78,6 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
   const { t } = await getTranslation(request, handle.i18nNamespace);
   return { documentTitle: t('app:index.employee-dashboard') };
 }
-
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
-  return [{ title: data?.documentTitle }];
-};
 
 export default function EmployeeDashboard() {
   const { t } = useTranslation(handle.i18nNamespace);

--- a/frontend/app/routes/employee/profile/employment-information.tsx
+++ b/frontend/app/routes/employee/profile/employment-information.tsx
@@ -32,8 +32,8 @@ export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace],
 } as const satisfies RouteHandle;
 
-export function meta({ data }: Route.MetaArgs) {
-  return [{ title: data?.documentTitle }];
+export function meta({ loaderData }: Route.MetaArgs) {
+  return [{ title: loaderData?.documentTitle }];
 }
 
 export async function action({ context, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/employee/profile/index.tsx
+++ b/frontend/app/routes/employee/profile/index.tsx
@@ -37,8 +37,8 @@ export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace],
 } as const satisfies RouteHandle;
 
-export function meta({ data }: Route.MetaArgs) {
-  return [{ title: data?.documentTitle }];
+export function meta({ loaderData }: Route.MetaArgs) {
+  return [{ title: loaderData?.documentTitle }];
 }
 
 export async function action({ context, request }: Route.ActionArgs) {

--- a/frontend/app/routes/employee/profile/personal-information.tsx
+++ b/frontend/app/routes/employee/profile/personal-information.tsx
@@ -25,8 +25,8 @@ export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace],
 } as const satisfies RouteHandle;
 
-export function meta({ data }: Route.MetaArgs) {
-  return [{ title: data?.documentTitle }];
+export function meta({ loaderData }: Route.MetaArgs) {
+  return [{ title: loaderData?.documentTitle }];
 }
 
 export async function action({ context, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/employee/profile/privacy-consent.tsx
+++ b/frontend/app/routes/employee/profile/privacy-consent.tsx
@@ -1,5 +1,7 @@
-import type { RouteHandle, LoaderFunctionArgs, ActionFunctionArgs, MetaFunction } from 'react-router';
+import type { RouteHandle, LoaderFunctionArgs, ActionFunctionArgs } from 'react-router';
 import { Form } from 'react-router';
+
+import type { Route } from './+types/privacy-consent';
 
 import type { Profile } from '~/.server/domain/models';
 import { getProfileService } from '~/.server/domain/services/profile-service';
@@ -14,9 +16,9 @@ export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace],
 } as const satisfies RouteHandle;
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
-  return [{ title: data?.documentTitle }];
-};
+export function meta({ loaderData }: Route.MetaArgs) {
+  return [{ title: loaderData?.documentTitle }];
+}
 
 export async function action({ context, request }: ActionFunctionArgs) {
   requireAuthentication(context.session, request);

--- a/frontend/app/routes/employee/profile/referral-preferences.tsx
+++ b/frontend/app/routes/employee/profile/referral-preferences.tsx
@@ -28,8 +28,8 @@ export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace],
 } as const satisfies RouteHandle;
 
-export function meta({ data }: Route.MetaArgs) {
-  return [{ title: data?.documentTitle }];
+export function meta({ loaderData }: Route.MetaArgs) {
+  return [{ title: loaderData?.documentTitle }];
 }
 
 export async function action({ context, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/hiring-manager/index.tsx
+++ b/frontend/app/routes/hiring-manager/index.tsx
@@ -1,6 +1,8 @@
-import type { RouteHandle, LoaderFunctionArgs, MetaFunction } from 'react-router';
+import type { RouteHandle, LoaderFunctionArgs } from 'react-router';
 
 import { useTranslation } from 'react-i18next';
+
+import type { Route } from './+types';
 
 import { PageTitle } from '~/components/page-title';
 import { getTranslation } from '~/i18n-config.server';
@@ -10,14 +12,14 @@ export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace],
 } as const satisfies RouteHandle;
 
+export function meta({ loaderData }: Route.MetaArgs) {
+  return [{ title: loaderData?.documentTitle }];
+}
+
 export async function loader({ context, request }: LoaderFunctionArgs) {
   const { t } = await getTranslation(request, handle.i18nNamespace);
   return { documentTitle: t('app:index.hiring-manager-dashboard') };
 }
-
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
-  return [{ title: data?.documentTitle }];
-};
 
 export default function HiringManagerDashboard() {
   const { t } = useTranslation(handle.i18nNamespace);

--- a/frontend/app/routes/hr-advisor/employee-profile/employment-information.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/employment-information.tsx
@@ -24,8 +24,8 @@ export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace],
 } as const satisfies RouteHandle;
 
-export function meta({ data }: Route.MetaArgs) {
-  return [{ title: data?.documentTitle }];
+export function meta({ loaderData }: Route.MetaArgs) {
+  return [{ title: loaderData?.documentTitle }];
 }
 
 export function action({ context, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/hr-advisor/employee-profile/index.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/index.tsx
@@ -33,8 +33,8 @@ export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace],
 } as const satisfies RouteHandle;
 
-export function meta({ data }: Route.MetaArgs) {
-  return [{ title: data?.documentTitle }];
+export function meta({ loaderData }: Route.MetaArgs) {
+  return [{ title: loaderData?.documentTitle }];
 }
 
 export async function action({ context, request }: Route.ActionArgs) {

--- a/frontend/app/routes/hr-advisor/employee-profile/personal-information.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/personal-information.tsx
@@ -20,8 +20,8 @@ export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace],
 } as const satisfies RouteHandle;
 
-export function meta({ data }: Route.MetaArgs) {
-  return [{ title: data?.documentTitle }];
+export function meta({ loaderData }: Route.MetaArgs) {
+  return [{ title: loaderData?.documentTitle }];
 }
 
 export function action({ context, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/hr-advisor/employee-profile/referral-preferences.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/referral-preferences.tsx
@@ -22,8 +22,8 @@ export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace],
 } as const satisfies RouteHandle;
 
-export function meta({ data }: Route.MetaArgs) {
-  return [{ title: data?.documentTitle }];
+export function meta({ loaderData }: Route.MetaArgs) {
+  return [{ title: loaderData?.documentTitle }];
 }
 
 export function action({ context, params, request }: Route.ActionArgs) {

--- a/frontend/app/routes/hr-advisor/employees.tsx
+++ b/frontend/app/routes/hr-advisor/employees.tsx
@@ -1,13 +1,13 @@
 import type { JSX } from 'react';
 
 import { useLoaderData } from 'react-router';
-import type { RouteHandle, LoaderFunctionArgs, MetaFunction } from 'react-router';
+import type { RouteHandle, LoaderFunctionArgs } from 'react-router';
 
 import type { ColumnDef } from '@tanstack/react-table';
 import { format } from 'date-fns';
 import { useTranslation } from 'react-i18next';
 
-import type { Route } from '../+types/index';
+import type { Route } from './+types/employees';
 
 import type { Profile } from '~/.server/domain/models';
 import { getProfileService } from '~/.server/domain/services/profile-service';
@@ -24,6 +24,10 @@ import { handle as parentHandle } from '~/routes/layout';
 export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace],
 } as const satisfies RouteHandle;
+
+export function meta({ loaderData }: Route.MetaArgs) {
+  return [{ title: loaderData?.documentTitle }];
+}
 
 export async function loader({ context, request }: LoaderFunctionArgs) {
   requireAuthentication(context.session, request);
@@ -51,10 +55,6 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     statuses,
   };
 }
-
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
-  return [{ title: data?.documentTitle }];
-};
 
 export default function EmployeeDashboard({ params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespace);


### PR DESCRIPTION
## Summary

There is a deprecation warning in the `meta` functions.  The suggested remedy is to use `loaderData` instead of `data`

<img width="1066" height="270" alt="image" src="https://github.com/user-attachments/assets/e8cfad1a-7545-4a4e-9924-7a90b10b8c34" />


