### PR TITLE
refactor(backend): Overhaul PUT /profiles/{id}

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/entity/ClassificationProfileEntity.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/entity/ClassificationProfileEntity.java
@@ -1,6 +1,7 @@
 package ca.gov.dtsstn.vacman.api.data.entity;
 
 import java.time.Instant;
+import java.util.Objects;
 
 import org.immutables.builder.Builder;
 import org.springframework.core.style.ToStringCreator;
@@ -65,6 +66,25 @@ public class ClassificationProfileEntity extends AbstractBaseEntity {
 			.append("classification", classification)
 			.append("profile", profile)
 			.toString();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+
+		if (!(obj instanceof ClassificationProfileEntity that)) {
+			return false;
+		}
+
+		return Objects.equals(this.profile, that.profile) && Objects.equals(this.classification, that.classification);
+
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(profile, classification);
 	}
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/entity/ProfileCityEntity.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/entity/ProfileCityEntity.java
@@ -1,6 +1,7 @@
 package ca.gov.dtsstn.vacman.api.data.entity;
 
 import java.time.Instant;
+import java.util.Objects;
 
 import org.immutables.builder.Builder;
 import org.springframework.core.style.ToStringCreator;
@@ -67,4 +68,22 @@ public class ProfileCityEntity extends AbstractBaseEntity {
 			.toString();
 	}
 
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+
+		if (!(obj instanceof ProfileCityEntity that)) {
+			return false;
+		}
+
+        return Objects.equals(this.profile, that.profile) && Objects.equals(this.city, that.city);
+
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(profile, city);
+	}
 }

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/entity/ProfileEmploymentOpportunityEntity.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/entity/ProfileEmploymentOpportunityEntity.java
@@ -1,6 +1,7 @@
 package ca.gov.dtsstn.vacman.api.data.entity;
 
 import java.time.Instant;
+import java.util.Objects;
 
 import org.immutables.builder.Builder;
 import org.springframework.core.style.ToStringCreator;
@@ -65,6 +66,25 @@ public class ProfileEmploymentOpportunityEntity extends AbstractBaseEntity {
 				.append("employmentOpportunity", employmentOpportunity)
 				.append("profile", profile)
 				.toString();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+
+		if (!(obj instanceof ProfileEmploymentOpportunityEntity that)) {
+			return false;
+		}
+
+		return Objects.equals(this.profile, that.profile) && Objects.equals(this.employmentOpportunity, that.employmentOpportunity);
+
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(profile, employmentOpportunity);
 	}
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/entity/ProfileLanguageReferralTypeEntity.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/entity/ProfileLanguageReferralTypeEntity.java
@@ -1,6 +1,7 @@
 package ca.gov.dtsstn.vacman.api.data.entity;
 
 import java.time.Instant;
+import java.util.Objects;
 
 import org.immutables.builder.Builder;
 import org.springframework.core.style.ToStringCreator;
@@ -65,6 +66,25 @@ public class ProfileLanguageReferralTypeEntity extends AbstractBaseEntity {
 			.append("languageReferralType", languageReferralType)
 			.append("profile", profile)
 			.toString();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+
+		if (!(obj instanceof ProfileLanguageReferralTypeEntity that)) {
+			return false;
+		}
+
+		return Objects.equals(this.profile, that.profile) && Objects.equals(this.languageReferralType, that.languageReferralType);
+
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(profile, languageReferralType);
 	}
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/ProfileService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/ProfileService.java
@@ -3,30 +3,24 @@ package ca.gov.dtsstn.vacman.api.service;
 import static ca.gov.dtsstn.vacman.api.exception.ExceptionUtils.generateIdDoesNotExistException;
 import static ca.gov.dtsstn.vacman.api.security.SecurityUtils.getCurrentUserEntraId;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import ca.gov.dtsstn.vacman.api.data.entity.*;
+import ca.gov.dtsstn.vacman.api.data.repository.*;
+import ca.gov.dtsstn.vacman.api.web.exception.ResourceConflictException;
+import ca.gov.dtsstn.vacman.api.web.model.ProfilePutModel;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
-import ca.gov.dtsstn.vacman.api.data.entity.ProfileEntity;
-import ca.gov.dtsstn.vacman.api.data.entity.ProfileEntityBuilder;
-import ca.gov.dtsstn.vacman.api.data.entity.UserEntity;
-import ca.gov.dtsstn.vacman.api.data.repository.ClassificationRepository;
-import ca.gov.dtsstn.vacman.api.data.repository.ProfileRepository;
-import ca.gov.dtsstn.vacman.api.data.repository.ProfileStatusRepository;
-import ca.gov.dtsstn.vacman.api.data.repository.WfaStatusRepository;
-import ca.gov.dtsstn.vacman.api.data.repository.WorkUnitRepository;
 import ca.gov.dtsstn.vacman.api.event.ProfileCreateEvent;
 import ca.gov.dtsstn.vacman.api.event.ProfileReadEvent;
 import ca.gov.dtsstn.vacman.api.event.ProfileStatusChangeEvent;
 import ca.gov.dtsstn.vacman.api.event.ProfileUpdatedEvent;
 import ca.gov.dtsstn.vacman.api.web.exception.ResourceNotFoundException;
-import ca.gov.dtsstn.vacman.api.web.model.ProfileReadModel;
 
 @Service
 public class ProfileService {
@@ -39,9 +33,15 @@ public class ProfileService {
 
 	private final ProfileRepository profileRepository;
 
+	private final LanguageRepository languageRepository;
+
 	private final ClassificationRepository classificationRepository;
 
+	private final CityRepository cityRepository;
+
 	private final ProfileStatusRepository profileStatusRepository;
+
+	private final EmploymentOpportunityRepository employmentOpportunityRepository;
 
 	private final ApplicationEventPublisher eventPublisher;
 
@@ -51,6 +51,8 @@ public class ProfileService {
 
 	private final WorkUnitRepository workUnitRepository;
 
+	private final LanguageReferralTypeRepository languageReferralTypeRepository;
+
 	// Keys are tied to the potential values of getProfilesByStatusAndHrId parameter isActive.
 	private static final Map<Boolean, Set<String>> profileStatusSets = Map.of(
 		Boolean.TRUE, ACTIVE_PROFILE_STATUS,
@@ -58,19 +60,23 @@ public class ProfileService {
 	);
 
 	public ProfileService(ClassificationRepository classificationRepository,
-			ProfileRepository profileRepository,
-			ProfileStatusRepository profileStatusRepository,
-			UserService userService, WfaStatusRepository wfaStatusRepository,
-			WorkUnitRepository workUnitRepository,
-			ApplicationEventPublisher eventPublisher) {
+                          ProfileRepository profileRepository, LanguageRepository languageRepository, CityRepository cityRepository,
+                          ProfileStatusRepository profileStatusRepository, EmploymentOpportunityRepository employmentOpportunityRepository,
+                          UserService userService, WfaStatusRepository wfaStatusRepository,
+                          WorkUnitRepository workUnitRepository,
+                          ApplicationEventPublisher eventPublisher, LanguageReferralTypeRepository languageReferralTypeRepository) {
 		this.classificationRepository = classificationRepository;
 		this.profileRepository = profileRepository;
-		this.profileStatusRepository = profileStatusRepository;
-		this.userService = userService;
+        this.languageRepository = languageRepository;
+        this.cityRepository = cityRepository;
+        this.profileStatusRepository = profileStatusRepository;
+        this.employmentOpportunityRepository = employmentOpportunityRepository;
+        this.userService = userService;
 		this.wfaStatusRepository = wfaStatusRepository;
 		this.workUnitRepository = workUnitRepository;
 		this.eventPublisher = eventPublisher;
-	}
+        this.languageReferralTypeRepository = languageReferralTypeRepository;
+    }
 
 	/**
 	 * Returns all profiles that are either "active" or "inactive" depending on the argument value. Optionally,
@@ -183,7 +189,7 @@ public class ProfileService {
 	 * @return The updated profile entity.
 	 * @throws ResourceNotFoundException When any given ID does not exist within the DB.
 	 */
-	public ProfileEntity updateProfile(ProfileReadModel updateModel, ProfileEntity existingEntity) {
+	public ProfileEntity updateProfile(ProfilePutModel updateModel, ProfileEntity existingEntity) {
 		final var hrAdvisorId = updateModel.hrAdvisorId();
 
 		if (hrAdvisorId != null && !hrAdvisorId.equals(existingEntity.getHrAdvisor().getId())) {
@@ -197,33 +203,189 @@ public class ProfileService {
 			existingEntity.setHrAdvisor(hrAdvisor);
 		}
 
-		final var classificationId = updateModel.substantiveClassification().getId();
+		final var languageId = updateModel.languageOfCorrespondenceId();
+		if (languageId != null && !languageId.equals(existingEntity.getClassification().getId())) {
+			existingEntity.setLanguage(languageRepository.findById(languageId)
+					.orElseThrow(() -> generateIdDoesNotExistException("Language", languageId)));
+		}
+
+		final var classificationId = updateModel.classificationId();
 		if (classificationId != null && !classificationId.equals(existingEntity.getClassification().getId())) {
 			existingEntity.setClassification(classificationRepository.findById(classificationId)
 				.orElseThrow(() -> generateIdDoesNotExistException("Classification", classificationId)));
 		}
 
-		final var workUnitId = updateModel.substantiveWorkUnit().getId();
+		final var cityId = updateModel.cityId();
+		if (cityId != null && !cityId.equals(existingEntity.getClassification().getId())) {
+			existingEntity.setCity(cityRepository.findById(cityId)
+					.orElseThrow(() -> generateIdDoesNotExistException("City", cityId)));
+		}
+
+        final var workUnitId = updateModel.workUnitId();
 		if (workUnitId != null && !workUnitId.equals(existingEntity.getWorkUnit().getId())) {
 			existingEntity.setWorkUnit(workUnitRepository.findById(workUnitId)
 				.orElseThrow(() -> generateIdDoesNotExistException("Work Unit", workUnitId)));
 		}
 
-		final var wfaStatusId = updateModel.wfaStatus().getId();
+		final var wfaStatusId = updateModel.wfaStatusId();
 		if (wfaStatusId != null && !wfaStatusId.equals(existingEntity.getWfaStatus().getId())) {
 			existingEntity.setWfaStatus(wfaStatusRepository.findById(wfaStatusId)
 				.orElseThrow(() -> generateIdDoesNotExistException("WFA Status", wfaStatusId)));
 		}
 
+		syncPreferredCities(updateModel, existingEntity);
+		syncPreferredClassifications(updateModel, existingEntity);
+		syncPreferredEmploymentOpportunities(updateModel, existingEntity);
+		syncPreferredLanguages(updateModel, existingEntity);
+
+		existingEntity.setPersonalPhoneNumber((updateModel.personalPhoneNumber()));
 		existingEntity.setPersonalEmailAddress(updateModel.personalEmailAddress());
 		existingEntity.setIsAvailableForReferral(updateModel.isAvailableForReferral());
 		existingEntity.setIsInterestedInAlternation(updateModel.isInterestedInAlternation());
+		existingEntity.setHasConsentedToPrivacyTerms(updateModel.hasConsentedToPrivacyTerms());
 		existingEntity.setAdditionalComment(updateModel.additionalComment());
 
 		final var updatedEntity = profileRepository.save(existingEntity);
 		eventPublisher.publishEvent(new ProfileUpdatedEvent(updatedEntity));
 
+
 		return updatedEntity;
+	}
+
+	/**
+	 * Updates a {@link ProfileEntity}'s associative entity based on the given parameters.
+	 * <p/>
+	 * This method computes the delta between the current state and expected state off the associative entity,
+	 * adds that which is missing, and removes that which needs to be removed. While this <em>is</em> complex for
+	 * associations that should be relatively small per profile, the simpler solution of clearing and adding to the
+	 * association's {@link Set} does not work due to how Hibernate orders it's operations. Hibernate will
+	 * execute it's inserts before deletions, which can lead to violations of the unique key constraint in these
+	 * associative entities. <a href="https://hibernate.atlassian.net/browse/HHH-2801">See HHH-2801 for other details</a>.
+	 *
+	 * @param incomingIds A list of IDs representing the state after the sync has completed.
+	 * @param currentAssociations The current associative entities related to the target profile.
+	 * @param getAssociatedId A function to retrieve the ID of the underlying entity from the associative entity.
+	 * @param createAssociation A function to create an associative entity between the target profile and the target
+	 *                          related entity.
+	 * @param fetchEntitiesByIds A function to retrieve all target entities by ID.
+	 * @param <E> The underlying entity type that has a relationship with the profile.
+	 * @param <A> The target associative entity type.
+	 */
+	private <E, A> void syncAssociations(Set<Long> incomingIds,
+										 Set<A> currentAssociations,
+										 Function<A, Long> getAssociatedId,
+										 Function<E, A> createAssociation,
+										 Function<Set<Long>, List<E>> fetchEntitiesByIds,
+										 String associationName) {
+		// We allow empty incoming IDs to move forward. This effectively is treated as a "remove all" option.
+		if (incomingIds == null || incomingIds.contains(null)) {
+			throw new ResourceConflictException("Cannot assign " + associationName + " with null value(s).");
+		}
+
+		final var currentIds = currentAssociations.stream()
+				.map(getAssociatedId)
+				.collect(Collectors.toSet());
+
+		// Return early if there are no changes to make.
+		if (incomingIds.equals(currentIds)) {
+			return;
+		}
+
+		// Compute the delta between the incoming IDs and current IDs.
+		final var idsToAdd = new HashSet<>(incomingIds);
+		idsToAdd.removeAll(currentIds);
+
+		final var idsToRemove = new HashSet<>(currentIds);
+		idsToRemove.removeAll(incomingIds);
+
+		final var entitiesToAdd = fetchEntitiesByIds.apply(idsToAdd);
+		final var foundIds = entitiesToAdd.stream()
+				.map(e -> getAssociatedId.apply(createAssociation.apply(e)))
+				.collect(Collectors.toSet());
+
+		// If any IDs did not exist, we will not get an exception from fetchAllById. Instead, we check for the
+		// absence of a returned ID from the asked-for IDs and throw our own exception.
+		final var missingIds = new HashSet<>(idsToAdd);
+		missingIds.removeAll(foundIds);
+
+		if (!missingIds.isEmpty()) {
+			StringBuilder sb = new StringBuilder();
+			sb.append("A(n) entity for association ").append(associationName).append(" where id(s)=[ ");
+			for (var missingId : missingIds) {
+				sb.append(missingId).append(" ");
+			}
+			sb.append("] do(es) not exist");
+			throw new ResourceConflictException(sb.toString());
+		}
+
+		// Remove all associations that are no longer required.
+		currentAssociations.removeIf(a -> idsToRemove.contains(getAssociatedId.apply(a)));
+
+		// Add all associations that are now required.
+		for (E entity : entitiesToAdd) {
+			currentAssociations.add(createAssociation.apply(entity));
+		}
+
+	}
+
+	private void syncPreferredCities(final ProfilePutModel updateModel, final ProfileEntity existingEntity) {
+		syncAssociations(
+				updateModel.preferredCities(),
+				existingEntity.getProfileCities(),
+				pc -> pc.getCity().getId(),
+				city -> {
+					ProfileCityEntity pce = new ProfileCityEntity();
+					pce.setProfile(existingEntity);
+					pce.setCity(city);
+					return pce;
+				},
+				cityRepository::findAllById,
+				"ProfileCities");
+	}
+
+	private void syncPreferredClassifications(final ProfilePutModel updateModel, final ProfileEntity existingEntity) {
+		syncAssociations(
+				updateModel.preferredClassification(),
+				existingEntity.getClassificationProfiles(),
+				cp -> cp.getClassification().getId(),
+				classification -> {
+					ClassificationProfileEntity cpe = new ClassificationProfileEntity();
+					cpe.setProfile(existingEntity);
+					cpe.setClassification(classification);
+					return cpe;
+				},
+				classificationRepository::findAllById,
+				"ClassificationProfiles");
+	}
+
+	private void syncPreferredEmploymentOpportunities(final ProfilePutModel updateModel, final ProfileEntity existingEntity) {
+		syncAssociations(
+				updateModel.preferredEmploymentOpportunities(),
+				existingEntity.getEmploymentOpportunities(),
+				peoe -> peoe.getEmploymentOpportunity().getId(),
+				empOpp -> {
+					ProfileEmploymentOpportunityEntity peoe = new ProfileEmploymentOpportunityEntity();
+					peoe.setProfile(existingEntity);
+					peoe.setEmploymentOpportunity(empOpp);
+					return peoe;
+				},
+				employmentOpportunityRepository::findAllById,
+				"ProfileEmploymentOpportunities");
+	}
+
+	private void syncPreferredLanguages(final ProfilePutModel updateModel, final ProfileEntity existingEntity) {
+		syncAssociations(
+				updateModel.languageReferralTypes(),
+				existingEntity.getLanguageReferralTypes(),
+				lrt -> lrt.getLanguageReferralType().getId(),
+				lrte -> {
+					ProfileLanguageReferralTypeEntity plrte = new ProfileLanguageReferralTypeEntity();
+					plrte.setProfile(existingEntity);
+					plrte.setLanguageReferralType(lrte);
+					return plrte;
+				},
+				languageReferralTypeRepository::findAllById,
+				"ProfileLanguageReferralTypes");
 	}
 
 }

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/ProfilesController.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/ProfilesController.java
@@ -7,6 +7,7 @@ import static ca.gov.dtsstn.vacman.api.exception.ExceptionUtils.generateUserWith
 import java.util.Collection;
 import java.util.Set;
 
+import ca.gov.dtsstn.vacman.api.web.model.ProfilePutModel;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.validator.constraints.Range;
 import org.mapstruct.factory.Mappers;
@@ -177,7 +178,7 @@ public class ProfilesController {
 	@PreAuthorize("hasAuthority('hr-advisor')")
 	@SecurityRequirement(name = SpringDocConfig.AZURE_AD)
 	@Operation(summary = "Update an existing profile specified by ID.")
-	public ResponseEntity<ProfileReadModel> updateProfileById(@PathVariable(name = "id") Long profileId, @Valid @RequestBody ProfileReadModel updatedProfile) {
+	public ResponseEntity<ProfileReadModel> updateProfileById(@PathVariable(name = "id") Long profileId, @Valid @RequestBody ProfilePutModel updatedProfile) {
 		log.info("Received request to get profile; ID: [{}]", profileId);
 
 		final var foundProfile = profileService.getProfile(profileId)

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/model/ProfilePutModel.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/model/ProfilePutModel.java
@@ -1,0 +1,56 @@
+package ca.gov.dtsstn.vacman.api.web.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Set;
+
+@Schema(name = "ProfilePutModel")
+public record ProfilePutModel (
+        @Schema(accessMode = Schema.AccessMode.WRITE_ONLY, description = "The unique identifier for the HR advisor associated with this profile.", example = "2")
+        Long hrAdvisorId,
+
+        @Schema(accessMode = Schema.AccessMode.WRITE_ONLY, description = "The personal phone number of this profile.", example = "555-123-4567")
+        String personalPhoneNumber,
+
+        @Schema(accessMode = Schema.AccessMode.WRITE_ONLY, description = "The personal email of this profile.", example = "john.doe@example.com")
+        String personalEmailAddress,
+
+        @Schema(accessMode = Schema.AccessMode.WRITE_ONLY, description = "The language associated with the user associated with this profile.", example = "1")
+        Long languageOfCorrespondenceId,
+
+        @Schema(accessMode = Schema.AccessMode.WRITE_ONLY, description = "The classification of this profile.", example = "1")
+        Long classificationId,
+
+        @Schema(accessMode = Schema.AccessMode.WRITE_ONLY, description = "The city of this profile.", example = "1")
+        Long cityId,
+
+        @Schema(accessMode = Schema.AccessMode.WRITE_ONLY, description = "The work unit of this profile.", example = "1")
+        Long workUnitId,
+
+        @Schema(accessMode = Schema.AccessMode.WRITE_ONLY, description = "The WFA status of this profile.", example = "1")
+        Long wfaStatusId,
+
+        @Schema(accessMode = Schema.AccessMode.WRITE_ONLY, description = "Is this profile available for referral?")
+        Boolean isAvailableForReferral,
+
+        @Schema(accessMode = Schema.AccessMode.WRITE_ONLY, description = "Is this profile available for alternation?", example = "true")
+        Boolean isInterestedInAlternation,
+
+        @Schema(accessMode = Schema.AccessMode.WRITE_ONLY, description = "Has this profile consented to privacy terms?", example = "true")
+        Boolean hasConsentedToPrivacyTerms,
+
+        @Schema(accessMode = Schema.AccessMode.WRITE_ONLY, description = "Additional comments on this profile.", example = "One cool individual.")
+        String additionalComment,
+
+        @Schema(accessMode = Schema.AccessMode.WRITE_ONLY, description = "Collection of cities designated as work locations")
+        Set<Long> preferredCities,
+
+        @Schema(accessMode = Schema.AccessMode.WRITE_ONLY, description = "Collection of cities designated as work locations")
+        Set<Long> preferredClassification,
+
+        @Schema(accessMode = Schema.AccessMode.WRITE_ONLY, description = "Collection of cities designated as work locations")
+        Set<Long> preferredEmploymentOpportunities,
+
+        @Schema(accessMode = Schema.AccessMode.WRITE_ONLY, description = "Collection of cities designated as work locations")
+        Set<Long> languageReferralTypes
+) {}


### PR DESCRIPTION
## Summary

A refactoring of the `PUT /profiles/{id}` operation:

* Creating a dedicated "Put" model for the profile that accepts IDs instead of models
* Including some missed fields from the initial implementation, including the associative entities
    * Associative entities required a somewhat non-trivial solution due to unique key constraints rubbing up against Hibernate's execution model ([see Javadoc for `syncAssociations` for more information](https://github.com/DTS-STN/vacman/commit/b56b326cf669acf13eea5fb5face4d3dcbe8bf57#diff-f1d8e719f2f5513f698923e4b548011b36edcd20345247480bdbcc758cec64adR255-R273))
    * Associative entities required to override `equals` and `hashCode` methods to properly trigger "dirty" changes

## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [x] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [x] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [x] documentation has been updated to reflect the changes (if applicable)
- [x] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>
