### PR TITLE
config(frontend): disable mock services for int environment

### DIFF
--- a/gitops/nonprod/overlays/int/configs/vacman-frontend.conf
+++ b/gitops/nonprod/overlays/int/configs/vacman-frontend.conf
@@ -36,17 +36,17 @@ ENABLE_DEVMODE_OIDC=
 # Classification Level, Branch or Service Canada Region, Directorate, Province, Language, Employment opportunities type and Qualifications (level of education) lookups are mocked in the frontend.
 # Note: Although the default is false in production mode, you can override it to true
 # for local development on localhost when testing with production-like settings.
-ENABLE_LOOKUP_FIELD_SERVICES_MOCK=true
+ENABLE_LOOKUP_FIELD_SERVICES_MOCK=false
 
 # Enable the mock user service for development purposes (default: false in production)
 # Note: Although the default is false in production mode, you can override it to true
 # for local development on localhost when testing with production-like settings.
-ENABLE_USER_SERVICES_MOCK=true
+ENABLE_USER_SERVICES_MOCK=false
 
 # Enable the mock profile service for development purposes (default: false in production)
 # Note: Although the default is false in production mode, you can override it to true
 # for local development on localhost when testing with production-like settings.
-ENABLE_PROFILE_SERVICES_MOCK=true
+ENABLE_PROFILE_SERVICES_MOCK=false
 
 # Enable the mock request service for development purposes (default: false in production)
 # Note: Although the default is false in production mode, you can override it to true


### PR DESCRIPTION
This pull request updates the `vacman-frontend.conf` configuration for the `int` (integration) environment to disable several mock services that were previously enabled. This change ensures the application uses real backend services instead of mocked data.

Configuration changes:

* Set `ENABLE_LOOKUP_FIELD_SERVICES_MOCK`, `ENABLE_USER_SERVICES_MOCK`, and `ENABLE_PROFILE_SERVICES_MOCK` to `false` to disable mock services for lookups, user, and profile data in the integration environment.