### PR TITLE
refactor(frontend) fix hasReferralDataChanged

### DIFF
--- a/frontend/app/.server/utils/profile-utils.ts
+++ b/frontend/app/.server/utils/profile-utils.ts
@@ -1,4 +1,4 @@
-import type { Profile, User, UserQueryParams } from '~/.server/domain/models';
+import type { Profile, ProfilePutModel, User, UserQueryParams } from '~/.server/domain/models';
 import { getUserService } from '~/.server/domain/services/user-service';
 
 /**
@@ -138,18 +138,30 @@ export async function getHrAdvisors(accessToken: string): Promise<User[]> {
   return result.unwrap().content;
 }
 
-export function hasEmploymentDataChanged(oldData: Profile, newData: Profile) {
-  const keysToCheck: (keyof Profile)[] = [
-    'substantiveClassification',
-    'wfaStatus',
-    'wfaStartDate',
-    'wfaEndDate',
-    'hrAdvisorId',
-  ];
-  return keysToCheck.some((key) => newData[key] !== oldData[key]);
+export function hasReferralDataChanged(oldData: Profile, newData: ProfilePutModel): boolean {
+  const normalizedOld = {
+    preferredClassifications: oldData.preferredClassifications?.map((c) => c.id) ?? [],
+    preferredCities: oldData.preferredCities?.map((c) => c.id) ?? [],
+  };
+
+  const normalizedNew = {
+    preferredClassifications: newData.preferredClassifications ?? [],
+    preferredCities: newData.preferredCities ?? [],
+  };
+
+  return !deepEqual(normalizedOld, normalizedNew);
 }
 
-export function hasReferralDataChanged(oldData: Profile, newData: Profile) {
-  const keysToCheck: (keyof Profile)[] = ['preferredClassifications', 'preferredCities'];
-  return keysToCheck.some((key) => newData[key] !== oldData[key]);
+// TODO consider lodash instead
+function deepEqual(x: any, y: any): boolean {
+  if (x === y) return true;
+  if (typeof x !== 'object' || x === null || typeof y !== 'object' || y === null) return false;
+  const keysX = Object.keys(x);
+  const keysY = Object.keys(y);
+  if (keysX.length !== keysY.length) return false;
+  for (const key of keysX) {
+    if (!keysY.includes(key)) return false;
+    if (!deepEqual(x[key], y[key])) return false;
+  }
+  return true;
 }

--- a/frontend/app/.server/utils/profile-utils.ts
+++ b/frontend/app/.server/utils/profile-utils.ts
@@ -1,4 +1,4 @@
-import type { User, UserQueryParams } from '~/.server/domain/models';
+import type { Profile, User, UserQueryParams } from '~/.server/domain/models';
 import { getUserService } from '~/.server/domain/services/user-service';
 
 /**
@@ -136,4 +136,20 @@ export async function getHrAdvisors(accessToken: string): Promise<User[]> {
     throw result.unwrapErr();
   }
   return result.unwrap().content;
+}
+
+export function hasEmploymentDataChanged(oldData: Profile, newData: Profile) {
+  const keysToCheck: (keyof Profile)[] = [
+    'substantiveClassification',
+    'wfaStatus',
+    'wfaStartDate',
+    'wfaEndDate',
+    'hrAdvisorId',
+  ];
+  return keysToCheck.some((key) => newData[key] !== oldData[key]);
+}
+
+export function hasReferralDataChanged(oldData: Profile, newData: Profile) {
+  const keysToCheck: (keyof Profile)[] = ['preferredClassifications', 'preferredCities'];
+  return keysToCheck.some((key) => newData[key] !== oldData[key]);
 }


### PR DESCRIPTION
## Summary

We need to check whether a change data in the referral preferences page should trigger a status update for re-approval.  What's annoying about this is that the `Profile` and the `ProfilePutModel` differ in shape and types, meaning we have to normalize the data before comparing.  We might want to consider installing/importing a `deepEqual` function, from say `lodash` for example.
