### PR TITLE
refactor(frontend): add separate models for profile update

### DIFF
--- a/frontend/app/.server/domain/models.ts
+++ b/frontend/app/.server/domain/models.ts
@@ -176,3 +176,19 @@ export type UserReferralPreferences = {
   interestedInAlternationInd?: boolean;
   employmentTenureIds?: number[];
 };
+
+export type SaveProfile = Readonly<{
+  profileId: number;
+  userId: number;
+  userIdReviewedBy?: number;
+  userIdApprovedBy?: number;
+  priorityLevelId?: number;
+  privacyConsentInd?: boolean;
+  userCreated: string;
+  dateCreated: string;
+  userUpdated?: string;
+  dateUpdated?: string;
+  personalInformation: UserPersonalInformation;
+  employmentInformation: UserEmploymentInformation;
+  referralPreferences: UserReferralPreferences;
+}>;

--- a/frontend/app/.server/domain/services/profile-service-default.ts
+++ b/frontend/app/.server/domain/services/profile-service-default.ts
@@ -4,7 +4,7 @@ import type { Option, Result } from 'oxide.ts';
 import { apiClient } from './api-client';
 import { getProfileStatusService } from './profile-status-service';
 
-import type { Profile, ProfileStatus } from '~/.server/domain/models';
+import type { Profile, ProfileStatus, SaveProfile } from '~/.server/domain/models';
 import type { ListProfilesParams, ProfileApiResponse, ProfileService } from '~/.server/domain/services/profile-service';
 import type { ProfileStatusCode } from '~/domain/constants';
 import { AppError } from '~/errors/app-error';
@@ -131,10 +131,10 @@ export function getDefaultProfileService(): ProfileService {
      * The request sends the full Profile object in the body (PUT)
      * and expects the updated Profile in the response.
      */
-    async updateProfileById(accessToken: string, profile: Profile): Promise<Result<Profile, AppError>> {
+    async updateProfileById(accessToken: string, profile: SaveProfile): Promise<Result<Profile, AppError>> {
       const path = `/profiles/${profile.profileId}`;
 
-      const result = await apiClient.put<Profile, Profile>(path, 'update profile', profile, accessToken);
+      const result = await apiClient.put<SaveProfile, Profile>(path, 'update profile', profile, accessToken);
 
       if (result.isErr()) {
         const originalError = result.unwrapErr();

--- a/frontend/app/.server/domain/services/profile-service-mock.ts
+++ b/frontend/app/.server/domain/services/profile-service-mock.ts
@@ -4,7 +4,7 @@ import type { Result, Option } from 'oxide.ts';
 import { getProfileStatusService } from './profile-status-service';
 import { getUserService } from './user-service';
 
-import type { Profile, ProfileStatus, UserPersonalInformation } from '~/.server/domain/models';
+import type { Profile, ProfileStatus, SaveProfile, UserPersonalInformation } from '~/.server/domain/models';
 import type { ListProfilesParams, ProfileService } from '~/.server/domain/services/profile-service';
 import type { ProfileStatusCode } from '~/domain/constants';
 import {
@@ -58,7 +58,7 @@ export function getMockProfileService(): ProfileService {
 
       return Promise.resolve(None);
     },
-    updateProfileById: (accessToken: string, profile: Profile): Promise<Result<Profile, AppError>> => {
+    updateProfileById: (accessToken: string, profile: SaveProfile): Promise<Result<Profile, AppError>> => {
       const existingProfile = mockProfiles.find((p) => p.profileId === profile.profileId);
 
       if (!existingProfile) {

--- a/frontend/app/.server/domain/services/profile-service.ts
+++ b/frontend/app/.server/domain/services/profile-service.ts
@@ -1,6 +1,6 @@
 import type { Option, Result } from 'oxide.ts';
 
-import type { Profile, ProfileStatus } from '~/.server/domain/models';
+import type { Profile, ProfileStatus, SaveProfile } from '~/.server/domain/models';
 import { getDefaultProfileService } from '~/.server/domain/services/profile-service-default';
 import { getMockProfileService } from '~/.server/domain/services/profile-service-mock';
 import { serverEnvironment } from '~/.server/environment';
@@ -45,7 +45,7 @@ export type ProfileApiResponse = {
 
 export type ProfileService = {
   registerProfile(accessToken: string): Promise<Result<Profile, AppError>>;
-  updateProfileById(accessToken: string, data: Profile): Promise<Result<Profile, AppError>>;
+  updateProfileById(accessToken: string, data: SaveProfile): Promise<Result<Profile, AppError>>;
   updateProfileStatus(
     accessToken: string,
     profileId: string,


### PR DESCRIPTION
## Summary

Add separate models for profile update. as discussed with the team, the update model for profile will be same (excluding the profile status id). The Profile model will be updated separately in [task](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6626/)

## Types of changes

What types of changes does this PR introduce?

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
_(check all that apply by placing an `x` in the relevant boxes)_

- [ ] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)


