### PR TITLE
fix(auth): check for token expiry and re-auth

### DIFF
--- a/frontend/app/.server/utils/auth-utils.ts
+++ b/frontend/app/.server/utils/auth-utils.ts
@@ -44,7 +44,7 @@ export function requireAuthentication(
   const currentTime = Math.floor(Date.now() / 1000);
   const clockSkew = 10; // seconds
 
-  if (exp && (currentTime - clockSkew) >= exp) {
+  if (exp && currentTime - clockSkew >= exp) {
     log.debug('JWT access token has expired (with clock skew); redirecting to login page');
     throw redirect(returnToUrl);
   }

--- a/frontend/app/.server/utils/auth-utils.ts
+++ b/frontend/app/.server/utils/auth-utils.ts
@@ -45,10 +45,6 @@ export function requireAuthentication(
 
   if (exp && currentTime >= exp) {
     log.debug('JWT access token has expired; redirecting to login page');
-
-    // Clear the expired auth state
-    delete session.authState;
-
     throw redirect(returnToUrl);
   }
 }

--- a/frontend/app/.server/utils/auth-utils.ts
+++ b/frontend/app/.server/utils/auth-utils.ts
@@ -39,12 +39,13 @@ export function requireAuthentication(
     throw redirect(returnToUrl);
   }
 
-  // Check if the JWT access token has expired
+  // Check if the JWT access token has expired, allowing for clock skew
   const { exp } = session.authState.accessTokenClaims;
   const currentTime = Math.floor(Date.now() / 1000);
+  const clockSkew = 10; // seconds
 
-  if (exp && currentTime >= exp) {
-    log.debug('JWT access token has expired; redirecting to login page');
+  if (exp && (currentTime - clockSkew) >= exp) {
+    log.debug('JWT access token has expired (with clock skew); redirecting to login page');
     throw redirect(returnToUrl);
   }
 }

--- a/frontend/app/.server/utils/auth-utils.ts
+++ b/frontend/app/.server/utils/auth-utils.ts
@@ -42,9 +42,9 @@ export function requireAuthentication(
   // Check if the JWT access token has expired, allowing for clock skew
   const { exp } = session.authState.accessTokenClaims;
   const currentTime = Math.floor(Date.now() / 1000);
-  const clockSkew = 10; // seconds
+  const clockSkewSeconds = 10;
 
-  if (exp && currentTime - clockSkew >= exp) {
+  if (exp && currentTime - clockSkewSeconds >= exp) {
     log.debug('JWT access token has expired (with clock skew); redirecting to login page');
     throw redirect(returnToUrl);
   }

--- a/frontend/app/.server/utils/auth-utils.ts
+++ b/frontend/app/.server/utils/auth-utils.ts
@@ -39,7 +39,7 @@ export function requireAuthentication(
 
   // Check if the JWT access token has expired
   const { exp } = session.authState.accessTokenClaims;
-  const currentTime = Math.floor(Date.now() / 1000); // Current time in seconds since epoch
+  const currentTime = Math.floor(Date.now() / 1000);
 
   if (exp && currentTime >= exp) {
     log.debug('JWT access token has expired; redirecting to login page');

--- a/frontend/tests/.server/utils/auth-utils.test.ts
+++ b/frontend/tests/.server/utils/auth-utils.test.ts
@@ -53,9 +53,6 @@ describe('auth-utils', () => {
 
       expect(() => requireAuthentication(session, request)).toThrow();
       expect(vi.mocked(redirect)).toHaveBeenCalledWith('/auth/login?returnto=%2Fprotected');
-
-      // Should clear the expired auth state
-      expect(session.authState).toBeUndefined();
     });
 
     it('should pass when JWT is valid and not expired', () => {

--- a/frontend/tests/.server/utils/auth-utils.test.ts
+++ b/frontend/tests/.server/utils/auth-utils.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for authentication utilities.
+ */
+import { redirect } from 'react-router';
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { requireAuthentication, requireAllRoles, requireAnyRole } from '~/.server/utils/auth-utils';
+
+// Mock the redirect function
+vi.mock('react-router', () => ({
+  redirect: vi.fn(),
+}));
+
+describe('auth-utils', () => {
+  describe('requireAuthentication', () => {
+    it('should throw redirect when session has no authState', () => {
+      const session: AppSession = {} as AppSession;
+      const request = new Request('https://example.com/test?param=value');
+
+      expect(() => requireAuthentication(session, request)).toThrow();
+      expect(vi.mocked(redirect)).toHaveBeenCalledWith('/auth/login?returnto=%2Ftest%3Fparam%3Dvalue');
+    });
+
+    it('should throw redirect when JWT has expired', () => {
+      const currentTime = Math.floor(Date.now() / 1000);
+      const expiredTime = currentTime - 3600; // 1 hour ago
+
+      const session: AppSession = {
+        authState: {
+          accessToken: 'test-token',
+          accessTokenClaims: {
+            exp: expiredTime,
+            aud: 'test-client',
+            iss: 'test-issuer',
+            sub: 'test-user',
+            iat: expiredTime - 3600,
+            oid: 'test-oid',
+          },
+          idToken: 'test-id-token',
+          idTokenClaims: {
+            exp: expiredTime,
+            aud: 'test-client',
+            iss: 'test-issuer',
+            sub: 'test-user',
+            iat: expiredTime - 3600,
+            oid: 'test-oid',
+          },
+        },
+      } as AppSession;
+
+      const request = new Request('https://example.com/protected');
+
+      expect(() => requireAuthentication(session, request)).toThrow();
+      expect(vi.mocked(redirect)).toHaveBeenCalledWith('/auth/login?returnto=%2Fprotected');
+
+      // Should clear the expired auth state
+      expect(session.authState).toBeUndefined();
+    });
+
+    it('should pass when JWT is valid and not expired', () => {
+      const currentTime = Math.floor(Date.now() / 1000);
+      const futureTime = currentTime + 3600; // 1 hour from now
+
+      const session: AppSession = {
+        authState: {
+          accessToken: 'test-token',
+          accessTokenClaims: {
+            exp: futureTime,
+            aud: 'test-client',
+            iss: 'test-issuer',
+            sub: 'test-user',
+            iat: currentTime,
+            oid: 'test-oid',
+          },
+          idToken: 'test-id-token',
+          idTokenClaims: {
+            exp: futureTime,
+            aud: 'test-client',
+            iss: 'test-issuer',
+            sub: 'test-user',
+            iat: currentTime,
+            oid: 'test-oid',
+          },
+        },
+      } as AppSession;
+
+      const request = new Request('https://example.com/protected');
+
+      // Should not throw
+      expect(() => requireAuthentication(session, request)).not.toThrow();
+
+      // Should not clear the auth state
+      expect(session.authState).toBeDefined();
+    });
+
+    it('should handle missing exp claim gracefully', () => {
+      const currentTime = Math.floor(Date.now() / 1000);
+
+      const session: AppSession = {
+        authState: {
+          accessToken: 'test-token',
+          accessTokenClaims: {
+            // No exp claim
+            aud: 'test-client',
+            iss: 'test-issuer',
+            sub: 'test-user',
+            iat: currentTime,
+            oid: 'test-oid',
+          },
+          idToken: 'test-id-token',
+          idTokenClaims: {
+            aud: 'test-client',
+            iss: 'test-issuer',
+            sub: 'test-user',
+            iat: currentTime,
+            oid: 'test-oid',
+          },
+        },
+      } as AppSession;
+
+      const request = new Request('https://example.com/protected');
+
+      // Should not throw when exp claim is missing
+      expect(() => requireAuthentication(session, request)).not.toThrow();
+    });
+  });
+
+  describe('requireAllRoles', () => {
+    it('should call requireAuthentication first', () => {
+      const session: AppSession = {} as AppSession;
+      const url = new URL('https://example.com/test');
+
+      expect(() => requireAllRoles(session, url, ['admin'])).toThrow();
+      expect(vi.mocked(redirect)).toHaveBeenCalled();
+    });
+  });
+
+  describe('requireAnyRole', () => {
+    it('should call requireAuthentication first', () => {
+      const session: AppSession = {} as AppSession;
+      const url = new URL('https://example.com/test');
+
+      expect(() => requireAnyRole(session, url, ['admin'])).toThrow();
+      expect(vi.mocked(redirect)).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
This pull request enhances authentication logic by ensuring that JWT expiration is properly checked and handled in authentication utilities. It also adds comprehensive tests for these behaviors to improve reliability and maintainability.

**Authentication logic improvements:**

* Added a check in `requireAuthentication` (in `auth-utils.ts`) to detect if the JWT access token is expired, and redirect the user to the login page if necessary.
* Updated `requireAllRoles` and `requireAnyRole` to always call `requireAuthentication` first, ensuring both authentication and token validity are enforced before checking user roles. [[1]](diffhunk://#diff-bef08db62a238509ba3a1332c3810ebe53954b1305b064d623d445b9b618f784L58-R75) [[2]](diffhunk://#diff-bef08db62a238509ba3a1332c3810ebe53954b1305b064d623d445b9b618f784L86-R99)

**Testing enhancements:**

* Added a new test suite (`auth-utils.test.ts`) covering scenarios for `requireAuthentication`, `requireAllRoles`, and `requireAnyRole`, including cases for missing auth state, expired tokens, valid tokens, and missing expiration claims.