### PR TITLE
fix(route-utils): decode URL-encoded characters in findRouteByPath before normalization

### DIFF
--- a/frontend/app/utils/route-utils.ts
+++ b/frontend/app/utils/route-utils.ts
@@ -36,7 +36,9 @@ export function findRouteByFile(file: string, routes: I18nRoute[]): I18nPageRout
  * @returns The I18nPageRoute that matches the given pathname, or undefined if no route is found.
  */
 export function findRouteByPath(pathname: string, routes: I18nRoute[]): I18nPageRoute | undefined {
-  const normalizedPathname = normalizePath(pathname);
+  // Decode URL-encoded characters (e.g., %C3%A9 -> é) before normalizing
+  const decodedPathname = decodeURIComponent(pathname);
+  const normalizedPathname = normalizePath(decodedPathname);
 
   for (const route of routes) {
     if (isI18nLayoutRoute(route)) {


### PR DESCRIPTION
This pull request updates the `findRouteByPath` function in `route-utils.ts` to improve how route matching works with URL-encoded paths. The main change is to ensure that any URL-encoded characters in the path are decoded before normalizing and matching against the route definitions.

Routing improvements:

* Updated `findRouteByPath` to decode URL-encoded characters in the input `pathname` before normalizing, ensuring correct route matching for paths containing special characters.