### PR TITLE
refactor(frontend): move dashboard card to separate file

### DIFF
--- a/frontend/app/components/dashboard-card.tsx
+++ b/frontend/app/components/dashboard-card.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from 'react';
+import type { ComponentProps, JSX } from 'react';
 
 import type { Params } from 'react-router';
 
@@ -10,18 +10,18 @@ import { Card, CardHeader, CardIcon, CardTitle } from '~/components/card';
 import { AppLink } from '~/components/links';
 import type { I18nRouteFile } from '~/i18n-routes';
 
-interface DashboardCardProps {
+type DashboardCardProps = ComponentProps<typeof AppLink> & {
   file: I18nRouteFile;
   params?: Params;
   icon: IconProp;
   title: string;
   body?: string;
-}
+};
 
-export function DashboardCard({ file, params, icon, title, body }: DashboardCardProps): JSX.Element {
+export function DashboardCard({ file, params, icon, title, body, ...props }: DashboardCardProps): JSX.Element {
   return (
     <Card asChild className="flex cursor-pointer items-center gap-4 p-4 transition-colors hover:bg-gray-50 sm:p-6">
-      <AppLink file={file} params={params}>
+      <AppLink file={file} params={params} {...props}>
         <CardIcon icon={icon} />
         <div className="flex flex-col gap-2">
           <CardHeader asChild className="p-0">

--- a/frontend/app/components/dashboard-card.tsx
+++ b/frontend/app/components/dashboard-card.tsx
@@ -1,0 +1,42 @@
+import type { JSX } from 'react';
+
+import type { Params } from 'react-router';
+
+import type { IconProp } from '@fortawesome/fontawesome-svg-core';
+import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import { Card, CardHeader, CardIcon, CardTitle } from '~/components/card';
+import { AppLink } from '~/components/links';
+import type { I18nRouteFile } from '~/i18n-routes';
+
+interface DashboardCardProps {
+  file: I18nRouteFile;
+  params?: Params;
+  icon: IconProp;
+  title: string;
+  body?: string;
+}
+
+export function DashboardCard({ file, params, icon, title, body }: DashboardCardProps): JSX.Element {
+  return (
+    <Card asChild className="flex cursor-pointer items-center gap-4 p-4 transition-colors hover:bg-gray-50 sm:p-6">
+      <AppLink file={file} params={params}>
+        <CardIcon icon={icon} />
+        <div className="flex flex-col gap-2">
+          <CardHeader asChild className="p-0">
+            <span>
+              <CardTitle asChild className="flex items-center gap-2">
+                <span role="heading" aria-level={2}>
+                  {title}
+                  <FontAwesomeIcon icon={faChevronRight} />
+                </span>
+              </CardTitle>
+            </span>
+          </CardHeader>
+          {body && <div>{body}</div>}
+        </div>
+      </AppLink>
+    </Card>
+  );
+}

--- a/frontend/app/i18n-routes.ts
+++ b/frontend/app/i18n-routes.ts
@@ -101,9 +101,6 @@ export function isI18nPageRoute(obj: unknown): obj is I18nPageRoute {
  * be imported into clientside code without triggering side effects.
  */
 export const i18nRoutes = [
-  //
-  // Protected routes (ie: authentication required)
-  //
   {
     file: 'routes/layout.tsx',
     children: [
@@ -218,18 +215,4 @@ export const i18nRoutes = [
       },
     ],
   },
-
-  //
-  // Publicly accessable routes (ie: no authentication required)
-  //
-  // {
-  //   file: 'routes/public/layout.tsx',
-  //   children: [
-  //     {
-  //       id: 'PUBL-0001',
-  //       file: 'routes/public/index.tsx',
-  //       paths: { en: '/en/public', fr: '/fr/public' },
-  //     },
-  //   ],
-  // },
 ] as const satisfies I18nRoute[];

--- a/frontend/app/routes/employee/index.tsx
+++ b/frontend/app/routes/employee/index.tsx
@@ -64,7 +64,7 @@ export default function EmployeeDashboard({ loaderData, params }: Route.Componen
       <div className="mb-8 w-full px-4 sm:w-3/5 sm:px-6">
         <PageTitle className="after:w-14">{t('app:index.get-started')}</PageTitle>
         <div className="grid gap-4">
-          <DashboardCard file={'routes/employee/profile/index.tsx'} icon={faUser} title={t('app:profile.view')} />
+          <DashboardCard file="routes/employee/profile/index.tsx" icon={faUser} title={t('app:profile.view')} />
         </div>
       </div>
     </div>

--- a/frontend/app/routes/hr-advisor/index.tsx
+++ b/frontend/app/routes/hr-advisor/index.tsx
@@ -1,16 +1,11 @@
-import type { JSX } from 'react';
-
 import type { RouteHandle, LoaderFunctionArgs, MetaFunction } from 'react-router';
 
-import type { IconProp } from '@fortawesome/fontawesome-svg-core';
-import { faChevronRight, faUser } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faUser } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 
 import { getUserService } from '~/.server/domain/services/user-service';
 import { requireAuthentication } from '~/.server/utils/auth-utils';
-import { Card, CardHeader, CardIcon, CardTitle } from '~/components/card';
-import { AppLink } from '~/components/links';
+import { DashboardCard } from '~/components/dashboard-card';
 import { PageTitle } from '~/components/page-title';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/layout';
@@ -68,36 +63,13 @@ export default function EmployeeDashboard() {
       <div className="mb-8 w-full px-4 sm:w-3/5 sm:px-6">
         <PageTitle className="after:w-14">{t('app:hr-advisor-dashboard.page-title')}</PageTitle>
         <div className="grid gap-4">
-          <ActionCard icon={faUser} title={t('app:hr-advisor-dashboard.all-employees')} />
+          <DashboardCard
+            file="routes/hr-advisor/employees.tsx"
+            icon={faUser}
+            title={t('app:hr-advisor-dashboard.all-employees')}
+          />
         </div>
       </div>
     </div>
-  );
-}
-
-interface ActionCardProps {
-  icon: IconProp;
-  title: string;
-}
-
-function ActionCard({ icon, title }: ActionCardProps): JSX.Element {
-  return (
-    <AppLink file="routes/hr-advisor/employees.tsx">
-      <Card asChild className="flex cursor-pointer items-center gap-4 p-4 transition-colors hover:bg-gray-50 sm:p-6">
-        <button type="submit" className="w-full text-left">
-          <CardIcon icon={icon} />
-          <CardHeader asChild className="p-0">
-            <span>
-              <CardTitle asChild className="flex items-center gap-2">
-                <span role="heading" aria-level={2}>
-                  {title}
-                  <FontAwesomeIcon icon={faChevronRight} />
-                </span>
-              </CardTitle>
-            </span>
-          </CardHeader>
-        </button>
-      </Card>
-    </AppLink>
   );
 }


### PR DESCRIPTION
## Summary

As discussed in [this closed pr#292 ](https://github.com/DTS-STN/vacman/pull/292) prefer anchor tags over forms with buttons for navigation (or whatever we use for navigation since buttons are an anti-pattern and more used for onscreen events, like triggering popups, showing animations, submitting forms for input validation, etc)

The Dashboard card component is used on employee index and hr advisor index page, replacing duplicate code for ActionCard.


## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.

- [x] code has been linted and formatted locally

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>
