### PR TITLE
Fixed wfaStatus error not appearing for field

### DIFF
--- a/frontend/app/routes/page-components/employees/employment-information/form.tsx
+++ b/frontend/app/routes/page-components/employees/employment-information/form.tsx
@@ -215,7 +215,7 @@ export function EmploymentInformationForm({
               <InputRadios
                 id="wfaStatus"
                 name="wfaStatus"
-                errorMessage={t(extractValidationKey(formErrors?.wfaStatus))}
+                errorMessage={t(extractValidationKey(formErrors?.wfaStatusId))}
                 required
                 options={wfaStatusOptions}
                 legend={t('employment-information.wfa-status')}


### PR DESCRIPTION
## Summary

Fixed wfaStatus error not appearing for field

Changed it to use "`formErrors?.wfaStatusId`"

[ADO#6777](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6777)

<img width="750" height="484" alt="image" src="https://github.com/user-attachments/assets/3fc9650a-b7f3-4259-a108-1d889a9664cc" />


## Types of changes

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades
