### PR TITLE
chore(frontend) remove unnecessary userId extraction in employee/profile routes

### DIFF
--- a/frontend/app/routes/employee/profile/employment-information.tsx
+++ b/frontend/app/routes/employee/profile/employment-information.tsx
@@ -39,8 +39,6 @@ export function meta({ loaderData }: Route.MetaArgs) {
 export async function action({ context, params, request }: Route.ActionArgs) {
   requireAuthentication(context.session, request);
 
-  // Get the current user's ID from the authenticated session
-  const currentUserId = context.session.authState.idTokenClaims.oid;
   const formData = await request.formData();
   const { parseResult, formValues } = await parseEmploymentInformation(formData, context.session.authState.accessToken);
   if (!parseResult.success) {
@@ -71,16 +69,16 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     hasEmploymentDataChanged(currentProfile.employmentInformation, parseResult.output)
   ) {
     // profile needs to be re-approved if and only if the current profile status is 'approved'
-    await profileService.submitProfileForReview(currentUserId);
+    await profileService.submitProfileForReview(context.session.authState.accessToken);
     return i18nRedirect('routes/employee/profile/index.tsx', request, {
-      params: { id: currentUserId },
+      params: { id: currentProfile.userId.toString() },
       search: new URLSearchParams({
         edited: 'true',
       }),
     });
   }
   return i18nRedirect('routes/employee/profile/index.tsx', request, {
-    params: { id: currentUserId },
+    params: { id: currentProfile.userId.toString() },
   });
 }
 

--- a/frontend/app/routes/employee/profile/index.tsx
+++ b/frontend/app/routes/employee/profile/index.tsx
@@ -44,9 +44,6 @@ export function meta({ loaderData }: Route.MetaArgs) {
 export async function action({ context, request }: Route.ActionArgs) {
   requireAuthentication(context.session, request);
 
-  // Get the current user's ID from the authenticated session
-  const currentUserId = context.session.authState.idTokenClaims.oid;
-
   const profileResult = await getProfileService().getCurrentUserProfile(context.session.authState.accessToken);
   if (profileResult.isNone()) {
     return { status: 'profile-not-found' };
@@ -94,7 +91,7 @@ export async function action({ context, request }: Route.ActionArgs) {
   }
 
   // If all complete, submit for review
-  const submitResult = await getProfileService().submitProfileForReview(currentUserId);
+  const submitResult = await getProfileService().submitProfileForReview(context.session.authState.accessToken);
   if (submitResult.isErr()) {
     throw submitResult.unwrap();
   }

--- a/frontend/app/routes/employee/profile/personal-information.tsx
+++ b/frontend/app/routes/employee/profile/personal-information.tsx
@@ -33,8 +33,6 @@ export function meta({ loaderData }: Route.MetaArgs) {
 export async function action({ context, params, request }: Route.ActionArgs) {
   requireAuthentication(context.session, request);
 
-  // Get the current user's ID from the authenticated session
-  const currentUserId = context.session.authState.idTokenClaims.oid;
   const formData = await request.formData();
   const parseResult = v.safeParse(personalInformationSchema, {
     surname: formString(formData.get('surname')),
@@ -68,7 +66,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
   }
 
   return i18nRedirect('routes/employee/profile/index.tsx', request, {
-    params: { id: currentUserId },
+    params: { id: currentProfile.userId.toString() },
   });
 }
 

--- a/frontend/app/routes/employee/profile/referral-preferences.tsx
+++ b/frontend/app/routes/employee/profile/referral-preferences.tsx
@@ -36,8 +36,6 @@ export function meta({ loaderData }: Route.MetaArgs) {
 export async function action({ context, params, request }: Route.ActionArgs) {
   requireAuthentication(context.session, request);
 
-  // Get the current user's ID from the authenticated session
-  const currentUserId = context.session.authState.idTokenClaims.oid;
   const formData = await request.formData();
   const parseResult = v.safeParse(referralPreferencesSchema, {
     languageReferralTypeIds: formData.getAll('languageReferralTypes'),
@@ -73,7 +71,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
   }
 
   return i18nRedirect('routes/employee/profile/index.tsx', request, {
-    params: { id: currentUserId },
+    params: { id: currentProfile.userId.toString() },
   });
 }
 


### PR DESCRIPTION
## Summary

The `userId` can be obtained from the current profile instead of `context.session.authState.idTokenClaims.oid`, which as Greg says, the frontend should never need to do.
