### PR TITLE
feat(backend) match feedback code table lookup

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/config/CacheConfig.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/config/CacheConfig.java
@@ -132,4 +132,10 @@ class CacheConfig {
 		return new CaffeineCacheFactory("work-units");
 	}
 
+	@ConfigurationProperties("application.caching.caches.match-feedback")
+	@Bean CaffeineCacheFactory matchFeedbackCache() {
+		log.info("Creating 'matchFeedbackCache' bean");
+		return new CaffeineCacheFactory("match-feedback");
+	}
+
 }

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/constants/AppConstants.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/constants/AppConstants.java
@@ -34,6 +34,7 @@ public final class AppConstants {
 		public static final String WFA_STATUSES = "wfa-statuses";
 		public static final String WORK_SCHEDULES = "work-schedules";
 		public static final String WORK_UNITS = "work-units";
+		public static final String MATCH_FEEDBACK = "match-feedback";
 
 		private CacheNames() {}
 	}

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/entity/MatchFeedbackEntity.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/entity/MatchFeedbackEntity.java
@@ -1,0 +1,43 @@
+package ca.gov.dtsstn.vacman.api.data.entity;
+
+import java.time.Instant;
+
+import org.immutables.builder.Builder;
+import org.springframework.core.style.ToStringCreator;
+
+import jakarta.annotation.Nullable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity(name = "MatchFeedback")
+@Table(name = "[CD_MATCH_FEEDBACK]", uniqueConstraints = { @UniqueConstraint(name = "MTCHFDBCK_UK", columnNames = "[MATCH_FEEDBACK_NAME_EN]") })
+public class MatchFeedbackEntity extends AbstractCodeEntity {
+
+	public MatchFeedbackEntity() {
+		super();
+	}
+
+	@Builder.Constructor
+	public MatchFeedbackEntity(
+			@Nullable Long id,
+			@Nullable String code,
+			@Nullable String nameEn,
+			@Nullable String nameFr,
+			@Nullable Instant effectiveDate,
+			@Nullable Instant expiryDate,
+			@Nullable String createdBy,
+			@Nullable Instant createdDate,
+			@Nullable String lastModifiedBy,
+			@Nullable Instant lastModifiedDate) {
+		super(id, code, nameEn, nameFr, effectiveDate, expiryDate, createdBy, createdDate, lastModifiedBy, lastModifiedDate);
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringCreator(this)
+			.append("super", super.toString())
+			.toString();
+	}
+
+}

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/entity/RequestEntity.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/entity/RequestEntity.java
@@ -15,6 +15,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
 @Entity(name = "Request")
@@ -144,6 +145,11 @@ public class RequestEntity extends AbstractBaseEntity {
 	@JoinColumn(name = "[WORK_UNIT_ID]", nullable = false)
 	private WorkUnitEntity workUnit;
 
+	// TODO this actually belongs in the MatchEntity (not yet created)
+	@OneToOne
+	@JoinColumn(name = "[MATCH_FEEDBACK_ID]", nullable = false)
+	private MatchFeedbackEntity matchFeedback;
+
 	public RequestEntity() {
 		super();
 	}
@@ -185,6 +191,7 @@ public class RequestEntity extends AbstractBaseEntity {
 			@Nullable Boolean workforceMgmtApprovalRecvd,
 			@Nullable WorkScheduleEntity workSchedule,
 			@Nullable WorkUnitEntity workUnit,
+			@Nullable MatchFeedbackEntity matchFeedback,
 			@Nullable String createdBy,
 			@Nullable Instant createdDate,
 			@Nullable String lastModifiedBy,
@@ -224,6 +231,7 @@ public class RequestEntity extends AbstractBaseEntity {
 		this.workforceMgmtApprovalRecvd = workforceMgmtApprovalRecvd;
 		this.workSchedule = workSchedule;
 		this.workUnit = workUnit;
+		this.matchFeedback = matchFeedback;
 	}
 
 	public String getAdditionalComment() {
@@ -510,6 +518,14 @@ public class RequestEntity extends AbstractBaseEntity {
 		this.workUnit = workUnit;
 	}
 
+	public MatchFeedbackEntity getMatchFeedback() {
+		return matchFeedback;
+	}
+
+	public void setMatchFeedback(MatchFeedbackEntity matchFeedback) {
+		this.matchFeedback = matchFeedback;
+	}
+
 	@Override
 	public String toString() {
 		return new ToStringCreator(this)
@@ -550,6 +566,7 @@ public class RequestEntity extends AbstractBaseEntity {
 			.append("workforceMgmtApprovalRecvd", workforceMgmtApprovalRecvd)
 			.append("workSchedule", workSchedule)
 			.append("workUnit", workUnit)
+			.append("matchFeedback", matchFeedback)
 			.toString();
 	}
 }

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/repository/MatchFeedbackRepository.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/repository/MatchFeedbackRepository.java
@@ -1,0 +1,8 @@
+package ca.gov.dtsstn.vacman.api.data.repository;
+
+import org.springframework.stereotype.Repository;
+
+import ca.gov.dtsstn.vacman.api.data.entity.MatchFeedbackEntity;
+
+@Repository
+public interface MatchFeedbackRepository extends AbstractBaseRepository<MatchFeedbackEntity> {}

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/CodeService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/CodeService.java
@@ -26,6 +26,7 @@ import ca.gov.dtsstn.vacman.api.data.entity.UserTypeEntity;
 import ca.gov.dtsstn.vacman.api.data.entity.WfaStatusEntity;
 import ca.gov.dtsstn.vacman.api.data.entity.WorkScheduleEntity;
 import ca.gov.dtsstn.vacman.api.data.entity.WorkUnitEntity;
+import ca.gov.dtsstn.vacman.api.data.entity.MatchFeedbackEntity;
 import ca.gov.dtsstn.vacman.api.data.repository.CityRepository;
 import ca.gov.dtsstn.vacman.api.data.repository.ClassificationRepository;
 import ca.gov.dtsstn.vacman.api.data.repository.EmploymentEquityRepository;
@@ -45,6 +46,7 @@ import ca.gov.dtsstn.vacman.api.data.repository.UserTypeRepository;
 import ca.gov.dtsstn.vacman.api.data.repository.WfaStatusRepository;
 import ca.gov.dtsstn.vacman.api.data.repository.WorkScheduleRepository;
 import ca.gov.dtsstn.vacman.api.data.repository.WorkUnitRepository;
+import ca.gov.dtsstn.vacman.api.data.repository.MatchFeedbackRepository;
 
 /**
  * Service class for retrieving code table values.
@@ -93,6 +95,8 @@ public class CodeService {
 
 	private final WorkUnitRepository workUnitRepository;
 
+	private final MatchFeedbackRepository matchFeedbackRepository;
+
 	public CodeService(
 			CityRepository cityRepository,
 			ClassificationRepository classificationRepository,
@@ -112,7 +116,8 @@ public class CodeService {
 			UserTypeRepository userTypeRepository,
 			WfaStatusRepository wfaStatusRepository,
 			WorkScheduleRepository workScheduleRepository,
-			WorkUnitRepository workUnitRepository) {
+			WorkUnitRepository workUnitRepository,
+			MatchFeedbackRepository matchFeedbackRepository) {
 		this.cityRepository = cityRepository;
 		this.classificationRepository = classificationRepository;
 		this.employmentEquityRepository = employmentEquityRepository;
@@ -132,6 +137,7 @@ public class CodeService {
 		this.wfaStatusRepository = wfaStatusRepository;
 		this.workScheduleRepository = workScheduleRepository;
 		this.workUnitRepository = workUnitRepository;
+		this.matchFeedbackRepository = matchFeedbackRepository;
 	}
 
 	/**
@@ -341,6 +347,18 @@ public class CodeService {
  @Cacheable(cacheNames = { AppConstants.CacheNames.WORK_UNITS })
 	public Page<WorkUnitEntity> getWorkUnits(Pageable pageable) {
 		return workUnitRepository.findAll(pageable);
+
+	}
+	
+	/**
+	 * Retrieves a paginated list of match feedback.
+	 *
+	 * @param pageable pagination information
+	 * @return a page of {@link MatchFeedbackEntity} objects
+	 */
+ @Cacheable(cacheNames = { AppConstants.CacheNames.MATCH_FEEDBACK })
+	public Page<MatchFeedbackEntity> getMatchFeedback(Pageable pageable) {
+		return matchFeedbackRepository.findAll(pageable);
 	}
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/CodesController.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/CodesController.java
@@ -29,6 +29,7 @@ import ca.gov.dtsstn.vacman.api.web.model.UserTypeReadModel;
 import ca.gov.dtsstn.vacman.api.web.model.WfaStatusReadModel;
 import ca.gov.dtsstn.vacman.api.web.model.WorkScheduleReadModel;
 import ca.gov.dtsstn.vacman.api.web.model.WorkUnitReadModel;
+import ca.gov.dtsstn.vacman.api.web.model.MatchFeedbackReadModel;
 import ca.gov.dtsstn.vacman.api.web.model.mapper.CodeModelMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -255,4 +256,14 @@ public class CodesController {
 		return new CollectionModel<>(workUnits);
 	}
 
+	@PreAuthorize("permitAll()")
+	@GetMapping({ "/match-feedback" })
+	@Operation(summary = "Get all match feedback codes")
+	public CollectionModel<MatchFeedbackReadModel> getMatchFeedback() {
+		final var matchFeedback = codeService.getMatchFeedback(Pageable.unpaged())
+			.map(codeMapper::map)
+			.toList();
+
+		return new CollectionModel<>(matchFeedback);
+	}
 }

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/model/MatchFeedbackReadModel.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/model/MatchFeedbackReadModel.java
@@ -1,0 +1,6 @@
+package ca.gov.dtsstn.vacman.api.web.model;
+
+import org.immutables.value.Value.Immutable;
+
+@Immutable
+public interface MatchFeedbackReadModel extends CodeReadModel {}

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/model/mapper/CodeModelMapper.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/model/mapper/CodeModelMapper.java
@@ -22,6 +22,7 @@ import ca.gov.dtsstn.vacman.api.data.entity.UserTypeEntity;
 import ca.gov.dtsstn.vacman.api.data.entity.WfaStatusEntity;
 import ca.gov.dtsstn.vacman.api.data.entity.WorkScheduleEntity;
 import ca.gov.dtsstn.vacman.api.data.entity.WorkUnitEntity;
+import ca.gov.dtsstn.vacman.api.data.entity.MatchFeedbackEntity;
 import ca.gov.dtsstn.vacman.api.web.model.CityReadModel;
 import ca.gov.dtsstn.vacman.api.web.model.ClassificationReadModel;
 import ca.gov.dtsstn.vacman.api.web.model.EmploymentEquityReadModel;
@@ -41,6 +42,7 @@ import ca.gov.dtsstn.vacman.api.web.model.UserTypeReadModel;
 import ca.gov.dtsstn.vacman.api.web.model.WfaStatusReadModel;
 import ca.gov.dtsstn.vacman.api.web.model.WorkScheduleReadModel;
 import ca.gov.dtsstn.vacman.api.web.model.WorkUnitReadModel;
+import ca.gov.dtsstn.vacman.api.web.model.MatchFeedbackReadModel;
 
 @Mapper(nullValueMappingStrategy = NullValueMappingStrategy.RETURN_NULL)
 public interface CodeModelMapper {
@@ -83,4 +85,5 @@ public interface CodeModelMapper {
 
 	WorkUnitReadModel map(WorkUnitEntity entity);
 
+	MatchFeedbackReadModel map(MatchFeedbackEntity entity);
 }

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/validator/MatchFeedbackCodeValidator.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/validator/MatchFeedbackCodeValidator.java
@@ -1,0 +1,33 @@
+package ca.gov.dtsstn.vacman.api.web.validator;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import ca.gov.dtsstn.vacman.api.service.CodeService;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+@Component
+public class MatchFeedbackCodeValidator implements ConstraintValidator<ValidMatchFeedbackCode, Long> {
+
+	private final CodeService codeService;
+
+	public MatchFeedbackCodeValidator(CodeService codeService) {
+		this.codeService = codeService;
+	}
+
+	@Override
+	public void initialize(ValidMatchFeedbackCode constraintAnnotation) {
+		// No initialization needed
+	}
+
+	@Override
+	public boolean isValid(Long matchFeedbackId, ConstraintValidatorContext context) {
+		if (matchFeedbackId == null) { return true; }
+
+		return codeService.getMatchFeedback(Pageable.unpaged()).stream()
+			.filter(matchFeedback -> matchFeedback.getId().equals(matchFeedbackId))
+			.findFirst().isPresent();
+	}
+
+}

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/validator/ValidMatchFeedbackCode.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/validator/ValidMatchFeedbackCode.java
@@ -1,0 +1,24 @@
+package ca.gov.dtsstn.vacman.api.web.validator;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE_USE })
+@Constraint(validatedBy = MatchFeedbackCodeValidator.class)
+public @interface ValidMatchFeedbackCode {
+
+	String message() default "Match feedback does not exist";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+
+}

--- a/backend/src/test/java/ca/gov/dtsstn/vacman/api/service/CodeServiceTest.java
+++ b/backend/src/test/java/ca/gov/dtsstn/vacman/api/service/CodeServiceTest.java
@@ -34,6 +34,7 @@ import ca.gov.dtsstn.vacman.api.data.entity.UserTypeEntityBuilder;
 import ca.gov.dtsstn.vacman.api.data.entity.WfaStatusEntityBuilder;
 import ca.gov.dtsstn.vacman.api.data.entity.WorkScheduleEntityBuilder;
 import ca.gov.dtsstn.vacman.api.data.entity.WorkUnitEntityBuilder;
+import ca.gov.dtsstn.vacman.api.data.entity.MatchFeedbackEntityBuilder;
 import ca.gov.dtsstn.vacman.api.data.repository.CityRepository;
 import ca.gov.dtsstn.vacman.api.data.repository.ClassificationRepository;
 import ca.gov.dtsstn.vacman.api.data.repository.EmploymentEquityRepository;
@@ -53,6 +54,7 @@ import ca.gov.dtsstn.vacman.api.data.repository.UserTypeRepository;
 import ca.gov.dtsstn.vacman.api.data.repository.WfaStatusRepository;
 import ca.gov.dtsstn.vacman.api.data.repository.WorkScheduleRepository;
 import ca.gov.dtsstn.vacman.api.data.repository.WorkUnitRepository;
+import ca.gov.dtsstn.vacman.api.data.repository.MatchFeedbackRepository;
 
 @DisplayName("CodeService tests")
 @ExtendWith({ MockitoExtension.class })
@@ -114,6 +116,9 @@ class CodeServiceTest {
 
 	@Mock
 	WorkUnitRepository workUnitRepository;
+	
+	@Mock
+	MatchFeedbackRepository matchFeedbackRepository;
 
 	@InjectMocks
 	CodeService codeService;
@@ -363,6 +368,19 @@ class CodeServiceTest {
 		assertNotNull(result);
 		assertEquals(1, result.getTotalElements());
 		assertEquals(new WorkUnitEntityBuilder().code("TEST_WU").build(), result.getContent().getFirst());
+	}
+	
+	@Test
+	@DisplayName("getMatchFeedback() returns a page of match feedback")
+	void getMatchFeedbackReturnsPageOfMatchFeedback() {
+		when(matchFeedbackRepository.findAll(Pageable.unpaged()))
+			.thenReturn(new PageImpl<>(List.of(new MatchFeedbackEntityBuilder().code("TEST_MF").build())));
+
+		final var result = codeService.getMatchFeedback(Pageable.unpaged());
+
+		assertNotNull(result);
+		assertEquals(1, result.getTotalElements());
+		assertEquals(new MatchFeedbackEntityBuilder().code("TEST_MF").build(), result.getContent().getFirst());
 	}
 
 }

--- a/backend/src/test/java/ca/gov/dtsstn/vacman/api/web/CodesControllerTest.java
+++ b/backend/src/test/java/ca/gov/dtsstn/vacman/api/web/CodesControllerTest.java
@@ -41,6 +41,7 @@ import ca.gov.dtsstn.vacman.api.data.entity.UserTypeEntityBuilder;
 import ca.gov.dtsstn.vacman.api.data.entity.WfaStatusEntityBuilder;
 import ca.gov.dtsstn.vacman.api.data.entity.WorkScheduleEntityBuilder;
 import ca.gov.dtsstn.vacman.api.data.entity.WorkUnitEntityBuilder;
+import ca.gov.dtsstn.vacman.api.data.entity.MatchFeedbackEntityBuilder;
 import ca.gov.dtsstn.vacman.api.service.CodeService;
 
 @ActiveProfiles({ "test" })
@@ -643,4 +644,33 @@ class CodesControllerTest {
 			.andExpect(jsonPath("$.content[0].lastModifiedDate").value(workUnit.getLastModifiedDate().toString()));
 	}
 
+	@Test
+	@WithAnonymousUser
+	@DisplayName("GET /codes/match-feeback - Should return 200 OK with a page of match feedback")
+	void getMatchFeedback_shouldReturnOk() throws Exception {
+		final var matchFeedback = new MatchFeedbackEntityBuilder()
+			.id(0L)
+			.code("TEST")
+			.nameEn("Test Match Feedback")
+			.nameFr("Commentaires de test")
+			.createdBy("TestUser")
+			.createdDate(Instant.EPOCH)
+			.lastModifiedBy("TestUser")
+			.lastModifiedDate(Instant.EPOCH)
+			.build();
+
+		when(codeService.getMatchFeedback(Pageable.unpaged())).thenReturn(new PageImpl<>(List.of(matchFeedback)));
+
+		mockMvc.perform(get("/api/v1/codes/match-feedback"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.content", hasSize(1)))
+			.andExpect(jsonPath("$.content[0].id").value(matchFeedback.getId()))
+			.andExpect(jsonPath("$.content[0].code").value(matchFeedback.getCode()))
+			.andExpect(jsonPath("$.content[0].nameEn").value(matchFeedback.getNameEn()))
+			.andExpect(jsonPath("$.content[0].nameFr").value(matchFeedback.getNameFr()))
+			.andExpect(jsonPath("$.content[0].createdBy").value(matchFeedback.getCreatedBy()))
+			.andExpect(jsonPath("$.content[0].createdDate").value(matchFeedback.getCreatedDate().toString()))
+			.andExpect(jsonPath("$.content[0].lastModifiedBy").value(matchFeedback.getLastModifiedBy()))
+			.andExpect(jsonPath("$.content[0].lastModifiedDate").value(matchFeedback.getLastModifiedDate().toString()));
+	}
 }

--- a/backend/src/test/java/ca/gov/dtsstn/vacman/api/web/validator/MatchFeedbackCodeValidatorTest.java
+++ b/backend/src/test/java/ca/gov/dtsstn/vacman/api/web/validator/MatchFeedbackCodeValidatorTest.java
@@ -1,0 +1,54 @@
+package ca.gov.dtsstn.vacman.api.web.validator;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import ca.gov.dtsstn.vacman.api.data.entity.MatchFeedbackEntityBuilder;
+import ca.gov.dtsstn.vacman.api.service.CodeService;
+
+@ExtendWith({ MockitoExtension.class })
+@DisplayName("MatchFeedbackCodeValidator tests")
+class MatchFeedbackCodeValidatorTest {
+
+	@Mock
+	CodeService codeService;
+
+	@InjectMocks
+	MatchFeedbackCodeValidator matchFeedbackCodeValidator;
+
+	@Test
+	@DisplayName("isValid() returns true when match feedback code is null")
+	void isValidReturnsTrueWhenMatchFeedbackCodeIsNull() {
+		assertTrue(matchFeedbackCodeValidator.isValid(null, null));
+	}
+
+	@Test
+	@DisplayName("isValid() returns true when match feedback code is valid")
+	void isValidReturnsTrueWhenMatchFeedbackCodeIsValid() {
+		when(codeService.getMatchFeedback(Pageable.unpaged()))
+			.thenReturn(new PageImpl<>(List.of(new MatchFeedbackEntityBuilder().id(0L).build())));
+
+		assertTrue(matchFeedbackCodeValidator.isValid(0L, null));
+	}
+
+	@Test
+	@DisplayName("isValid() returns false when match feedback code is invalid")
+	void isValidReturnsFalseWhenMatchFeedbackCodeIsInvalid() {
+		when(codeService.getMatchFeedback(Pageable.unpaged())).thenReturn(Page.empty());
+		assertFalse(matchFeedbackCodeValidator.isValid(0L, null));
+	}
+
+}


### PR DESCRIPTION
## Summary

Converting to draft.  

```java
	@OneToOne
	@JoinColumn(name = "[MATCH_FEEDBACK_ID]", nullable = false)
	private MatchFeedbackEntity matchFeedback;
```

belong on the `MatchEntity` which hasn't been created yet.

Preface: I'm not a springboot guy.  This is very much monkey-see-monkey-do.  This PR adds Match Feedback domain code for the backend CodeService.

## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

