### PR TITLE
refactor(frontend) employment-information and updateProfileById

### DIFF
--- a/frontend/app/.server/domain/services/profile-service-mock.ts
+++ b/frontend/app/.server/domain/services/profile-service-mock.ts
@@ -3,7 +3,9 @@ import type { Result, Option } from 'oxide.ts';
 
 import { getCityService } from './city-service';
 import { getClassificationService } from './classification-service';
+import { getDirectorateService } from './directorate-service';
 import { getEmploymentOpportunityTypeService } from './employment-opportunity-type-service';
+import { getWFAStatuses } from './wfa-status-service';
 
 import type {
   Profile,
@@ -296,6 +298,8 @@ export function getMockProfileService(): ProfileService {
       const classificationService = getClassificationService();
       const cityService = getCityService();
       const employmentOppourtunityService = getEmploymentOpportunityTypeService();
+      const directorateService = getDirectorateService();
+      const wfaStatusService = getWFAStatuses();
 
       let languageOfCorrespondence = existingProfile.languageOfCorrespondence;
       if (profile.languageOfCorrespondenceId) {
@@ -304,29 +308,61 @@ export function getMockProfileService(): ProfileService {
           languageOfCorrespondence = langResult.unwrap();
         }
       }
-      const preferredLanguages = profile.preferredLanguages
-        ? (await Promise.all(profile.preferredLanguages.map((id) => languageReferralTypeService.getById(id))))
-            .filter((result) => result.isOk())
-            .map((result) => result.unwrap())
-        : existingProfile.preferredLanguages;
+      const preferredLanguages =
+        profile.preferredLanguages !== undefined
+          ? (await Promise.all(profile.preferredLanguages.map((id) => languageReferralTypeService.getById(id))))
+              .filter((result) => result.isOk())
+              .map((result) => result.unwrap())
+          : existingProfile.preferredLanguages;
 
-      const preferredClassifications = profile.preferredClassification
-        ? (await Promise.all(profile.preferredClassification.map((id) => classificationService.getById(id))))
-            .filter((result) => result.isOk())
-            .map((result) => result.unwrap())
-        : existingProfile.preferredClassifications;
+      const preferredClassifications =
+        profile.preferredClassification !== undefined
+          ? (await Promise.all(profile.preferredClassification.map((id) => classificationService.getById(id))))
+              .filter((result) => result.isOk())
+              .map((result) => result.unwrap())
+          : existingProfile.preferredClassifications;
 
-      const preferredCities = profile.preferredCities
-        ? (await Promise.all(profile.preferredCities.map((id) => cityService.getById(id))))
-            .filter((result) => result.isOk())
-            .map((result) => result.unwrap())
-        : existingProfile.preferredCities;
+      const preferredCities =
+        profile.preferredCities !== undefined
+          ? (await Promise.all(profile.preferredCities.map((id) => cityService.getById(id))))
+              .filter((result) => result.isOk())
+              .map((result) => result.unwrap())
+          : existingProfile.preferredCities;
 
-      const preferredEmploymentOpportunities = profile.preferredEmploymentOpportunities
-        ? (await Promise.all(profile.preferredEmploymentOpportunities.map((id) => employmentOppourtunityService.getById(id))))
-            .filter((result) => result.isOk())
-            .map((result) => result.unwrap())
-        : existingProfile.preferredEmploymentOpportunities;
+      const preferredEmploymentOpportunities =
+        profile.preferredEmploymentOpportunities !== undefined
+          ? (await Promise.all(profile.preferredEmploymentOpportunities.map((id) => employmentOppourtunityService.getById(id))))
+              .filter((result) => result.isOk())
+              .map((result) => result.unwrap())
+          : existingProfile.preferredEmploymentOpportunities;
+
+      const substantiveClassification =
+        profile.classificationId !== undefined
+          ? (await Promise.all([classificationService.getById(profile.classificationId)]))
+              .filter((result) => result.isOk())
+              .map((result) => result.unwrap())[0]
+          : existingProfile.substantiveClassification;
+
+      const substantiveWorkUnit =
+        profile.workUnitId !== undefined
+          ? (await Promise.all([directorateService.getById(profile.workUnitId)]))
+              .filter((result) => result.isOk())
+              .map((result) => result.unwrap())[0]
+          : existingProfile.substantiveWorkUnit;
+
+      const substantiveCity =
+        profile.cityId !== undefined
+          ? (await Promise.all([cityService.getById(profile.cityId)]))
+              .filter((result) => result.isOk())
+              .map((result) => result.unwrap())[0]
+          : existingProfile.substantiveCity;
+
+      const wfaStatus =
+        profile.wfaStatusId !== undefined
+          ? (await Promise.all([wfaStatusService.getById(profile.wfaStatusId)]))
+              .filter((result) => result.isOk())
+              .map((result) => result.unwrap())[0]
+          : existingProfile.wfaStatus;
 
       // Convert ProfilePutModel to Profile by mapping ID fields to objects and merging with existing data
       const updatedProfile: Profile = {
@@ -334,7 +370,6 @@ export function getMockProfileService(): ProfileService {
         // Map ProfilePutModel properties to Profile properties
         additionalComment: profile.additionalComment ?? existingProfile.additionalComment,
         hasConsentedToPrivacyTerms: profile.hasConsentedToPrivacyTerms ?? existingProfile.hasConsentedToPrivacyTerms,
-        hrAdvisorId: profile.hrAdvisorId ?? existingProfile.hrAdvisorId,
         isAvailableForReferral: profile.isAvailableForReferral ?? existingProfile.isAvailableForReferral,
         isInterestedInAlternation: profile.isInterestedInAlternation ?? existingProfile.isInterestedInAlternation,
         personalEmailAddress: profile.personalEmailAddress ?? existingProfile.personalEmailAddress,
@@ -346,6 +381,15 @@ export function getMockProfileService(): ProfileService {
         preferredClassifications,
         preferredCities,
         preferredEmploymentOpportunities,
+
+        hrAdvisorId: profile.hrAdvisorId,
+        substantiveClassification,
+        substantiveWorkUnit,
+        substantiveCity,
+        wfaStatus,
+        wfaStartDate: profile.wfaStartDate ?? existingProfile.wfaStartDate,
+        wfaEndDate: profile.wfaEndDate ?? existingProfile.wfaEndDate,
+
         id: profileId, // Ensure ID doesn't change
         lastModifiedDate: new Date().toISOString(),
         lastModifiedBy: 'mock-user',

--- a/frontend/app/routes/employee/profile/employment-information.tsx
+++ b/frontend/app/routes/employee/profile/employment-information.tsx
@@ -55,14 +55,18 @@ export async function action({ context, params, request }: Route.ActionArgs) {
 
   const updateResult = await profileService.updateProfileById(
     currentProfile.id,
-    omitObjectProperties(parseResult.output, [
-      'wfaEffectiveDateYear',
-      'wfaEffectiveDateMonth',
-      'wfaEffectiveDateDay',
-      'wfaEndDateYear',
-      'wfaEndDateMonth',
-      'wfaEndDateDay',
-    ]),
+    {
+      ...omitObjectProperties(parseResult.output, [
+        'wfaStartDateYear',
+        'wfaStartDateMonth',
+        'wfaStartDateDay',
+        'wfaEndDateYear',
+        'wfaEndDateMonth',
+        'wfaEndDateDay',
+      ]),
+      classificationId: parseResult.output.substantiveClassification,
+      workUnitId: parseResult.output.directorate,
+    },
     context.session.authState.accessToken,
   );
 
@@ -109,24 +113,16 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
   const wfaStatuses = await getWFAStatuses().listAllLocalized(lang);
   const hrAdvisors = await getHrAdvisors(context.session.authState.accessToken);
 
-  const workUnitResult =
-    profileData.substantiveWorkUnit !== undefined
-      ? await getDirectorateService().findLocalizedById(profileData.substantiveWorkUnit.id, lang)
-      : undefined;
-  const workUnit = workUnitResult?.into();
-
   return {
     documentTitle: t('app:employment-information.page-title'),
     defaultValues: {
-      substantivePosition: profileData.substantiveClassification,
-      branchOrServiceCanadaRegion: workUnit?.parent?.id,
-      directorate: workUnit?.id,
-      province: profileData.substantiveCity?.provinceTerritory,
-      city: profileData.substantiveCity,
+      substantiveClassification: profileData.substantiveClassification,
+      substantiveWorkUnit: profileData.substantiveWorkUnit,
+      substantiveCity: profileData.substantiveCity,
       wfaStatus: profileData.wfaStatus,
-      wfaEffectiveDate: profileData.wfaStartDate,
+      wfaStartDate: profileData.wfaStartDate,
       wfaEndDate: profileData.wfaEndDate,
-      hrAdvisor: profileData.hrAdvisorId,
+      hrAdvisorId: profileData.hrAdvisorId,
     },
     substantivePositions: substantivePositions,
     branchOrServiceCanadaRegions: branchOrServiceCanadaRegions,

--- a/frontend/app/routes/hr-advisor/employee-profile/employment-information.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/employment-information.tsx
@@ -55,14 +55,18 @@ export async function action({ context, params, request }: Route.ActionArgs) {
   }
   const updateResult = await profileService.updateProfileById(
     profile.id,
-    omitObjectProperties(parseResult.output, [
-      'wfaEffectiveDateYear',
-      'wfaEffectiveDateMonth',
-      'wfaEffectiveDateDay',
-      'wfaEndDateYear',
-      'wfaEndDateMonth',
-      'wfaEndDateDay',
-    ]),
+    {
+      ...omitObjectProperties(parseResult.output, [
+        'wfaStartDateYear',
+        'wfaStartDateMonth',
+        'wfaStartDateDay',
+        'wfaEndDateYear',
+        'wfaEndDateMonth',
+        'wfaEndDateDay',
+      ]),
+      classificationId: parseResult.output.substantiveClassification,
+      workUnitId: parseResult.output.directorate,
+    },
     context.session.authState.accessToken,
   );
 
@@ -99,24 +103,16 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
   const hrAdvisors = await getHrAdvisors(context.session.authState.accessToken);
   const profileData: Profile = profileResult.unwrap();
 
-  const workUnitResult =
-    profileData.substantiveWorkUnit !== undefined
-      ? await getDirectorateService().findLocalizedById(profileData.substantiveWorkUnit.id, lang)
-      : undefined;
-  const workUnit = workUnitResult?.into();
-
   return {
     documentTitle: t('app:employment-information.page-title'),
     defaultValues: {
-      substantivePosition: profileData.substantiveClassification,
-      branchOrServiceCanadaRegion: workUnit?.parent?.id,
-      directorate: workUnit?.id,
-      province: profileData.substantiveCity?.provinceTerritory,
-      city: profileData.substantiveCity,
+      substantiveClassification: profileData.substantiveClassification,
+      substantiveWorkUnit: profileData.substantiveWorkUnit,
+      substantiveCity: profileData.substantiveCity,
       wfaStatus: profileData.wfaStatus,
-      wfaEffectiveDate: profileData.wfaStartDate,
+      wfaStartDate: profileData.wfaStartDate,
       wfaEndDate: profileData.wfaEndDate,
-      hrAdvisor: profileData.hrAdvisorId,
+      hrAdvisorId: profileData.hrAdvisorId,
     },
     substantivePositions: substantivePositions,
     branchOrServiceCanadaRegions: branchOrServiceCanadaRegions,

--- a/frontend/app/routes/page-components/employees/employment-information/form.tsx
+++ b/frontend/app/routes/page-components/employees/employment-information/form.tsx
@@ -57,9 +57,11 @@ export function EmploymentInformationForm({
 }: EmploymentProps): JSX.Element {
   const { t } = useTranslation('app');
 
-  const [branch, setBranch] = useState(formValues?.substantiveWorkUnit ? String(formValues.substantiveWorkUnit.id) : undefined);
+  const [branch, setBranch] = useState(
+    formValues?.substantiveWorkUnit ? String(formValues.substantiveWorkUnit.parent?.id) : undefined,
+  );
   const [directorate, setDirectorate] = useState(
-    formValues?.substantiveWorkUnit?.parent?.id !== undefined ? String(formValues.substantiveWorkUnit.parent.id) : undefined,
+    formValues?.substantiveWorkUnit !== undefined ? String(formValues.substantiveWorkUnit.id) : undefined,
   );
   const [province, setProvince] = useState(
     formValues?.substantiveCity?.provinceTerritory !== undefined
@@ -144,9 +146,9 @@ export function EmploymentInformationForm({
           <div className="space-y-6">
             <h2 className="font-lato text-2xl font-bold">{t('employment-information.substantive-position-heading')}</h2>
             <InputSelect
-              id="substantivePosition"
-              name="substantivePosition"
-              errorMessage={t(extractValidationKey(formErrors?.substantivePosition))}
+              id="substantiveClassification"
+              name="substantiveClassification"
+              errorMessage={t(extractValidationKey(formErrors?.substantiveClassification))}
               required
               options={substantivePositionOptions}
               label={t('employment-information.substantive-position-group-and-level')}
@@ -164,7 +166,7 @@ export function EmploymentInformationForm({
               options={branchOrServiceCanadaRegionOptions}
               label={t('employment-information.branch-or-service-canada-region')}
               defaultValue={
-                formValues?.substantiveWorkUnit !== undefined ? String(formValues.substantiveClassification?.id) : ''
+                formValues?.substantiveWorkUnit !== undefined ? String(formValues.substantiveWorkUnit.parent?.id) : ''
               }
               className="w-full sm:w-1/2"
             />
@@ -227,18 +229,18 @@ export function EmploymentInformationForm({
               <>
                 <DatePickerField
                   defaultValue={formValues?.wfaStartDate ?? ''}
-                  id="wfaEffectiveDate"
+                  id="wfaStartDate"
                   legend={t('employment-information.wfa-effective-date')}
                   names={{
-                    day: 'wfaEffectiveDateDay',
-                    month: 'wfaEffectiveDateMonth',
-                    year: 'wfaEffectiveDateYear',
+                    day: 'wfaStartDateDay',
+                    month: 'wfaStartDateMonth',
+                    year: 'wfaStartDateYear',
                   }}
                   errorMessages={{
-                    all: t(extractValidationKey(formErrors?.wfaEffectiveDate)),
-                    year: t(extractValidationKey(formErrors?.wfaEffectiveDateYear)),
-                    month: t(extractValidationKey(formErrors?.wfaEffectiveDateMonth)),
-                    day: t(extractValidationKey(formErrors?.wfaEffectiveDateDay)),
+                    all: t(extractValidationKey(formErrors?.wfaStartDate)),
+                    year: t(extractValidationKey(formErrors?.wfaStartDateYear)),
+                    month: t(extractValidationKey(formErrors?.wfaStartDateMonth)),
+                    day: t(extractValidationKey(formErrors?.wfaStartDateDay)),
                   }}
                   required
                 />
@@ -261,9 +263,9 @@ export function EmploymentInformationForm({
               </>
             )}
             <InputSelect
-              id="hrAdvisor"
-              name="hrAdvisor"
-              errorMessage={t(extractValidationKey(formErrors?.hrAdvisor))}
+              id="hrAdvisorId"
+              name="hrAdvisorId"
+              errorMessage={t(extractValidationKey(formErrors?.hrAdvisorId))}
               required
               options={hrAdvisorOptions}
               label={t('employment-information.hr-advisor')}

--- a/frontend/app/routes/page-components/employees/validation.server.ts
+++ b/frontend/app/routes/page-components/employees/validation.server.ts
@@ -38,7 +38,7 @@ export async function createEmploymentInformationSchema(accessToken: string, for
   return v.pipe(
     v.intersect([
       v.object({
-        substantivePosition: v.lazy(() =>
+        substantiveClassification: v.lazy(() =>
           v.pipe(
             stringToIntegerSchema('app:employment-information.errors.substantive-group-and-level-required'),
             v.picklist(
@@ -83,7 +83,7 @@ export async function createEmploymentInformationSchema(accessToken: string, for
             ),
           ),
         ),
-        hrAdvisor: v.lazy(() =>
+        hrAdvisorId: v.lazy(() =>
           v.pipe(
             stringToIntegerSchema('app:employment-information.errors.hr-advisor-required'),
             v.picklist(
@@ -101,10 +101,10 @@ export async function createEmploymentInformationSchema(accessToken: string, for
               stringToIntegerSchema(),
               v.picklist(selectedValidWfaStatusesForOptionalDate.map(({ id }) => id)),
             ),
-            wfaEffectiveDateYear: v.optional(v.string()),
-            wfaEffectiveDateMonth: v.optional(v.string()),
-            wfaEffectiveDateDay: v.optional(v.string()),
-            wfaEffectiveDate: v.optional(v.string()),
+            wfaStartDateYear: v.optional(v.string()),
+            wfaStartDateMonth: v.optional(v.string()),
+            wfaStartDateDay: v.optional(v.string()),
+            wfaStartDate: v.optional(v.string()),
             wfaEndDateYear: v.optional(v.string()),
             wfaEndDateMonth: v.optional(v.string()),
             wfaEndDateDay: v.optional(v.string()),
@@ -115,7 +115,7 @@ export async function createEmploymentInformationSchema(accessToken: string, for
               stringToIntegerSchema(),
               v.picklist(selectedValidWfaStatusesForRequiredDate.map(({ id }) => id)),
             ),
-            wfaEffectiveDateYear: v.pipe(
+            wfaStartDateYear: v.pipe(
               stringToIntegerSchema('app:employment-information.errors.wfa-effective-date.required-year'),
               v.minValue(1, 'app:employment-information.errors.wfa-effective-date.invalid-year'),
               v.maxValue(
@@ -123,17 +123,17 @@ export async function createEmploymentInformationSchema(accessToken: string, for
                 'app:employment-information.errors.wfa-effective-date.invalid-year',
               ),
             ),
-            wfaEffectiveDateMonth: v.pipe(
+            wfaStartDateMonth: v.pipe(
               stringToIntegerSchema('app:employment-information.errors.wfa-effective-date.required-month'),
               v.minValue(1, 'app:employment-information.errors.wfa-effective-date.invalid-month'),
               v.maxValue(12, 'app:employment-information.errors.wfa-effective-date.invalid-month'),
             ),
-            wfaEffectiveDateDay: v.pipe(
+            wfaStartDateDay: v.pipe(
               stringToIntegerSchema('app:employment-information.errors.wfa-effective-date.required-day'),
               v.minValue(1, 'app:employment-information.errors.wfa-effective-date.invalid-day'),
               v.maxValue(31, 'app:employment-information.errors.wfa-effective-date.invalid-day'),
             ),
-            wfaEffectiveDate: v.pipe(
+            wfaStartDate: v.pipe(
               v.string(),
               v.trim(),
               v.transform((input) => (input === '' ? undefined : input)),
@@ -193,9 +193,9 @@ export async function createEmploymentInformationSchema(accessToken: string, for
     ]),
     v.forward(
       v.partialCheck(
-        [['wfaEffectiveDate'], ['wfaEndDate']],
-        //wfaEffectiveDate and wfaEndDate are optional, but if both are present, then check that wfaEffectiveDate < wfaEndDate
-        (input) => !input.wfaEffectiveDate || !input.wfaEndDate || input.wfaEffectiveDate < input.wfaEndDate,
+        [['wfaStartDate'], ['wfaEndDate']],
+        //wfaStartDate and wfaEndDate are optional, but if both are present, then check that wfaStartDate < wfaEndDate
+        (input) => !input.wfaStartDate || !input.wfaEndDate || input.wfaStartDate < input.wfaEndDate,
         'app:employment-information.errors.wfa-end-date.invalid-before-effective-date',
       ),
       ['wfaEndDate'],
@@ -386,30 +386,30 @@ export const referralPreferencesSchema = v.object({
 });
 
 export async function parseEmploymentInformation(formData: FormData, accessToken: string) {
-  const wfaEffectiveDateYear = formData.get('wfaEffectiveDateYear')?.toString();
-  const wfaEffectiveDateMonth = formData.get('wfaEffectiveDateMonth')?.toString();
-  const wfaEffectiveDateDay = formData.get('wfaEffectiveDateDay')?.toString();
+  const wfaStartDateYear = formData.get('wfaStartDateYear')?.toString();
+  const wfaStartDateMonth = formData.get('wfaStartDateMonth')?.toString();
+  const wfaStartDateDay = formData.get('wfaStartDateDay')?.toString();
 
   const wfaEndDateYear = formData.get('wfaEndDateYear')?.toString();
   const wfaEndDateMonth = formData.get('wfaEndDateMonth')?.toString();
   const wfaEndDateDay = formData.get('wfaEndDateDay')?.toString();
 
   const formValues = {
-    substantivePosition: formString(formData.get('substantivePosition')),
+    substantiveClassification: formString(formData.get('substantiveClassification')),
     branchOrServiceCanadaRegion: formString(formData.get('branchOrServiceCanadaRegion')),
     directorate: formString(formData.get('directorate')),
     provinceId: formString(formData.get('province')),
     cityId: formString(formData.get('cityId')),
     wfaStatusId: formString(formData.get('wfaStatus')),
-    wfaEffectiveDate: toDateString(wfaEffectiveDateYear, wfaEffectiveDateMonth, wfaEffectiveDateDay),
-    wfaEffectiveDateYear: wfaEffectiveDateYear,
-    wfaEffectiveDateMonth: wfaEffectiveDateMonth,
-    wfaEffectiveDateDay: wfaEffectiveDateDay,
+    wfaStartDate: toDateString(wfaStartDateYear, wfaStartDateMonth, wfaStartDateDay),
+    wfaStartDateYear: wfaStartDateYear,
+    wfaStartDateMonth: wfaStartDateMonth,
+    wfaStartDateDay: wfaStartDateDay,
     wfaEndDate: toDateString(wfaEndDateYear, wfaEndDateMonth, wfaEndDateDay),
     wfaEndDateYear: wfaEndDateYear,
     wfaEndDateMonth: wfaEndDateMonth,
     wfaEndDateDay: wfaEndDateDay,
-    hrAdvisor: formString(formData.get('hrAdvisor')),
+    hrAdvisorId: formString(formData.get('hrAdvisorId')),
   };
 
   const employmentInformationSchema = await createEmploymentInformationSchema(accessToken, formData);
@@ -417,21 +417,21 @@ export async function parseEmploymentInformation(formData: FormData, accessToken
   return {
     parseResult: v.safeParse(employmentInformationSchema, formValues),
     formValues: {
-      substantivePosition: formValues.substantivePosition,
+      substantiveClassification: formValues.substantiveClassification,
       branchOrServiceCanadaRegion: formValues.branchOrServiceCanadaRegion,
       directorate: formValues.directorate,
       provinceId: formValues.provinceId,
       cityId: formValues.cityId,
       wfaStatusId: formValues.wfaStatusId,
-      wfaEffectiveDateYear: formValues.wfaEffectiveDateYear,
-      wfaEffectiveDateMonth: formValues.wfaEffectiveDateMonth,
-      wfaEffectiveDateDay: formValues.wfaEffectiveDateDay,
-      wfaEffectiveDate: formValues.wfaEffectiveDate,
+      wfaStartDateYear: formValues.wfaStartDateYear,
+      wfaStartDateMonth: formValues.wfaStartDateMonth,
+      wfaStartDateDay: formValues.wfaStartDateDay,
+      wfaStartDate: formValues.wfaStartDate,
       wfaEndDate: formValues.wfaEndDate,
       wfaEndDateYear: formValues.wfaEndDateYear,
       wfaEndDateMonth: formValues.wfaEndDateMonth,
       wfaEndDateDay: formValues.wfaEndDateDay,
-      hrAdvisor: formValues.hrAdvisor,
+      hrAdvisorId: formValues.hrAdvisorId,
     },
   };
 }


### PR DESCRIPTION
## Summary
Fixes issues with `/employment-information`, specifically loading data that was found on file because the references were off and adds the ability to update the relevant profile data in the mock.

