### PR TITLE
refactor(frontend) BackLink component

### DIFF
--- a/frontend/app/components/back-link.tsx
+++ b/frontend/app/components/back-link.tsx
@@ -1,0 +1,36 @@
+import type { Params, Path } from 'react-router';
+
+import { faAngleLeft } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useTranslation } from 'react-i18next';
+
+import { InlineLink } from '~/components/links';
+import type { I18nRouteFile } from '~/i18n-routes';
+import { cn } from '~/utils/tailwind-utils';
+
+interface BackLinkProps {
+  file: I18nRouteFile;
+  params?: Params;
+  className?: string;
+  hash?: Path['hash'];
+  search?: Path['search'];
+  translationKey?: string;
+}
+
+export function BackLink({ className, file, params, hash, search, translationKey = 'app:profile.back' }: BackLinkProps) {
+  const { t } = useTranslation();
+  const linkText = t(translationKey);
+  return (
+    <InlineLink
+      className={cn('inline-flex items-center', className)}
+      file={file}
+      params={params}
+      hash={hash}
+      search={search}
+      aria-label={linkText}
+    >
+      <FontAwesomeIcon icon={faAngleLeft} />
+      {linkText}
+    </InlineLink>
+  );
+}

--- a/frontend/app/routes/employee/profile/employment-information.tsx
+++ b/frontend/app/routes/employee/profile/employment-information.tsx
@@ -1,7 +1,6 @@
 import type { RouteHandle } from 'react-router';
 import { data } from 'react-router';
 
-import { useTranslation } from 'react-i18next';
 import * as v from 'valibot';
 
 import type { Route } from '../profile/+types/employment-information';
@@ -18,7 +17,7 @@ import { extractUniqueBranchesFromDirectorates } from '~/.server/utils/directora
 import { requirePrivacyConsentForOwnProfile } from '~/.server/utils/privacy-consent-utils';
 import { getHrAdvisors, hasEmploymentDataChanged, omitObjectProperties } from '~/.server/utils/profile-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
-import { InlineLink } from '~/components/links';
+import { BackLink } from '~/components/back-link';
 import { PROFILE_STATUS_ID, PROFILE_STATUS_PENDING } from '~/domain/constants';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
 import { getTranslation } from '~/i18n-config.server';
@@ -142,14 +141,11 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 }
 
 export default function EmploymentInformation({ loaderData, actionData, params }: Route.ComponentProps) {
-  const { t } = useTranslation(handle.i18nNamespace);
   const errors = actionData?.errors;
 
   return (
     <>
-      <InlineLink className="mt-6 block" file="routes/employee/profile/index.tsx" params={params} id="back-button">
-        {`< ${t('app:profile.back')}`}
-      </InlineLink>
+      <BackLink className="mt-6" file="routes/employee/profile/index.tsx" params={params} />
       <div className="max-w-prose">
         <EmploymentInformationForm
           cancelLink={'routes/employee/profile/index.tsx'}

--- a/frontend/app/routes/employee/profile/personal-information.tsx
+++ b/frontend/app/routes/employee/profile/personal-information.tsx
@@ -1,7 +1,6 @@
 import type { RouteHandle } from 'react-router';
 import { data } from 'react-router';
 
-import { useTranslation } from 'react-i18next';
 import * as v from 'valibot';
 
 import type { Route } from '../profile/+types/personal-information';
@@ -13,7 +12,7 @@ import { getUserService } from '~/.server/domain/services/user-service';
 import { requireAuthentication } from '~/.server/utils/auth-utils';
 import { requirePrivacyConsentForOwnProfile } from '~/.server/utils/privacy-consent-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
-import { InlineLink } from '~/components/links';
+import { BackLink } from '~/components/back-link';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/layout';
@@ -154,14 +153,11 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 }
 
 export default function PersonalInformation({ loaderData, actionData, params }: Route.ComponentProps) {
-  const { t } = useTranslation(handle.i18nNamespace);
   const errors = actionData?.errors;
 
   return (
     <>
-      <InlineLink className="mt-6 block" file="routes/employee/profile/index.tsx" params={params} id="back-button">
-        {`< ${t('app:profile.back')}`}
-      </InlineLink>
+      <BackLink className="mt-6" file="routes/employee/profile/index.tsx" params={params} />
       <div className="max-w-prose">
         <PersonalInformationForm
           cancelLink={'routes/employee/profile/index.tsx'}

--- a/frontend/app/routes/employee/profile/referral-preferences.tsx
+++ b/frontend/app/routes/employee/profile/referral-preferences.tsx
@@ -1,7 +1,6 @@
 import type { RouteHandle } from 'react-router';
 import { data } from 'react-router';
 
-import { useTranslation } from 'react-i18next';
 import * as v from 'valibot';
 
 import type { Route } from './+types/referral-preferences';
@@ -17,7 +16,7 @@ import { requireAuthentication } from '~/.server/utils/auth-utils';
 import { requirePrivacyConsentForOwnProfile } from '~/.server/utils/privacy-consent-utils';
 import { hasReferralDataChanged } from '~/.server/utils/profile-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
-import { InlineLink } from '~/components/links';
+import { BackLink } from '~/components/back-link';
 import { PROFILE_STATUS_ID, PROFILE_STATUS_PENDING, REQUIRE_OPTIONS } from '~/domain/constants';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
 import { getTranslation } from '~/i18n-config.server';
@@ -148,14 +147,11 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 }
 
 export default function PersonalDetails({ loaderData, actionData, params }: Route.ComponentProps) {
-  const { t } = useTranslation(handle.i18nNamespace);
   const errors = actionData?.errors;
 
   return (
     <>
-      <InlineLink className="mt-6 block" file="routes/employee/profile/index.tsx" params={params} id="back-button">
-        {`< ${t('app:profile.back')}`}
-      </InlineLink>
+      <BackLink className="mt-6" file="routes/employee/profile/index.tsx" params={params} />
       <div className="max-w-prose">
         <ReferralPreferencesForm
           cancelLink={'routes/employee/profile/index.tsx'}

--- a/frontend/app/routes/hr-advisor/employee-profile/employment-information.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/employment-information.tsx
@@ -1,7 +1,6 @@
 import type { RouteHandle } from 'react-router';
 import { data } from 'react-router';
 
-import { useTranslation } from 'react-i18next';
 import * as v from 'valibot';
 
 import type { Route } from '../employee-profile/+types/employment-information';
@@ -17,7 +16,7 @@ import { requireAuthentication } from '~/.server/utils/auth-utils';
 import { extractUniqueBranchesFromDirectorates } from '~/.server/utils/directorate-utils';
 import { getHrAdvisors, omitObjectProperties } from '~/.server/utils/profile-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
-import { InlineLink } from '~/components/links';
+import { BackLink } from '~/components/back-link';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/layout';
@@ -133,14 +132,11 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 }
 
 export default function EmploymentInformation({ loaderData, actionData, params }: Route.ComponentProps) {
-  const { t } = useTranslation(handle.i18nNamespace);
   const errors = actionData?.errors;
 
   return (
     <>
-      <InlineLink className="mt-6 block" file="routes/hr-advisor/employee-profile/index.tsx" params={params} id="back-button">
-        {`< ${t('app:profile.back')}`}
-      </InlineLink>
+      <BackLink className="mt-6" file="routes/hr-advisor/employee-profile/index.tsx" params={params} />
       <div className="max-w-prose">
         <EmploymentInformationForm
           cancelLink={'routes/hr-advisor/employee-profile/index.tsx'}

--- a/frontend/app/routes/hr-advisor/employee-profile/personal-information.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/personal-information.tsx
@@ -1,7 +1,6 @@
 import { data } from 'react-router';
 import type { RouteHandle } from 'react-router';
 
-import { useTranslation } from 'react-i18next';
 import * as v from 'valibot';
 
 import type { Route } from '../employee-profile/+types/personal-information';
@@ -12,7 +11,7 @@ import { getProfileService } from '~/.server/domain/services/profile-service';
 import { getUserService } from '~/.server/domain/services/user-service';
 import { requireAuthentication } from '~/.server/utils/auth-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
-import { InlineLink } from '~/components/links';
+import { BackLink } from '~/components/back-link';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/layout';
@@ -159,14 +158,11 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 }
 
 export default function PersonalInformation({ loaderData, actionData, params }: Route.ComponentProps) {
-  const { t } = useTranslation(handle.i18nNamespace);
   const errors = actionData?.errors;
 
   return (
     <>
-      <InlineLink className="mt-6 block" file="routes/hr-advisor/employee-profile/index.tsx" params={params} id="back-button">
-        {`< ${t('app:profile.back')}`}
-      </InlineLink>
+      <BackLink className="mt-6" file="routes/hr-advisor/employee-profile/index.tsx" params={params} />
       <div className="max-w-prose">
         <PersonalInformationForm
           cancelLink={'routes/hr-advisor/employee-profile/index.tsx'}

--- a/frontend/app/routes/hr-advisor/employee-profile/referral-preferences.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/referral-preferences.tsx
@@ -1,7 +1,6 @@
 import type { RouteHandle } from 'react-router';
 import { data } from 'react-router';
 
-import { useTranslation } from 'react-i18next';
 import * as v from 'valibot';
 
 import type { Route } from './+types/referral-preferences';
@@ -15,7 +14,7 @@ import { getProfileService } from '~/.server/domain/services/profile-service';
 import { getProvinceService } from '~/.server/domain/services/province-service';
 import { requireAuthentication } from '~/.server/utils/auth-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
-import { InlineLink } from '~/components/links';
+import { BackLink } from '~/components/back-link';
 import { REQUIRE_OPTIONS } from '~/domain/constants';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
 import { getTranslation } from '~/i18n-config.server';
@@ -137,14 +136,11 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 }
 
 export default function PersonalDetails({ loaderData, actionData, params }: Route.ComponentProps) {
-  const { t } = useTranslation(handle.i18nNamespace);
   const errors = actionData?.errors;
 
   return (
     <>
-      <InlineLink className="mt-6 block" file="routes/hr-advisor/employee-profile/index.tsx" params={params} id="back-button">
-        {`< ${t('app:profile.back')}`}
-      </InlineLink>
+      <BackLink className="mt-6" file="routes/hr-advisor/employee-profile/index.tsx" params={params} />
       <div className="max-w-prose">
         <ReferralPreferencesForm
           cancelLink={'routes/hr-advisor/employee-profile/index.tsx'}


### PR DESCRIPTION
## Summary

<img width="519" height="126" alt="image" src="https://github.com/user-attachments/assets/524340a7-8ae9-4bdd-849e-4d470b367dd2" />

Long story short, while looking for a11y issues, I noticed the "back to profile" links were using `"<"` in the link text, which would be read by a screenreader as "Less than back to profle".  Seeing as how we have this back to profile link on several pages, I guess it can be extracted out as a component.

