### PR TITLE
feature(backend): Find-or-create user by email

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/dto/MSGraphUserCollection.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/dto/MSGraphUserCollection.java
@@ -1,0 +1,10 @@
+package ca.gov.dtsstn.vacman.api.service.dto;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+import java.util.List;
+
+@RecordBuilder
+public record MSGraphUserCollection(
+        List<MSGraphUser> value
+) {}

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/model/FindOrCreateModel.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/model/FindOrCreateModel.java
@@ -1,0 +1,14 @@
+package ca.gov.dtsstn.vacman.api.web.model;
+
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.immutables.value.Value.Immutable;
+
+@Immutable
+@JsonDeserialize(as = ImmutableFindOrCreateModel.class)
+public interface FindOrCreateModel {
+
+    @Schema(accessMode = Schema.AccessMode.WRITE_ONLY, description = "The business email address of the associated individual.")
+    String getBusinessEmail();
+}

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/model/mapper/UserModelMapper.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/model/mapper/UserModelMapper.java
@@ -1,5 +1,6 @@
 package ca.gov.dtsstn.vacman.api.web.model.mapper;
 
+import ca.gov.dtsstn.vacman.api.service.dto.MSGraphUser;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -74,6 +75,13 @@ public interface UserModelMapper {
 	@Mapping(source = "initials", target = "initial")
 	@Mapping(source = "languageId", target = "language")
 	UserEntity toEntity(UserPatchModel model);
+
+	@Mapping(target = "id", ignore = true)
+	@Mapping(source = "id", target = "microsoftEntraId")
+	@Mapping(source = "givenName", target = "firstName")
+	@Mapping(source = "surname", target = "lastName")
+	@Mapping(source = "mail", target = "businessEmailAddress")
+	UserEntity toEntity(MSGraphUser graphUser);
 
 	/**
 	 * Maps a language id to a {@link LanguageEntity}.


### PR DESCRIPTION
## Summary
Implement `POST /api/v1/users/find-or-create` operation that takes in an email and:

* If the email exists via Microsoft Entra:
  * Fetches the user information
  * If the user exists in the DB
    * Reuse the existing user information
  * Else create a new user
* Else return an error 

## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
_(check all that apply by placing an `x` in the relevant boxes)_

- [ ] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>