### PR TITLE
fix(frontend) profile status once profile submitted

### DIFF
--- a/frontend/app/.server/domain/services/profile-service-mock.ts
+++ b/frontend/app/.server/domain/services/profile-service-mock.ts
@@ -95,7 +95,7 @@ export function getMockProfileService(): ProfileService {
         profile.profileId.toString() === profileId
           ? {
               ...profile,
-              profileStatusId: status.id,
+              profileStatus: status,
               dateUpdated: new Date().toISOString(),
             }
           : profile,

--- a/frontend/app/routes/employee/profile/index.tsx
+++ b/frontend/app/routes/employee/profile/index.tsx
@@ -87,7 +87,6 @@ export async function action({ context, request }: Route.ActionArgs) {
       personalInfoComplete,
       employmentInfoComplete,
       referralComplete,
-      profileStatusId: 3, // Incomplete status
     };
   }
 

--- a/frontend/tests/.server/utils/privacy-consent-utils.test.ts
+++ b/frontend/tests/.server/utils/privacy-consent-utils.test.ts
@@ -172,7 +172,6 @@ describe('Privacy Consent Flow', () => {
         Some({
           profileId: 1,
           userId: 1,
-          profileStatusId: 1,
           privacyConsentInd: true,
           userCreated: 'test-user-consent',
           dateCreated: '2024-01-01T00:00:00Z',
@@ -203,7 +202,6 @@ describe('Privacy Consent Flow', () => {
         Some({
           profileId: 2,
           userId: 2,
-          profileStatusId: 1,
           privacyConsentInd: false,
           userCreated: 'test-user-no-consent',
           dateCreated: '2024-01-01T00:00:00Z',


### PR DESCRIPTION
## Summary

There were some issues with the profile status not switching to be in a "pending approval" state once it had been successfully submitted.  

<img width="1008" height="636" alt="image" src="https://github.com/user-attachments/assets/5167491d-fd1d-48c0-8018-7071ce5c8762" />

