### PR TITLE
fix(profile): update handling of workPhone form values in personal-information 

### DIFF
--- a/frontend/app/routes/employee/profile/personal-information.tsx
+++ b/frontend/app/routes/employee/profile/personal-information.tsx
@@ -75,8 +75,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     throw updateResult.unwrapErr();
   }
 
-  // Update the user's businessPhone if workPhone was provided
-  if (workPhone && currentUser) {
+  if (currentUser) {
     const userUpdateResult = await userService.updateUser(
       {
         ...currentUser,

--- a/frontend/app/routes/employee/profile/personal-information.tsx
+++ b/frontend/app/routes/employee/profile/personal-information.tsx
@@ -57,13 +57,37 @@ export async function action({ context, params, request }: Route.ActionArgs) {
   const currentProfileOption = await profileService.getCurrentUserProfile(context.session.authState.accessToken);
   const currentProfile = currentProfileOption.unwrap();
 
+  // Get current user for complete user update
+  const userService = getUserService();
+  const currentUserOption = await userService.getCurrentUser(context.session.authState.accessToken);
+  const currentUser = currentUserOption.isSome() ? currentUserOption.unwrap() : undefined;
+
+  // Extract workPhone for user update, remove it from profile data
+  const { workPhone, ...personalInformationForProfile } = parseResult.output;
+
+  // Update the profile (without workPhone)
   const updateResult = await profileService.updateProfileById(context.session.authState.accessToken, {
     ...currentProfile,
-    personalInformation: parseResult.output,
+    personalInformation: personalInformationForProfile,
   });
 
   if (updateResult.isErr()) {
     throw updateResult.unwrapErr();
+  }
+
+  // Update the user's businessPhone if workPhone was provided
+  if (workPhone && currentUser) {
+    const userUpdateResult = await userService.updateUser(
+      {
+        ...currentUser,
+        businessPhone: workPhone,
+      },
+      context.session.authState.accessToken,
+    );
+
+    if (userUpdateResult.isErr()) {
+      throw userUpdateResult.unwrapErr();
+    }
   }
 
   return i18nRedirect('routes/employee/profile/index.tsx', request, {
@@ -90,10 +114,10 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
       surname: profileData.personalInformation.surname,
       givenName: profileData.personalInformation.givenName,
       personalRecordIdentifier: profileData.personalInformation.personalRecordIdentifier,
-      preferredLanguage: profileData.personalInformation.preferredLanguage,
-      workEmail: currentUser?.businessEmail ?? profileData.personalInformation.workPhone,
+      preferredLanguageId: profileData.personalInformation.preferredLanguage,
+      workEmail: currentUser?.businessEmail ?? profileData.personalInformation.workEmail,
       personalEmail: profileData.personalInformation.personalEmail,
-      workPhone: toE164(profileData.personalInformation.workPhone),
+      workPhone: toE164(currentUser?.businessPhone ?? profileData.personalInformation.workPhone),
       personalPhone: toE164(profileData.personalInformation.personalPhone),
       additionalInformation: profileData.personalInformation.additionalInformation,
     },

--- a/frontend/app/routes/employee/profile/personal-information.tsx
+++ b/frontend/app/routes/employee/profile/personal-information.tsx
@@ -117,7 +117,7 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
       preferredLanguageId: profileData.personalInformation.preferredLanguage,
       workEmail: currentUser?.businessEmail ?? profileData.personalInformation.workEmail,
       personalEmail: profileData.personalInformation.personalEmail,
-      workPhone: toE164(currentUser?.businessPhone ?? profileData.personalInformation.workPhone),
+      workPhone: toE164(currentUser?.businessPhone),
       personalPhone: toE164(profileData.personalInformation.personalPhone),
       additionalInformation: profileData.personalInformation.additionalInformation,
     },

--- a/frontend/app/routes/employee/profile/personal-information.tsx
+++ b/frontend/app/routes/employee/profile/personal-information.tsx
@@ -60,7 +60,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
   // Get current user for complete user update
   const userService = getUserService();
   const currentUserOption = await userService.getCurrentUser(context.session.authState.accessToken);
-  const currentUser = currentUserOption.isSome() ? currentUserOption.unwrap() : undefined;
+  const currentUser = currentUserOption.into();
 
   // Extract workPhone for user update, remove it from profile data
   const { workPhone, ...personalInformationForProfile } = parseResult.output;

--- a/frontend/app/routes/employee/profile/personal-information.tsx
+++ b/frontend/app/routes/employee/profile/personal-information.tsx
@@ -115,7 +115,7 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
       surname: profileData.personalInformation.surname,
       givenName: profileData.personalInformation.givenName,
       personalRecordIdentifier: profileData.personalInformation.personalRecordIdentifier,
-      preferredLanguageId: profileData.personalInformation.preferredLanguage,
+      preferredLanguage: profileData.personalInformation.preferredLanguage,
       workEmail: currentUser?.businessEmail ?? profileData.personalInformation.workEmail,
       personalEmail: profileData.personalInformation.personalEmail,
       workPhone: toE164(currentUser?.businessPhone),

--- a/frontend/app/routes/employee/profile/personal-information.tsx
+++ b/frontend/app/routes/employee/profile/personal-information.tsx
@@ -80,6 +80,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     const userUpdateResult = await userService.updateUser(
       {
         ...currentUser,
+        languageId: parseResult.output.preferredLanguageId,
         businessPhone: workPhone,
       },
       context.session.authState.accessToken,


### PR DESCRIPTION
This pull request refactors how the employee's work phone number is managed between the profile and user objects in the personal information update flows for both employees and HR advisors. The main goal is to ensure that the `workPhone` field is stored and updated in the user object (`businessPhone`), rather than the profile, and that the data shown on the frontend reflects this separation.

### Profile and User Data Separation

* When updating personal information, the `workPhone` field is extracted from the form data and instead used to update the user's `businessPhone` field. [[1]](diffhunk://#diff-3c0dd5680235d9c216b798a690cf9a721be70d8eff9f6716afecda6e1e4e490fR60-R93) [[2]](diffhunk://#diff-5bf328dd7f1edc86e607f2b8d9f7a7861a9876dc615afcae89a8d812a803bfccR64-R69)

* The user update now sends the complete user object, including the updated `businessPhone` and `languageId`, to the backend for consistency and future extensibility. [[1]](diffhunk://#diff-3c0dd5680235d9c216b798a690cf9a721be70d8eff9f6716afecda6e1e4e490fR60-R93) [[2]](diffhunk://#diff-5bf328dd7f1edc86e607f2b8d9f7a7861a9876dc615afcae89a8d812a803bfccL83-R91)

### Loader Data Consistency

* The loader logic is updated so that the displayed `workPhone` field is sourced from the user's `businessPhone`, not the profile's personal information, ensuring the frontend always shows the correct phone number. [[1]](diffhunk://#diff-3c0dd5680235d9c216b798a690cf9a721be70d8eff9f6716afecda6e1e4e490fL93-R121) [[2]](diffhunk://#diff-5bf328dd7f1edc86e607f2b8d9f7a7861a9876dc615afcae89a8d812a803bfccL119-R129)