### PR TITLE
fix(backend): Move incomplete status to inactive set

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/ProfileService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/ProfileService.java
@@ -1,5 +1,6 @@
 package ca.gov.dtsstn.vacman.api.service;
 
+import static ca.gov.dtsstn.vacman.api.constants.AppConstants.ProfileStatusCodes.*;
 import static ca.gov.dtsstn.vacman.api.exception.ExceptionUtils.generateIdDoesNotExistException;
 import static ca.gov.dtsstn.vacman.api.security.SecurityUtils.getCurrentUserEntraId;
 
@@ -32,10 +33,10 @@ import ca.gov.dtsstn.vacman.api.web.model.ProfileReadModel;
 public class ProfileService {
 
 	/** A collection of active profile status codes. */
-	public static final Set<String> ACTIVE_PROFILE_STATUS = Set.of("APPROVED", "PENDING", "INCOMPLETE");
+	public static final Set<String> ACTIVE_PROFILE_STATUS = Set.of(APPROVED, PENDING);
 
 	/** A collection of inactive profile status codes. */
-	public static final Set<String> INACTIVE_PROFILE_STATUS = Set.of("ARCHIVED");
+	public static final Set<String> INACTIVE_PROFILE_STATUS = Set.of(INCOMPLETE, ARCHIVED);
 
 	private final ProfileRepository profileRepository;
 


### PR DESCRIPTION
## Summary

Move `INCOMPLETE` profile type to `INACTIVE` category set. Also used the values from the constants class instead of string literals.

## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
_(check all that apply by placing an `x` in the relevant boxes)_

- [ ] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>