### PR TITLE
fix(frontend) details not allowed as child of span

### DIFF
--- a/frontend/app/components/input-help.tsx
+++ b/frontend/app/components/input-help.tsx
@@ -2,7 +2,7 @@ import type { ComponentProps, ReactNode } from 'react';
 
 import { cn } from '~/utils/tailwind-utils';
 
-export interface InputHelpProps extends ComponentProps<'span'> {
+export interface InputHelpProps extends ComponentProps<'div'> {
   children: ReactNode;
   id: string;
 }
@@ -10,8 +10,8 @@ export interface InputHelpProps extends ComponentProps<'span'> {
 export function InputHelp(props: InputHelpProps) {
   const { children, className, ...restProps } = props;
   return (
-    <span className={cn('block max-w-prose text-gray-500', className)} data-testid="input-help" {...restProps}>
+    <div className={cn('block max-w-prose text-gray-500', className)} data-testid="input-help" {...restProps}>
       {children}
-    </span>
+    </div>
   );
 }

--- a/frontend/tests/components/__snapshots__/date-picker-field.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/date-picker-field.test.tsx.snap
@@ -835,13 +835,13 @@ exports[`DatePickerField > should render date picker field component with help m
           legend date picker field test
         </span>
       </legend>
-      <span
+      <div
         class="block max-w-prose text-gray-500"
         data-testid="input-help"
         id="date-picker-id-help-primary"
       >
         help message primary
-      </span>
+      </div>
       <div
         class="flex flex-col space-y-2 sm:flex-row sm:space-y-0 sm:space-x-2"
       >
@@ -1011,13 +1011,13 @@ exports[`DatePickerField > should render date picker field component with help m
           />
         </div>
       </div>
-      <span
+      <div
         class="block max-w-prose text-gray-500"
         data-testid="input-help"
         id="date-picker-id-help-secondary"
       >
         help message secondary
-      </span>
+      </div>
     </fieldset>
   </div>
 </div>

--- a/frontend/tests/components/__snapshots__/input-checkboxes.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/input-checkboxes.test.tsx.snap
@@ -12,23 +12,23 @@ exports[`InputCheckboxes > should display error message > expected html 1`] = `
 `;
 
 exports[`InputCheckboxes > should display helpMessagePrimary > expected html 1`] = `
-<span
+<div
   class="block max-w-prose text-gray-500"
   data-testid="input-help"
   id="input-checkboxes-test-id-help-primary"
 >
   Primary help message
-</span>
+</div>
 `;
 
 exports[`InputCheckboxes > should display helpMessageSecondary > expected html 1`] = `
-<span
+<div
   class="block max-w-prose text-gray-500"
   data-testid="input-help"
   id="input-checkboxes-test-id-help-secondary"
 >
   Secondary help message
-</span>
+</div>
 `;
 
 exports[`InputCheckboxes > should render component with legend and options > expected html 1`] = `

--- a/frontend/tests/components/__snapshots__/input-field.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/input-field.test.tsx.snap
@@ -96,13 +96,13 @@ exports[`InputField > should render input field with help message > expected htm
       type="text"
       value="default value"
     />
-    <span
+    <div
       class="block max-w-prose text-gray-500"
       data-testid="input-help"
       id="input-text-field-test-id-help-secondary"
     >
       help message
-    </span>
+    </div>
   </div>
 </div>
 `;

--- a/frontend/tests/components/__snapshots__/input-file.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/input-file.test.tsx.snap
@@ -126,13 +126,13 @@ exports[`InputFile > should render input file with help message > expected html 
       </span>
       input-file.no-file
     </label>
-    <span
+    <div
       class="block max-w-prose text-gray-500"
       data-testid="input-help"
       id="input-file-test-id-help-secondary"
     >
       help message
-    </span>
+    </div>
   </div>
 </div>
 `;

--- a/frontend/tests/components/__snapshots__/input-help.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/input-help.test.tsx.snap
@@ -2,12 +2,12 @@
 
 exports[`InputHelp > should render input help component > expected html 1`] = `
 <div>
-  <span
+  <div
     class="block max-w-prose text-gray-500"
     data-testid="input-help"
     id="id"
   >
     input help
-  </span>
+  </div>
 </div>
 `;

--- a/frontend/tests/components/__snapshots__/input-pattern-field.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/input-pattern-field.test.tsx.snap
@@ -266,13 +266,13 @@ exports[`InputPatternField > should render with help message > expected html 1`]
       type="text"
       value="800 000 002"
     />
-    <span
+    <div
       class="block max-w-prose text-gray-500 mt-2"
       data-testid="input-pattern-field-help-secondary"
       id="input-pattern-field-test-id-help-secondary"
     >
       help message
-    </span>
+    </div>
   </div>
 </div>
 `;

--- a/frontend/tests/components/__snapshots__/input-phone-field.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/input-phone-field.test.tsx.snap
@@ -138,13 +138,13 @@ exports[`InputPhoneField > should render with help message > expected html 1`] =
       type="tel"
       value="(514) 666-7777"
     />
-    <span
+    <div
       class="block max-w-prose text-gray-500 mt-2"
       data-testid="input-phone-field-help-secondary"
       id="input-phone-field-test-id-help-secondary"
     >
       help message
-    </span>
+    </div>
   </div>
 </div>
 `;

--- a/frontend/tests/components/__snapshots__/input-radios.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/input-radios.test.tsx.snap
@@ -104,13 +104,13 @@ exports[`InputRadios > displays helpMessagePrimary > expected html 1`] = `
         Test Legend
       </span>
     </legend>
-    <span
+    <div
       class="block max-w-prose text-gray-500 mb-2"
       data-testid="input-field-help-primary-it"
       id="input-radios-it-help-primary"
     >
       Primary help message
-    </span>
+    </div>
     <ul
       class="space-y-2"
     >
@@ -243,13 +243,13 @@ exports[`InputRadios > displays helpMessageSecondary > expected html 1`] = `
         </div>
       </li>
     </ul>
-    <span
+    <div
       class="block max-w-prose text-gray-500 mt-2"
       data-testid="input-field-help-secondary-it"
       id="input-radios-it-help-secondary"
     >
       Secondary help message
-    </span>
+    </div>
   </fieldset>
 </div>
 `;

--- a/frontend/tests/components/__snapshots__/input-select.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/input-select.test.tsx.snap
@@ -145,13 +145,13 @@ exports[`InputSelect > should render input select component with help message > 
         second option
       </option>
     </select>
-    <span
+    <div
       class="block max-w-prose text-gray-500 mt-2"
       data-testid="input-some-id-select-help"
       id="input-some-id-help"
     >
       help message
-    </span>
+    </div>
   </div>
 </div>
 `;

--- a/frontend/tests/components/__snapshots__/input-textarea.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/input-textarea.test.tsx.snap
@@ -113,13 +113,13 @@ exports[`InputTextarea > should render with help message > expected html 1`] = `
         label test
       </span>
     </label>
-    <span
+    <div
       class="block max-w-prose text-gray-500"
       data-testid="input-textarea-help"
       id="input-test-id-help"
     >
       help message
-    </span>
+    </div>
     <div
       class="relative"
     >


### PR DESCRIPTION
## Summary

According to the W3C HTML validator, `<detail>` cannot be a child of `<span>`. 

