### PR TITLE
chore(frontend) remove unused includeUserData

### DIFF
--- a/frontend/app/routes/hr-advisor/employees.tsx
+++ b/frontend/app/routes/hr-advisor/employees.tsx
@@ -41,7 +41,6 @@ export async function loader({ context, request }: Route.LoaderArgs) {
     accessToken: context.session.authState.accessToken,
     active: true, // will return In Progress, Pending Approval and Approved
     hrAdvisorId: filter === 'me' ? filter : null, // 'me' is used in the API to filter for the current HR advisor
-    includeUserData: true, // will add user data (names and email)
   };
 
   const profileService = getProfileService();

--- a/frontend/tests/.server/domain/services/profile-service-default.test.ts
+++ b/frontend/tests/.server/domain/services/profile-service-default.test.ts
@@ -138,7 +138,7 @@ describe('getDefaultProfileService', () => {
     it('should fetch, sanitize, and return profiles on success', async () => {
       // Arrange:
       vi.mocked(apiClient.get).mockResolvedValue(Ok(mockDirtyApiResponse));
-      const params = { accessToken: mockAccessToken, includeUserData: true };
+      const params = { accessToken: mockAccessToken };
 
       // Act
       const result = await profileService.listAllProfiles('mock-token', params);
@@ -156,7 +156,7 @@ describe('getDefaultProfileService', () => {
       // Arrange:
       const mockApiError = new AppError('API is down', ErrorCodes.VACMAN_API_ERROR);
       vi.mocked(apiClient.get).mockResolvedValue(Err(mockApiError));
-      const params = { accessToken: mockAccessToken, includeUserData: true };
+      const params = { accessToken: mockAccessToken };
 
       // Act & Assert
       await expect(profileService.listAllProfiles('mock-token', params)).rejects.toSatisfy((error: AppError) => {
@@ -171,7 +171,7 @@ describe('getDefaultProfileService', () => {
     it('should return Some(sanitizedProfiles) on success', async () => {
       // Arrange
       vi.mocked(apiClient.get).mockResolvedValue(Ok(mockDirtyApiResponse));
-      const params = { accessToken: mockAccessToken, includeUserData: true };
+      const params = { accessToken: mockAccessToken };
 
       // Act
       const result = await profileService.findAllProfiles('mock-token', params);
@@ -186,7 +186,7 @@ describe('getDefaultProfileService', () => {
       // Arrange
       const mockApiError = new AppError('API is down', ErrorCodes.VACMAN_API_ERROR);
       vi.mocked(apiClient.get).mockResolvedValue(Err(mockApiError));
-      const params = { accessToken: mockAccessToken, includeUserData: true };
+      const params = { accessToken: mockAccessToken };
 
       // Act
       const result = await profileService.findAllProfiles('mock-token', params);


### PR DESCRIPTION
## Summary

Since `includeUserData` was removed from the `profileParams` in the `listAllProfiles` call, it can be removed in the frontend loader and test calls.

