### PR TITLE
refactor(frontend): send languageId while updating user

### DIFF
--- a/frontend/app/routes/employee/profile/personal-information.tsx
+++ b/frontend/app/routes/employee/profile/personal-information.tsx
@@ -76,6 +76,27 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     ...personalInformationForProfile
   } = parseResult.output;
 
+  if (currentUser) {
+    const userUpdateResult = await userService.updateUserById(
+      // Send complete user object with updates
+      currentUser.id,
+      {
+        ...currentUser,
+        businessEmail: businessEmailAddress,
+        businessPhone: businessPhoneNumber,
+        firstName: firstName,
+        lastName: lastName,
+        personalRecordIdentifier: personalRecordIdentifier,
+        languageId: parseResult.output.languageOfCorrespondenceId,
+      },
+      context.session.authState.accessToken,
+    );
+
+    if (userUpdateResult.isErr()) {
+      throw userUpdateResult.unwrapErr();
+    }
+  }
+
   // Update the profile (without fields for updating user)
   const updateResult = await profileService.updateProfileById(
     currentProfile.id,
@@ -85,25 +106,6 @@ export async function action({ context, params, request }: Route.ActionArgs) {
 
   if (updateResult.isErr()) {
     throw updateResult.unwrapErr();
-  }
-
-  if (currentUser) {
-    const userUpdateResult = await userService.updateUserById(
-      currentUser.id,
-      {
-        ...currentUser,
-        businessEmail: businessEmailAddress,
-        businessPhone: businessPhoneNumber,
-        firstName: firstName,
-        lastName: lastName,
-        personalRecordIdentifier: personalRecordIdentifier,
-      },
-      context.session.authState.accessToken,
-    );
-
-    if (userUpdateResult.isErr()) {
-      throw userUpdateResult.unwrapErr();
-    }
   }
 
   return i18nRedirect('routes/employee/profile/index.tsx', request, {

--- a/frontend/app/routes/hr-advisor/employee-profile/personal-information.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/personal-information.tsx
@@ -61,7 +61,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     );
   }
 
-  // Extract workPhone for user update, remove it from profile data
+  // Extract fields for user update, remove it from profile data
   const {
     businessEmailAddress,
     businessPhoneNumber,
@@ -70,16 +70,6 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     personalRecordIdentifier,
     ...personalInformationForProfile
   } = parseResult.output;
-
-  const updateProfileResult = await profileService.updateProfileById(
-    profile.id,
-    personalInformationForProfile,
-    context.session.authState.accessToken,
-  );
-
-  if (updateProfileResult.isErr()) {
-    throw updateProfileResult.unwrapErr();
-  }
 
   const userService = getUserService();
   const userResult = await userService.getUserById(profile.profileUser.id, context.session.authState.accessToken);
@@ -100,12 +90,24 @@ export async function action({ context, params, request }: Route.ActionArgs) {
       firstName: firstName,
       lastName: lastName,
       personalRecordIdentifier: personalRecordIdentifier,
+      languageId: parseResult.output.languageOfCorrespondenceId,
     },
     context.session.authState.accessToken,
   );
 
   if (userUpdateResult.isErr()) {
     throw userUpdateResult.unwrapErr();
+  }
+
+  // Update the profile (without fields for updating user)
+  const updateProfileResult = await profileService.updateProfileById(
+    profile.id,
+    personalInformationForProfile,
+    context.session.authState.accessToken,
+  );
+
+  if (updateProfileResult.isErr()) {
+    throw updateProfileResult.unwrapErr();
   }
 
   return i18nRedirect('routes/hr-advisor/employee-profile/index.tsx', request, {


### PR DESCRIPTION
## Summary

While updating personal information of user profile, the backend throws error if Language ID is null, so sending languageId while updating user. Also updating the user before updating the profile.

## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades