### PR TITLE
refactor(frontend) privacy-consent-utils

### DIFF
--- a/frontend/app/.server/utils/privacy-consent-utils.ts
+++ b/frontend/app/.server/utils/privacy-consent-utils.ts
@@ -58,10 +58,14 @@ export async function requirePrivacyConsent(session: AuthenticatedSession, curre
  * not when a hiring manager is accessing another employee's profile.
  *
  * @param session - The authenticated session
- * @param currentUrl - The current request URL for redirect context
+ * @param requestOrUrl - The current request or URL for redirect context
  * @throws {Response} Redirect to index page if user hasn't accepted privacy consent
  */
-export async function requirePrivacyConsentForOwnProfile(session: AuthenticatedSession, currentUrl: URL): Promise<void> {
+export async function requirePrivacyConsentForOwnProfile(
+  session: AuthenticatedSession,
+  requestOrUrl: Request | URL,
+): Promise<void> {
+  const currentUrl = requestOrUrl instanceof Request ? new URL(requestOrUrl.url) : requestOrUrl;
   const currentUser = await getUserService().getCurrentUser(session.authState.accessToken);
   const profileOpion = await getProfileService().getCurrentUserProfile(session.authState.accessToken);
 

--- a/frontend/app/routes/employee/profile/employment-information.tsx
+++ b/frontend/app/routes/employee/profile/employment-information.tsx
@@ -16,6 +16,7 @@ import { getProvinceService } from '~/.server/domain/services/province-service';
 import { getUserService } from '~/.server/domain/services/user-service';
 import { getWFAStatuses } from '~/.server/domain/services/wfa-status-service';
 import { requireAuthentication } from '~/.server/utils/auth-utils';
+import { requirePrivacyConsentForOwnProfile } from '~/.server/utils/privacy-consent-utils';
 import { hasEmploymentDataChanged, omitObjectProperties } from '~/.server/utils/profile-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { InlineLink } from '~/components/links';
@@ -90,6 +91,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
 
 export async function loader({ context, request, params }: Route.LoaderArgs) {
   requireAuthentication(context.session, request);
+  await requirePrivacyConsentForOwnProfile(context.session, request);
 
   const currentProfileOption = await getProfileService().getCurrentUserProfile(context.session.authState.accessToken);
 

--- a/frontend/app/routes/employee/profile/index.tsx
+++ b/frontend/app/routes/employee/profile/index.tsx
@@ -106,8 +106,8 @@ export async function action({ context, request }: Route.ActionArgs) {
 }
 
 export async function loader({ context, request, params }: Route.LoaderArgs) {
-  const currentUrl = new URL(request.url);
-  requireAuthentication(context.session, currentUrl);
+  requireAuthentication(context.session, request);
+  await requirePrivacyConsentForOwnProfile(context.session, request);
 
   const profileResult = await getProfileService().getCurrentUserProfile(context.session.authState.accessToken);
 
@@ -116,8 +116,6 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
   }
 
   const profileData: Profile = profileResult.unwrap();
-
-  await requirePrivacyConsentForOwnProfile(context.session, currentUrl);
 
   const { lang, t } = await getTranslation(request, handle.i18nNamespace);
 

--- a/frontend/app/routes/employee/profile/personal-information.tsx
+++ b/frontend/app/routes/employee/profile/personal-information.tsx
@@ -11,6 +11,7 @@ import { getLanguageForCorrespondenceService } from '~/.server/domain/services/l
 import { getProfileService } from '~/.server/domain/services/profile-service';
 import { getUserService } from '~/.server/domain/services/user-service';
 import { requireAuthentication } from '~/.server/utils/auth-utils';
+import { requirePrivacyConsentForOwnProfile } from '~/.server/utils/privacy-consent-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { InlineLink } from '~/components/links';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
@@ -78,6 +79,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
 
 export async function loader({ context, request, params }: Route.LoaderArgs) {
   requireAuthentication(context.session, request);
+  await requirePrivacyConsentForOwnProfile(context.session, request);
 
   const accessToken = context.session.authState.accessToken;
   const currentUser = await getUserService().getCurrentUser(accessToken);

--- a/frontend/app/routes/employee/profile/referral-preferences.tsx
+++ b/frontend/app/routes/employee/profile/referral-preferences.tsx
@@ -14,6 +14,7 @@ import { getLanguageReferralTypeService } from '~/.server/domain/services/langua
 import { getProfileService } from '~/.server/domain/services/profile-service';
 import { getProvinceService } from '~/.server/domain/services/province-service';
 import { requireAuthentication } from '~/.server/utils/auth-utils';
+import { requirePrivacyConsentForOwnProfile } from '~/.server/utils/privacy-consent-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { InlineLink } from '~/components/links';
 import { REQUIRE_OPTIONS } from '~/domain/constants';
@@ -83,6 +84,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
 
 export async function loader({ context, request, params }: Route.LoaderArgs) {
   requireAuthentication(context.session, request);
+  await requirePrivacyConsentForOwnProfile(context.session, request);
 
   const currentProfileOption = await getProfileService().getCurrentUserProfile(context.session.authState.accessToken);
 


### PR DESCRIPTION
## Summary

IMO, the `requirePrivacyConsentForOwnProfile()` check should be done on all loaders in `/employee/profile` in the (rare) event a user decided to navigate unconventionally via a url.  

