### PR TITLE
fix(profile): update handling of workPhone form values in personal-information

### DIFF
--- a/frontend/app/routes/employee/profile/personal-information.tsx
+++ b/frontend/app/routes/employee/profile/personal-information.tsx
@@ -56,13 +56,38 @@ export async function action({ context, params, request }: Route.ActionArgs) {
   const profileService = getProfileService();
   const currentProfileOption = await profileService.getCurrentUserProfile(context.session.authState.accessToken);
   const currentProfile = currentProfileOption.unwrap();
+
+  // Get current user for complete user update
+  const userService = getUserService();
+  const currentUserOption = await userService.getCurrentUser(context.session.authState.accessToken);
+  const currentUser = currentUserOption.isSome() ? currentUserOption.unwrap() : undefined;
+
+  // Extract workPhone for user update, remove it from profile data
+  const { workPhone, ...personalInformationForProfile } = parseResult.output;
+
+  // Update the profile (without workPhone)
   const updateResult = await profileService.updateProfileById(context.session.authState.accessToken, {
     ...currentProfile,
-    personalInformation: parseResult.output,
+    personalInformation: personalInformationForProfile,
   });
 
   if (updateResult.isErr()) {
     throw updateResult.unwrapErr();
+  }
+
+  // Update the user's businessPhone if workPhone was provided
+  if (workPhone && currentUser) {
+    const userUpdateResult = await userService.updateUser(
+      {
+        ...currentUser,
+        businessPhone: workPhone,
+      },
+      context.session.authState.accessToken,
+    );
+
+    if (userUpdateResult.isErr()) {
+      throw userUpdateResult.unwrapErr();
+    }
   }
 
   return i18nRedirect('routes/employee/profile/index.tsx', request, {
@@ -90,9 +115,9 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
       givenName: profileData.personalInformation.givenName,
       personalRecordIdentifier: profileData.personalInformation.personalRecordIdentifier,
       preferredLanguageId: profileData.personalInformation.preferredLanguageId,
-      workEmail: currentUser?.businessEmail ?? profileData.personalInformation.workPhone,
+      workEmail: currentUser?.businessEmail ?? profileData.personalInformation.workEmail,
       personalEmail: profileData.personalInformation.personalEmail,
-      workPhone: toE164(profileData.personalInformation.workPhone),
+      workPhone: toE164(currentUser?.businessPhone ?? profileData.personalInformation.workPhone),
       personalPhone: toE164(profileData.personalInformation.personalPhone),
       additionalInformation: profileData.personalInformation.additionalInformation,
     },

--- a/frontend/app/routes/employee/profile/personal-information.tsx
+++ b/frontend/app/routes/employee/profile/personal-information.tsx
@@ -117,7 +117,7 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
       preferredLanguageId: profileData.personalInformation.preferredLanguageId,
       workEmail: currentUser?.businessEmail ?? profileData.personalInformation.workEmail,
       personalEmail: profileData.personalInformation.personalEmail,
-      workPhone: toE164(currentUser?.businessPhone ?? profileData.personalInformation.workPhone),
+      workPhone: toE164(currentUser?.businessPhone),
       personalPhone: toE164(profileData.personalInformation.personalPhone),
       additionalInformation: profileData.personalInformation.additionalInformation,
     },

--- a/frontend/app/routes/employee/profile/personal-information.tsx
+++ b/frontend/app/routes/employee/profile/personal-information.tsx
@@ -80,6 +80,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     const userUpdateResult = await userService.updateUser(
       {
         ...currentUser,
+        languageId: parseResult.output.preferredLanguageId,
         businessPhone: workPhone,
       },
       context.session.authState.accessToken,

--- a/frontend/app/routes/hr-advisor/employee-profile/personal-information.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/personal-information.tsx
@@ -61,9 +61,12 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     );
   }
 
+  // Extract workPhone for user update, remove it from profile data
+  const { workPhone, ...personalInformationForProfile } = parseResult.output;
+
   const updateProfileResult = await profileService.updateProfileById(context.session.authState.accessToken, {
     ...profile,
-    personalInformation: parseResult.output,
+    personalInformation: personalInformationForProfile,
   });
 
   if (updateProfileResult.isErr()) {
@@ -80,8 +83,12 @@ export async function action({ context, params, request }: Route.ActionArgs) {
   const user = userResult.unwrap();
 
   const userUpdateResult = await userService.updateUser(
-    // only the preferredLanguage is able to be edited, everything else is readonly
-    { id: user.id, languageId: parseResult.output.preferredLanguageId },
+    // Send complete user object with updates
+    {
+      ...user,
+      languageId: parseResult.output.preferredLanguageId,
+      businessPhone: workPhone,
+    },
     context.session.authState.accessToken,
   );
 
@@ -117,9 +124,9 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
       givenName: profileData.personalInformation.givenName,
       personalRecordIdentifier: profileData.personalInformation.personalRecordIdentifier,
       preferredLanguageId: profileData.personalInformation.preferredLanguageId,
-      workEmail: currentUser?.businessEmail ?? profileData.personalInformation.workPhone,
+      workEmail: currentUser?.businessEmail ?? profileData.personalInformation.workEmail,
       personalEmail: profileData.personalInformation.personalEmail,
-      workPhone: toE164(profileData.personalInformation.workPhone),
+      workPhone: toE164(currentUser?.businessPhone ?? profileData.personalInformation.workPhone),
       personalPhone: toE164(profileData.personalInformation.personalPhone),
       additionalInformation: profileData.personalInformation.additionalInformation,
     },


### PR DESCRIPTION
This addresses this bug: [Bug 6658](https://dev.azure.com/DTS-STN/VacMan/_boards/board/t/VacMan%20Team/Stories?System.IterationPath=VacMan%5CMVP%20-%20GET%20IT%20DONE&workitem=6658)

This pull request updates how personal information, specifically work phone numbers, are managed between user and profile records in both employee and HR advisor profile flows. The main goal is to ensure that changes to work phone numbers are consistently reflected in the user's business phone field and not duplicated in the profile's personal information.

### Synchronization and Separation of Work Phone Data

* In both `employee/profile/personal-information.tsx` and `hr-advisor/employee-profile/personal-information.tsx`, the work phone (`workPhone`) is now extracted from the profile update payload and updated separately in the user's `businessPhone` field. (`[[1]](diffhunk://#diff-3c0dd5680235d9c216b798a690cf9a721be70d8eff9f6716afecda6e1e4e490fR59-R92)`, `[[2]](diffhunk://#diff-5bf328dd7f1edc86e607f2b8d9f7a7861a9876dc615afcae89a8d812a803bfccR64-R69)`, `[[3]](diffhunk://#diff-5bf328dd7f1edc86e607f2b8d9f7a7861a9876dc615afcae89a8d812a803bfccL83-R91)`)

### Loader Data Correction

* The loaders for both routes now correctly display the work email and work phone by prioritizing the user's `businessEmail` and `businessPhone` fields over the profile's fields, fixing previous mapping errors and ensuring the correct source of truth is shown on the UI. (`[[1]](diffhunk://#diff-3c0dd5680235d9c216b798a690cf9a721be70d8eff9f6716afecda6e1e4e490fL93-R120)`, `[[2]](diffhunk://#diff-5bf328dd7f1edc86e607f2b8d9f7a7861a9876dc615afcae89a8d812a803bfccL120-R129)`)