### PR TITLE
refactor(frontend): save personal information in profile data

### DIFF
--- a/frontend/app/routes/employee/profile/personal-information.tsx
+++ b/frontend/app/routes/employee/profile/personal-information.tsx
@@ -6,7 +6,7 @@ import * as v from 'valibot';
 
 import type { Route } from '../profile/+types/personal-information';
 
-import type { Profile } from '~/.server/domain/models';
+import type { Profile, ProfilePutModel } from '~/.server/domain/models';
 import { getLanguageForCorrespondenceService } from '~/.server/domain/services/language-for-correspondence-service';
 import { getProfileService } from '~/.server/domain/services/profile-service';
 import { getUserService } from '~/.server/domain/services/user-service';
@@ -98,9 +98,19 @@ export async function action({ context, params, request }: Route.ActionArgs) {
   }
 
   // Update the profile (without fields for updating user)
+
+  const profilePayload: ProfilePutModel = {
+    ...currentProfile,
+    ...personalInformationForProfile,
+    preferredLanguages: [],
+    preferredCities: [],
+    preferredClassification: [],
+    preferredEmploymentOpportunities: [],
+  };
+
   const updateResult = await profileService.updateProfileById(
     currentProfile.id,
-    personalInformationForProfile,
+    profilePayload,
     context.session.authState.accessToken,
   );
 
@@ -129,8 +139,8 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
   return {
     documentTitle: t('app:personal-information.page-title'),
     defaultValues: {
-      firstName: profileData.profileUser.lastName,
-      lastName: profileData.profileUser.firstName,
+      firstName: profileData.profileUser.firstName,
+      lastName: profileData.profileUser.lastName,
       personalRecordIdentifier: profileData.profileUser.personalRecordIdentifier,
       languageOfCorrespondence: profileData.languageOfCorrespondence,
       businessEmailAddress: currentUser.businessEmailAddress ?? profileData.profileUser.businessEmailAddress,

--- a/frontend/app/routes/hr-advisor/employee-profile/personal-information.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/personal-information.tsx
@@ -6,7 +6,7 @@ import * as v from 'valibot';
 
 import type { Route } from '../employee-profile/+types/personal-information';
 
-import type { Profile } from '~/.server/domain/models';
+import type { Profile, ProfilePutModel } from '~/.server/domain/models';
 import { getLanguageForCorrespondenceService } from '~/.server/domain/services/language-for-correspondence-service';
 import { getProfileService } from '~/.server/domain/services/profile-service';
 import { getUserService } from '~/.server/domain/services/user-service';
@@ -100,9 +100,19 @@ export async function action({ context, params, request }: Route.ActionArgs) {
   }
 
   // Update the profile (without fields for updating user)
+
+  const profilePayload: ProfilePutModel = {
+    ...profile,
+    ...personalInformationForProfile,
+    preferredLanguages: [],
+    preferredCities: [],
+    preferredClassification: [],
+    preferredEmploymentOpportunities: [],
+  };
+
   const updateProfileResult = await profileService.updateProfileById(
     profile.id,
-    personalInformationForProfile,
+    profilePayload,
     context.session.authState.accessToken,
   );
 


### PR DESCRIPTION
## Summary

[AB#6769](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6769/)
[AB#6779](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6779/)
save personal information in profile data
Running the api locally, the profile data and user data are saved  from personal information screen

## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)


