### PR TITLE
chore(frontend) remove id param from path in employee routes

### DIFF
--- a/frontend/app/i18n-routes.ts
+++ b/frontend/app/i18n-routes.ts
@@ -132,32 +132,32 @@ export const i18nRoutes = [
         id: 'EMPL-0003',
         file: 'routes/employee/profile/index.tsx',
         paths: {
-          en: '/en/employee/:id/profile',
-          fr: '/fr/employe/:id/profil',
+          en: '/en/employee/profile',
+          fr: '/fr/employe/profil',
         },
       },
       {
         id: 'EMPL-0004',
         file: 'routes/employee/profile/personal-information.tsx',
         paths: {
-          en: '/en/employee/:id/profile/personal-information',
-          fr: '/fr/employe/:id/profil/informations-personnelles',
+          en: '/en/employee/profile/personal-information',
+          fr: '/fr/employe/profil/informations-personnelles',
         },
       },
       {
         id: 'EMPL-0005',
         file: 'routes/employee/profile/employment-information.tsx',
         paths: {
-          en: '/en/employee/:id/profile/employment-information',
-          fr: `/fr/employe/:id/profil/informations-sur-lemploi`,
+          en: '/en/employee/profile/employment-information',
+          fr: `/fr/employe/profil/informations-sur-lemploi`,
         },
       },
       {
         id: 'EMPL-0006',
         file: 'routes/employee/profile/referral-preferences.tsx',
         paths: {
-          en: '/en/employee/:id/profile/referral-preferences',
-          fr: '/fr/employe/:id/profil/préférences-de-référence',
+          en: '/en/employee/profile/referral-preferences',
+          fr: '/fr/employe/profil/préférences-de-référence',
         },
       },
       {


### PR DESCRIPTION
## Summary
Since `/employee/profile` will be accessed directly via `getCurrentUserProfile()` which calls `/profile/me?active=true` under the hood, we don't need to include the `id` of the user in the path param since it a) isn't used, and b) can be retrieved from the returned profile.

