### PR TITLE
feat(frontend) add match-status-service

### DIFF
--- a/frontend/app/.server/domain/models.ts
+++ b/frontend/app/.server/domain/models.ts
@@ -92,6 +92,9 @@ export type LocalizedEmploymentEquity = LocalizedLookupModel;
 export type MatchFeedback = LookupModel;
 export type LocalizedMatchFeedback = LocalizedLookupModel;
 
+export type MatchStatus = LookupModel;
+export type LocalizedMatchStatus = LocalizedLookupModel;
+
 export type User = Readonly<{
   id: number;
   role: string;

--- a/frontend/app/.server/domain/services/match-status-service-default.ts
+++ b/frontend/app/.server/domain/services/match-status-service-default.ts
@@ -1,0 +1,17 @@
+import type { MatchStatus } from '~/.server/domain/models';
+import type { MatchStatusService } from '~/.server/domain/services/match-status-service';
+import { createLookupService } from '~/.server/domain/services/shared/lookup-service-helpers';
+import { ErrorCodes } from '~/errors/error-codes';
+
+// Create a single instance of the service using shared implementation with standard localization
+const sharedService = createLookupService<MatchStatus>('/codes/match-status', 'match-status', ErrorCodes.NO_MATCH_STATUS_FOUND);
+
+// Create a shared instance of the service (module-level singleton)
+export const matchStatusService: MatchStatusService = sharedService;
+
+/**
+ * Returns the default match status service instance.
+ */
+export function getDefaultMatchStatusService(): MatchStatusService {
+  return matchStatusService;
+}

--- a/frontend/app/.server/domain/services/match-status-service-mock.ts
+++ b/frontend/app/.server/domain/services/match-status-service-mock.ts
@@ -1,0 +1,40 @@
+import type { MatchStatus } from '~/.server/domain/models';
+import type { MatchStatusService } from '~/.server/domain/services/match-status-service';
+import { createMockLookupService } from '~/.server/domain/services/shared/lookup-service-helpers';
+import matchStatusData from '~/.server/resources/matchStatus.json';
+import { ErrorCodes } from '~/errors/error-codes';
+
+// Transform the data to match the expected format
+const mockData: MatchStatus[] = matchStatusData.content.map((matchStatus) => ({
+  id: matchStatus.id,
+  code: matchStatus.code,
+  nameEn: matchStatus.nameEn,
+  nameFr: matchStatus.nameFr,
+}));
+
+// Create a single instance of the service using shared implementation with standard localization
+const sharedService = createMockLookupService<MatchStatus>(mockData, 'match status', ErrorCodes.NO_MATCH_STATUS_FOUND);
+
+export function getMockMatchStatusService(): MatchStatusService {
+  return {
+    listAll(): Promise<readonly MatchStatus[]> {
+      return Promise.resolve(sharedService.listAll());
+    },
+
+    getById(id: number) {
+      return Promise.resolve(sharedService.getById(id));
+    },
+
+    listAllLocalized(language: Language) {
+      return Promise.resolve(sharedService.listAllLocalized(language));
+    },
+
+    getLocalizedById(id: number, language: Language) {
+      return Promise.resolve(sharedService.getLocalizedById(id, language));
+    },
+
+    findLocalizedById(id: number, language: Language) {
+      return Promise.resolve(sharedService.findLocalizedById(id, language));
+    },
+  };
+}

--- a/frontend/app/.server/domain/services/match-status-service.ts
+++ b/frontend/app/.server/domain/services/match-status-service.ts
@@ -1,0 +1,19 @@
+import type { Result, Option } from 'oxide.ts';
+
+import type { MatchStatus, LocalizedMatchStatus } from '~/.server/domain/models';
+import { getDefaultMatchStatusService } from '~/.server/domain/services/match-status-service-default';
+import { getMockMatchStatusService } from '~/.server/domain/services/match-status-service-mock';
+import { serverEnvironment } from '~/.server/environment';
+import type { AppError } from '~/errors/app-error';
+
+export type MatchStatusService = {
+  listAll(): Promise<readonly MatchStatus[]>;
+  getById(id: number): Promise<Result<MatchStatus, AppError>>;
+  listAllLocalized(language: Language): Promise<readonly LocalizedMatchStatus[]>;
+  getLocalizedById(id: number, language: Language): Promise<Result<LocalizedMatchStatus, AppError>>;
+  findLocalizedById(id: number, language: Language): Promise<Option<LocalizedMatchStatus>>;
+};
+
+export function getMatchStatusService(): MatchStatusService {
+  return serverEnvironment.ENABLE_LOOKUP_FIELD_SERVICES_MOCK ? getMockMatchStatusService() : getDefaultMatchStatusService();
+}

--- a/frontend/app/errors/error-codes.ts
+++ b/frontend/app/errors/error-codes.ts
@@ -53,6 +53,7 @@ export const ErrorCodes = {
   NO_USER_TYPE_FOUND: 'SVC-0020',
   NO_WORK_SCHEDULE_FOUND: 'SVC-0021',
   NO_MATCH_FEEDBACK_FOUND: 'SVC-0022',
+  NO_MATCH_STATUS_FOUND: 'SVC-0023',
 
   // vacman api error codes
   VACMAN_API_ERROR: 'API-0001',


### PR DESCRIPTION
## Summary

[Unrelated to the current integration work being done, which is why the target is `main`]

[AB#6700](https://dev.azure.com/DTS-STN/4c33b941-c811-479f-b181-dfd5292182ff/_workitems/edit/6700)

Adds the match status service which will be used in Iteration 2 for request/match.
