### PR TITLE
fix(employment): enhance handling of directorate and branch selection logic

### DIFF
--- a/frontend/app/routes/employee/profile/employment-information.tsx
+++ b/frontend/app/routes/employee/profile/employment-information.tsx
@@ -113,11 +113,11 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
   const profileData: Profile = currentProfileOption.unwrap();
 
   const workUnitResult =
-    profileData.employmentInformation.directorate &&
+    profileData.employmentInformation.directorate !== undefined &&
     (await getDirectorateService().findLocalizedById(profileData.employmentInformation.directorate, lang));
   const workUnit = workUnitResult && workUnitResult.isSome() ? workUnitResult.unwrap() : undefined;
   const cityResult =
-    profileData.employmentInformation.cityId &&
+    profileData.employmentInformation.cityId !== undefined &&
     (await getCityService().findLocalizedById(profileData.employmentInformation.cityId, lang));
   const city = cityResult && cityResult.isSome() ? cityResult.unwrap() : undefined;
 
@@ -125,7 +125,7 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
     documentTitle: t('app:employment-information.page-title'),
     defaultValues: {
       substantivePosition: profileData.employmentInformation.substantivePosition,
-      branchOrServiceCanadaRegion: workUnit?.parent?.id,
+      branchOrServiceCanadaRegion: workUnit?.parent?.id ?? profileData.employmentInformation.branchOrServiceCanadaRegion,
       directorate: workUnit?.id,
       province: city?.provinceTerritory.id,
       cityId: profileData.employmentInformation.cityId,

--- a/frontend/app/routes/employee/profile/index.tsx
+++ b/frontend/app/routes/employee/profile/index.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import type { Route } from '../profile/+types/index';
 
 import type { Profile } from '~/.server/domain/models';
+import { getBranchService } from '~/.server/domain/services/branch-service';
 import { getCityService } from '~/.server/domain/services/city-service';
 import { getClassificationService } from '~/.server/domain/services/classification-service';
 import { getDirectorateService } from '~/.server/domain/services/directorate-service';
@@ -156,6 +157,10 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
   const workUnitResult =
     profileData.employmentInformation.directorate !== undefined &&
     (await getDirectorateService().findLocalizedById(profileData.employmentInformation.directorate, lang));
+  const branchResult =
+    profileData.employmentInformation.branchOrServiceCanadaRegion !== undefined &&
+    !profileData.employmentInformation.directorate && // Only look up branch directly if there's no directorate
+    (await getBranchService().findLocalizedById(profileData.employmentInformation.branchOrServiceCanadaRegion, lang));
   const substantivePositionResult =
     profileData.employmentInformation.substantivePosition !== undefined &&
     (await getClassificationService().findLocalizedById(profileData.employmentInformation.substantivePosition, lang));
@@ -172,7 +177,8 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
   const substantivePosition =
     substantivePositionResult && substantivePositionResult.isSome() ? substantivePositionResult.unwrap().name : undefined;
   const branchOrServiceCanadaRegion =
-    workUnitResult && workUnitResult.isSome() ? workUnitResult.unwrap().parent?.name : undefined;
+    (workUnitResult && workUnitResult.isSome() ? workUnitResult.unwrap().parent?.name : undefined) ??
+    (branchResult && branchResult.isSome() ? branchResult.unwrap().name : undefined);
   const directorate = workUnitResult && workUnitResult.isSome() ? workUnitResult.unwrap().name : undefined;
   const city = cityResult && cityResult.isSome() ? cityResult.unwrap() : undefined;
   const wfaStatus = wfaStatusResult ? (wfaStatusResult.isSome() ? wfaStatusResult.unwrap() : undefined) : undefined;

--- a/frontend/app/routes/hr-advisor/employee-profile/employment-information.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/employment-information.tsx
@@ -116,7 +116,7 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
     documentTitle: t('app:employment-information.page-title'),
     defaultValues: {
       substantivePosition: profileData.employmentInformation.substantivePosition,
-      branchOrServiceCanadaRegion: workUnit?.parent?.id,
+      branchOrServiceCanadaRegion: workUnit?.parent?.id ?? profileData.employmentInformation.branchOrServiceCanadaRegion,
       directorate: workUnit?.id,
       province: city?.provinceTerritory.id,
       cityId: profileData.employmentInformation.cityId,

--- a/frontend/app/routes/hr-advisor/employee-profile/index.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/index.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import type { Route } from '../employee-profile/+types/index';
 
 import type { Profile } from '~/.server/domain/models';
+import { getBranchService } from '~/.server/domain/services/branch-service';
 import { getCityService } from '~/.server/domain/services/city-service';
 import { getClassificationService } from '~/.server/domain/services/classification-service';
 import { getDirectorateService } from '~/.server/domain/services/directorate-service';
@@ -84,6 +85,10 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
   const workUnitResult =
     profileData.employmentInformation.directorate !== undefined &&
     (await getDirectorateService().findLocalizedById(profileData.employmentInformation.directorate, lang));
+  const branchResult =
+    profileData.employmentInformation.branchOrServiceCanadaRegion !== undefined &&
+    !profileData.employmentInformation.directorate && // Only look up branch directly if there's no directorate
+    (await getBranchService().findLocalizedById(profileData.employmentInformation.branchOrServiceCanadaRegion, lang));
   const substantivePositionResult =
     profileData.employmentInformation.substantivePosition !== undefined &&
     (await getClassificationService().findLocalizedById(profileData.employmentInformation.substantivePosition, lang));
@@ -100,7 +105,8 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
   const substantivePosition =
     substantivePositionResult && substantivePositionResult.isSome() ? substantivePositionResult.unwrap().name : undefined;
   const branchOrServiceCanadaRegion =
-    workUnitResult && workUnitResult.isSome() ? workUnitResult.unwrap().parent?.name : undefined;
+    (workUnitResult && workUnitResult.isSome() ? workUnitResult.unwrap().parent?.name : undefined) ??
+    (branchResult && branchResult.isSome() ? branchResult.unwrap().name : undefined);
   const directorate = workUnitResult && workUnitResult.isSome() ? workUnitResult.unwrap().name : undefined;
   const city = cityResult && cityResult.isSome() ? cityResult.unwrap() : undefined;
   const wfaStatus = wfaStatusResult ? (wfaStatusResult.isSome() ? wfaStatusResult.unwrap() : undefined) : undefined;


### PR DESCRIPTION
This pull request improves how employment information is loaded and validated, especially around the relationship between branches and directorates. The changes ensure that the directorate field is only required and shown if the selected branch has child directorates, both in the frontend form and server-side validation. This results in a more accurate and user-friendly experience when editing employment information.

**Frontend logic improvements:**

* The employment information form (`form.tsx`) now checks if the selected branch has child directorates and only displays the directorate dropdown if applicable. If not, the directorate field is hidden and set to an empty value. The branch change handler also clears the directorate selection when switching to a branch with no child directorates. [[1]](diffhunk://#diff-d64dafc55e21726545c0799ed65bdf602f27c7850a2cd3224e6bbaf2ecb6c57cR63-R65) [[2]](diffhunk://#diff-d64dafc55e21726545c0799ed65bdf602f27c7850a2cd3224e6bbaf2ecb6c57cR89-R91) [[3]](diffhunk://#diff-d64dafc55e21726545c0799ed65bdf602f27c7850a2cd3224e6bbaf2ecb6c57cR111-R125) [[4]](diffhunk://#diff-d64dafc55e21726545c0799ed65bdf602f27c7850a2cd3224e6bbaf2ecb6c57cL139-R181)

**Server-side validation enhancements:**

* The employment information schema (`validation.server.ts`) now dynamically requires the directorate field only if the selected branch has child directorates. Otherwise, the directorate field is optional and accepts an empty string. The schema creation function receives the form data to determine this logic. [[1]](diffhunk://#diff-b59c3434a7afdcfb1a5d570e5ca4d54522a3d39e2155d343fdcfea330d0ca039L47-R56) [[2]](diffhunk://#diff-b59c3434a7afdcfb1a5d570e5ca4d54522a3d39e2155d343fdcfea330d0ca039L71-R99) [[3]](diffhunk://#diff-b59c3434a7afdcfb1a5d570e5ca4d54522a3d39e2155d343fdcfea330d0ca039L421-R441)

**Loader and data fetching updates:**

* In the employee and HR advisor profile loaders (`employment-information.tsx`, `index.tsx`), the branch value is now preserved if no directorate is found, and branch lookup is performed directly if there is no directorate. The branch or service Canada region field is set based on available data, ensuring correct population of form defaults. [[1]](diffhunk://#diff-ba69a87dc77db29a07b93b48dabec7c6edf88c9acbf2279422228f5192c84c7dL116-R128) [[2]](diffhunk://#diff-2127b6ea31376ff27041f2948df6180737591bdf4047ff3ae3553d9602485a7bL119-R119) [[3]](diffhunk://#diff-95bd843a205ab4d44d00d5f5db6cd1a8aef8b38bb687ec19e833f8e348068c0eR160-R163) [[4]](diffhunk://#diff-95bd843a205ab4d44d00d5f5db6cd1a8aef8b38bb687ec19e833f8e348068c0eL175-R181) [[5]](diffhunk://#diff-538f76e2da42bb7a969c1202175f44e0dd702d6a05002f4d079ad366b0468864R88-R91) [[6]](diffhunk://#diff-538f76e2da42bb7a969c1202175f44e0dd702d6a05002f4d079ad366b0468864L103-R109)

**Dependency updates:**

* The branch service is imported where needed to support direct branch lookups in profile loaders. [[1]](diffhunk://#diff-95bd843a205ab4d44d00d5f5db6cd1a8aef8b38bb687ec19e833f8e348068c0eR11) [[2]](diffhunk://#diff-538f76e2da42bb7a969c1202175f44e0dd702d6a05002f4d079ad366b0468864R11)