### PR TITLE
bugfix(frontend): remove hover underline from card titles where card title is not a link

### DIFF
--- a/frontend/app/components/card.tsx
+++ b/frontend/app/components/card.tsx
@@ -61,7 +61,7 @@ export function CardTitle({ asChild, className, ...props }: CardTitleProps) {
   return (
     <Component
       className={cn(
-        'leading-none font-semibold group-[&:is(a)]:text-slate-700 group-[&:is(a)]:underline group-[&:is(a):focus]:text-blue-700 group-[&:is(a):hover]:text-blue-700 hover:underline hover:underline-offset-4',
+        'leading-none font-semibold group-[&:is(a)]:text-slate-700 group-[&:is(a)]:underline group-[&:is(a):focus]:text-blue-700 group-[&:is(a):hover]:text-blue-700 hover:underline-offset-4',
         className,
       )}
       {...props}

--- a/frontend/tests/components/__snapshots__/card.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/card.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Card > should render a card > expected html 1`] = `
       class="flex flex-col space-y-1.5 p-6"
     >
       <h2
-        class="leading-none font-semibold group-[&:is(a)]:text-slate-700 group-[&:is(a)]:underline group-[&:is(a):focus]:text-blue-700 group-[&:is(a):hover]:text-blue-700 hover:underline hover:underline-offset-4"
+        class="leading-none font-semibold group-[&:is(a)]:text-slate-700 group-[&:is(a)]:underline group-[&:is(a):focus]:text-blue-700 group-[&:is(a):hover]:text-blue-700 hover:underline-offset-4"
       >
         Card Title
       </h2>
@@ -34,7 +34,7 @@ exports[`Card > should render a card with a link > expected html 1`] = `
       class="flex flex-col space-y-1.5 p-6"
     >
       <h2
-        class="leading-none font-semibold group-[&:is(a)]:text-slate-700 group-[&:is(a)]:underline group-[&:is(a):focus]:text-blue-700 group-[&:is(a):hover]:text-blue-700 hover:underline hover:underline-offset-4"
+        class="leading-none font-semibold group-[&:is(a)]:text-slate-700 group-[&:is(a)]:underline group-[&:is(a):focus]:text-blue-700 group-[&:is(a):hover]:text-blue-700 hover:underline-offset-4"
       >
         Card Title
       </h2>
@@ -77,7 +77,7 @@ exports[`Card > should render a card with a link with an icon > expected html 1`
         class="flex flex-col space-y-1.5 p-0"
       >
         <h2
-          class="leading-none font-semibold group-[&:is(a)]:text-slate-700 group-[&:is(a)]:underline group-[&:is(a):focus]:text-blue-700 group-[&:is(a):hover]:text-blue-700 hover:underline hover:underline-offset-4"
+          class="leading-none font-semibold group-[&:is(a)]:text-slate-700 group-[&:is(a)]:underline group-[&:is(a):focus]:text-blue-700 group-[&:is(a):hover]:text-blue-700 hover:underline-offset-4"
         >
           Card Title
         </h2>
@@ -121,7 +121,7 @@ exports[`Card > should render a card with a link with an icon, content, footer w
         class="flex flex-col space-y-1.5 p-0"
       >
         <h2
-          class="leading-none font-semibold group-[&:is(a)]:text-slate-700 group-[&:is(a)]:underline group-[&:is(a):focus]:text-blue-700 group-[&:is(a):hover]:text-blue-700 hover:underline hover:underline-offset-4"
+          class="leading-none font-semibold group-[&:is(a)]:text-slate-700 group-[&:is(a)]:underline group-[&:is(a):focus]:text-blue-700 group-[&:is(a):hover]:text-blue-700 hover:underline-offset-4"
         >
           Card Title
         </h2>
@@ -173,7 +173,7 @@ exports[`Card > should render a card with a link with an image > expected html 1
       class="flex flex-col space-y-1.5 p-6"
     >
       <h2
-        class="leading-none font-semibold group-[&:is(a)]:text-slate-700 group-[&:is(a)]:underline group-[&:is(a):focus]:text-blue-700 group-[&:is(a):hover]:text-blue-700 hover:underline hover:underline-offset-4"
+        class="leading-none font-semibold group-[&:is(a)]:text-slate-700 group-[&:is(a)]:underline group-[&:is(a):focus]:text-blue-700 group-[&:is(a):hover]:text-blue-700 hover:underline-offset-4"
       >
         Card Title
       </h2>


### PR DESCRIPTION
## Summary

[AB#6796](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6796/) remove hover underline from card titles where card title is not a link

## Screenshots (if applicable)
The profile card titles are not underlined on hover as they are not links:
<img width="610" height="271" alt="image" src="https://github.com/user-attachments/assets/972e3337-23db-4cfb-ba1d-2d053305c56c" />
The card titles on the index are still underlined as they are links
<img width="715" height="206" alt="image" src="https://github.com/user-attachments/assets/4b5bb1f2-3973-48a8-aad8-d8823ea380db" />


## Types of changes

What types of changes does this PR introduce?

- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.

- [x] code has been linted and formatted locally

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>
