### PR TITLE
feat(frontend) stub out hiring manager routes

### DIFF
--- a/frontend/app/i18n-routes.ts
+++ b/frontend/app/i18n-routes.ts
@@ -158,14 +158,6 @@ export const i18nRoutes = [
         },
       },
       {
-        id: 'HIRE-0001',
-        file: 'routes/hiring-manager/index.tsx', //TODO: use employee-dashboard.tsx
-        paths: {
-          en: '/en/hiring-manager',
-          fr: '/fr/gestionnaire-embauche',
-        },
-      },
-      {
         id: 'HRAD-0001',
         file: 'routes/hr-advisor/index.tsx',
         paths: {
@@ -211,6 +203,86 @@ export const i18nRoutes = [
         paths: {
           en: '/en/hr-advisor/employee-profile/referral-preferences/:profileId',
           fr: '/fr/hr-advisor/employe-profil/préférences-de-référence/:profileId',
+        },
+      },
+      {
+        id: 'HIRE-0001',
+        file: 'routes/hiring-manager/index.tsx',
+        paths: {
+          en: '/en/hiring-manager',
+          fr: '/fr/gestionnaire-embauche',
+        },
+      },
+      {
+        id: 'HIRE-0002',
+        file: 'routes/hiring-manager/requests.tsx',
+        paths: {
+          en: '/en/hiring-manager/requests',
+          fr: '/fr/gestionnaire-embauche/demandes',
+        },
+      },
+      {
+        id: 'HIRE-0003',
+        file: 'routes/hiring-manager/request/index.tsx',
+        paths: {
+          en: '/en/hiring-manager/request/:requestId',
+          fr: '/fr/gestionnaire-embauche/demande/:requestId',
+        },
+      },
+      {
+        id: 'HIRE-0004',
+        file: 'routes/hiring-manager/request/process-information.tsx',
+        paths: {
+          en: '/en/hiring-manager/request/:requestId/process-information',
+          fr: '/fr/gestionnaire-embauche/demande/:requestId/informations-processus',
+        },
+      },
+      {
+        id: 'HIRE-0005',
+        file: 'routes/hiring-manager/request/position-information.tsx',
+        paths: {
+          en: '/en/hiring-manager/request/:requestId/position-information',
+          fr: '/fr/gestionnaire-embauche/demande/:requestId/informations-poste',
+        },
+      },
+      {
+        id: 'HIRE-0006',
+        file: 'routes/hiring-manager/request/somc-conditions.tsx',
+        paths: {
+          en: '/en/hiring-manager/request/:requestId/somc-conditions',
+          fr: '/fr/gestionnaire-embauche/demande/:requestId/cmc-conditions',
+        },
+      },
+      {
+        id: 'HIRE-0007',
+        file: 'routes/hiring-manager/request/submission-details.tsx',
+        paths: {
+          en: '/en/hiring-manager/request/:requestId/submission-details',
+          fr: '/fr/gestionnaire-embauche/demande/:requestId/details-soumission',
+        },
+      },
+      {
+        id: 'HIRE-0008',
+        file: 'routes/hiring-manager/request/matches.tsx',
+        paths: {
+          en: '/en/hiring-manager/request/:requestId/matches',
+          fr: '/fr/gestionnaire-embauche/demande/:requestId/correspondances',
+        },
+      },
+      {
+        id: 'HIRE-0009',
+        file: 'routes/hiring-manager/request/profile.tsx',
+        paths: {
+          en: '/en/hiring-manager/request/:requestId/profile/:profileId',
+          fr: '/fr/gestionnaire-embauche/demande/:requestId/profil/:profileId',
+        },
+      },
+      {
+        id: 'HIRE-0010',
+        file: 'routes/hiring-manager/request/match.tsx',
+        paths: {
+          en: '/en/hiring-manager/request/:requestId/match/:profileId',
+          fr: '/fr/gestionnaire-embauche/demande/:requestId/correspondance/:profileId',
         },
       },
     ],

--- a/frontend/app/routes/hiring-manager/request/index.tsx
+++ b/frontend/app/routes/hiring-manager/request/index.tsx
@@ -1,0 +1,3 @@
+import type { Route } from './+types/index';
+
+export default function HiringManagerRequestIndex({ loaderData, params }: Route.ComponentProps) {}

--- a/frontend/app/routes/hiring-manager/request/match.tsx
+++ b/frontend/app/routes/hiring-manager/request/match.tsx
@@ -1,0 +1,3 @@
+import type { Route } from './+types/match';
+
+export default function HiringManagerRequestMatch({ loaderData, params }: Route.ComponentProps) {}

--- a/frontend/app/routes/hiring-manager/request/matches.tsx
+++ b/frontend/app/routes/hiring-manager/request/matches.tsx
@@ -1,0 +1,3 @@
+import type { Route } from './+types/matches';
+
+export default function HiringManagerRequestMatches({ loaderData, params }: Route.ComponentProps) {}

--- a/frontend/app/routes/hiring-manager/request/position-information.tsx
+++ b/frontend/app/routes/hiring-manager/request/position-information.tsx
@@ -1,0 +1,3 @@
+import type { Route } from './+types/position-information';
+
+export default function HiringManagerRequestPositionInformation({ loaderData, params }: Route.ComponentProps) {}

--- a/frontend/app/routes/hiring-manager/request/process-information.tsx
+++ b/frontend/app/routes/hiring-manager/request/process-information.tsx
@@ -1,0 +1,3 @@
+import type { Route } from './+types/process-information';
+
+export default function HiringManagerRequestProcessInformation({ loaderData, params }: Route.ComponentProps) {}

--- a/frontend/app/routes/hiring-manager/request/profile.tsx
+++ b/frontend/app/routes/hiring-manager/request/profile.tsx
@@ -1,0 +1,3 @@
+import type { Route } from './+types/profile';
+
+export default function HiringManagerRequestProfile({ loaderData, params }: Route.ComponentProps) {}

--- a/frontend/app/routes/hiring-manager/request/somc-conditions.tsx
+++ b/frontend/app/routes/hiring-manager/request/somc-conditions.tsx
@@ -1,0 +1,3 @@
+import type { Route } from './+types/somc-conditions';
+
+export default function HiringManagerRequestSomcConditions({ loaderData, params }: Route.ComponentProps) {}

--- a/frontend/app/routes/hiring-manager/request/submission-details.tsx
+++ b/frontend/app/routes/hiring-manager/request/submission-details.tsx
@@ -1,0 +1,3 @@
+import type { Route } from './+types/submission-details';
+
+export default function HiringManagerRequestSubmissionDetails({ loaderData, params }: Route.ComponentProps) {}

--- a/frontend/app/routes/hiring-manager/requests.tsx
+++ b/frontend/app/routes/hiring-manager/requests.tsx
@@ -1,0 +1,3 @@
+import type { Route } from './+types/requests';
+
+export default function HiringManagerRequests({ loaderData, params }: Route.ComponentProps) {}


### PR DESCRIPTION
## Summary
AB#6667

Adds the scaffolding to `i18n-routes.ts` and barebones boiler place for the route components.

