### PR TITLE
fix(profile): remove includeUserData from getAllProfiles parameters and query key

### DIFF
--- a/frontend/app/.server/domain/services/profile-service-default.ts
+++ b/frontend/app/.server/domain/services/profile-service-default.ts
@@ -17,10 +17,10 @@ import queryClient from '~/query-client';
  * @private
  */
 async function getAllProfiles(params: ListProfilesParams): Promise<Result<readonly (Profile | null | undefined)[], AppError>> {
-  const { accessToken, active, hrAdvisorId, includeUserData } = params;
+  const { accessToken, active, hrAdvisorId } = params;
   // The query key MUST be unique for every combination of parameters
   // to prevent cache collisions. An object ensures the key is stable.
-  const queryKey = ['profiles', 'list', { active, hrAdvisorId, includeUserData, accessToken }];
+  const queryKey = ['profiles', 'list', { active, hrAdvisorId, accessToken }];
 
   const queryFn = async (): Promise<readonly (Profile | null | undefined)[]> => {
     const searchParams = new URLSearchParams();
@@ -32,8 +32,6 @@ async function getAllProfiles(params: ListProfilesParams): Promise<Result<readon
     if (hrAdvisorId) {
       searchParams.append('hr-advisor', hrAdvisorId);
     }
-
-    searchParams.append('user-data', String(includeUserData));
 
     const queryString = searchParams.toString();
     const endpoint = `/profiles${queryString ? `?${queryString}` : ''}`;

--- a/frontend/app/.server/domain/services/profile-service-mock.ts
+++ b/frontend/app/.server/domain/services/profile-service-mock.ts
@@ -5,7 +5,7 @@ import { getMockLanguageForCorrespondenceService } from './language-for-correspo
 import { getProfileStatusService } from './profile-status-service';
 import { getUserService } from './user-service';
 
-import type { Profile, ProfileStatus, SaveProfile, UserPersonalInformation } from '~/.server/domain/models';
+import type { Profile, ProfileStatus, SaveProfile } from '~/.server/domain/models';
 import type { ListProfilesParams, ProfileService } from '~/.server/domain/services/profile-service';
 import type { ProfileStatusCode } from '~/domain/constants';
 import {
@@ -142,15 +142,6 @@ export function getMockProfileService(): ProfileService {
         filtered = filtered.filter((p) => p.employmentInformation.hrAdvisor === currentUser.unwrap().id);
       }
 
-      // Simulate 'includeUserData' transformation
-      if (params.includeUserData === false) {
-        // Return profiles without personal information.
-        filtered = filtered.map((p) => ({
-          ...p,
-          personalInformation: emptyPersonalInformation,
-        }));
-      }
-
       return Promise.resolve(filtered);
     },
     getCurrentUserProfile: async (accessToken: string) => {
@@ -175,12 +166,6 @@ export function getMockProfileService(): ProfileService {
     },
   };
 }
-
-const emptyPersonalInformation: UserPersonalInformation = {
-  workEmail: '',
-  surname: '',
-  givenName: '',
-};
 
 /**
  * Mock profile data for testing and development.

--- a/frontend/app/.server/domain/services/profile-service.ts
+++ b/frontend/app/.server/domain/services/profile-service.ts
@@ -29,13 +29,6 @@ export interface ListProfilesParams {
    * - `null` or `undefined`: Do not filter by advisor.
    */
   hrAdvisorId?: string | null;
-
-  /**
-   * Determines whether to include extended user data (names, email) in the response.
-   * - `true`: Include user data.
-   * - `false`: Do not include user data.
-   */
-  includeUserData: boolean;
 }
 
 // The expected API response structure

--- a/frontend/tests/.server/domain/services/profile-service-default.test.ts
+++ b/frontend/tests/.server/domain/services/profile-service-default.test.ts
@@ -148,7 +148,7 @@ describe('getDefaultProfileService', () => {
       const result = await profileService.listAllProfiles('mock-token', params);
 
       // Assert
-      expect(apiClient.get).toHaveBeenCalledWith('/profiles?user-data=true', 'list filtered profiles', mockAccessToken);
+      expect(apiClient.get).toHaveBeenCalledWith('/profiles', 'list filtered profiles', mockAccessToken);
       expect(apiClient.get).toHaveBeenCalledTimes(1);
 
       // Verify the final output is sanitized


### PR DESCRIPTION
This pull request makes a small change to the profile service by removing the `includeUserData` parameter from the profiles listing logic.