### PR TITLE
bugfix(frontend): fix error on saving profile

### DIFF
--- a/frontend/app/routes/employee/profile/employment-information.tsx
+++ b/frontend/app/routes/employee/profile/employment-information.tsx
@@ -15,7 +15,7 @@ import { getWFAStatuses } from '~/.server/domain/services/wfa-status-service';
 import { requireAuthentication } from '~/.server/utils/auth-utils';
 import { extractUniqueBranchesFromDirectorates } from '~/.server/utils/directorate-utils';
 import { requirePrivacyConsentForOwnProfile } from '~/.server/utils/privacy-consent-utils';
-import { getHrAdvisors, hasEmploymentDataChanged, omitObjectProperties } from '~/.server/utils/profile-utils';
+import { getHrAdvisors, hasEmploymentDataChanged, mapProfileToPutModelWithOverrides } from '~/.server/utils/profile-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { BackLink } from '~/components/back-link';
 import { PROFILE_STATUS_ID, PROFILE_STATUS_PENDING } from '~/domain/constants';
@@ -52,23 +52,15 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     context.session.authState.accessToken,
   );
 
-  const profilePayload: ProfilePutModel = {
-    ...currentProfile,
-    ...omitObjectProperties(parseResult.output, [
-      'wfaStartDateYear',
-      'wfaStartDateMonth',
-      'wfaStartDateDay',
-      'wfaEndDateYear',
-      'wfaEndDateMonth',
-      'wfaEndDateDay',
-    ]),
+  const profilePayload: ProfilePutModel = mapProfileToPutModelWithOverrides(currentProfile, {
     classificationId: parseResult.output.substantiveClassification,
     workUnitId: parseResult.output.directorate,
-    preferredLanguages: [],
-    preferredCities: [],
-    preferredClassification: [],
-    preferredEmploymentOpportunities: [],
-  };
+    cityId: parseResult.output.cityId,
+    wfaStatusId: parseResult.output.wfaStatusId,
+    wfaStartDate: parseResult.output.wfaStartDate,
+    wfaEndDate: parseResult.output.wfaEndDate,
+    hrAdvisorId: parseResult.output.hrAdvisorId,
+  });
 
   const updateResult = await profileService.updateProfileById(
     currentProfile.id,

--- a/frontend/app/routes/employee/profile/personal-information.tsx
+++ b/frontend/app/routes/employee/profile/personal-information.tsx
@@ -11,6 +11,7 @@ import { getProfileService } from '~/.server/domain/services/profile-service';
 import { getUserService } from '~/.server/domain/services/user-service';
 import { requireAuthentication } from '~/.server/utils/auth-utils';
 import { requirePrivacyConsentForOwnProfile } from '~/.server/utils/privacy-consent-utils';
+import { mapProfileToPutModelWithOverrides } from '~/.server/utils/profile-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { BackLink } from '~/components/back-link';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
@@ -98,14 +99,12 @@ export async function action({ context, params, request }: Route.ActionArgs) {
 
   // Update the profile (without fields for updating user)
 
-  const profilePayload: ProfilePutModel = {
-    ...currentProfile,
-    ...personalInformationForProfile,
-    preferredLanguages: [],
-    preferredCities: [],
-    preferredClassification: [],
-    preferredEmploymentOpportunities: [],
-  };
+  const profilePayload: ProfilePutModel = mapProfileToPutModelWithOverrides(currentProfile, {
+    languageOfCorrespondenceId: personalInformationForProfile.languageOfCorrespondenceId,
+    personalEmailAddress: personalInformationForProfile.personalEmailAddress,
+    personalPhoneNumber: personalInformationForProfile.personalPhoneNumber,
+    additionalComment: personalInformationForProfile.additionalComment,
+  });
 
   const updateResult = await profileService.updateProfileById(
     currentProfile.id,

--- a/frontend/app/routes/employee/profile/referral-preferences.tsx
+++ b/frontend/app/routes/employee/profile/referral-preferences.tsx
@@ -14,7 +14,7 @@ import { getProfileService } from '~/.server/domain/services/profile-service';
 import { getProvinceService } from '~/.server/domain/services/province-service';
 import { requireAuthentication } from '~/.server/utils/auth-utils';
 import { requirePrivacyConsentForOwnProfile } from '~/.server/utils/privacy-consent-utils';
-import { hasReferralDataChanged } from '~/.server/utils/profile-utils';
+import { hasReferralDataChanged, mapProfileToPutModelWithOverrides } from '~/.server/utils/profile-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { BackLink } from '~/components/back-link';
 import { PROFILE_STATUS_ID, PROFILE_STATUS_PENDING, REQUIRE_OPTIONS } from '~/domain/constants';
@@ -65,15 +65,14 @@ export async function action({ context, params, request }: Route.ActionArgs) {
   const oldReferralData = currentProfile;
   const newReferralData = parseResult.output;
 
-  const profilePayload: ProfilePutModel = {
-    ...currentProfile,
+  const profilePayload: ProfilePutModel = mapProfileToPutModelWithOverrides(currentProfile, {
     preferredLanguages: parseResult.output.preferredLanguages,
     preferredClassification: parseResult.output.preferredClassifications,
     preferredCities: parseResult.output.preferredCities,
     isAvailableForReferral: parseResult.output.isAvailableForReferral,
     isInterestedInAlternation: parseResult.output.isInterestedInAlternation,
     preferredEmploymentOpportunities: parseResult.output.preferredEmploymentOpportunities,
-  };
+  });
 
   const updateResult = await profileService.updateProfileById(
     currentProfile.id,

--- a/frontend/app/routes/hr-advisor/employee-profile/employment-information.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/employment-information.tsx
@@ -14,7 +14,7 @@ import { getProvinceService } from '~/.server/domain/services/province-service';
 import { getWFAStatuses } from '~/.server/domain/services/wfa-status-service';
 import { requireAuthentication } from '~/.server/utils/auth-utils';
 import { extractUniqueBranchesFromDirectorates } from '~/.server/utils/directorate-utils';
-import { getHrAdvisors, omitObjectProperties } from '~/.server/utils/profile-utils';
+import { getHrAdvisors, mapProfileToPutModelWithOverrides } from '~/.server/utils/profile-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { BackLink } from '~/components/back-link';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
@@ -53,23 +53,15 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     );
   }
 
-  const profilePayload: ProfilePutModel = {
-    ...profile,
-    ...omitObjectProperties(parseResult.output, [
-      'wfaStartDateYear',
-      'wfaStartDateMonth',
-      'wfaStartDateDay',
-      'wfaEndDateYear',
-      'wfaEndDateMonth',
-      'wfaEndDateDay',
-    ]),
+  const profilePayload: ProfilePutModel = mapProfileToPutModelWithOverrides(profile, {
     classificationId: parseResult.output.substantiveClassification,
     workUnitId: parseResult.output.directorate,
-    preferredLanguages: [],
-    preferredCities: [],
-    preferredClassification: [],
-    preferredEmploymentOpportunities: [],
-  };
+    cityId: parseResult.output.cityId,
+    wfaStatusId: parseResult.output.wfaStatusId,
+    wfaStartDate: parseResult.output.wfaStartDate,
+    wfaEndDate: parseResult.output.wfaEndDate,
+    hrAdvisorId: parseResult.output.hrAdvisorId,
+  });
 
   const updateResult = await profileService.updateProfileById(
     profile.id,

--- a/frontend/app/routes/hr-advisor/employee-profile/personal-information.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/personal-information.tsx
@@ -10,6 +10,7 @@ import { getLanguageForCorrespondenceService } from '~/.server/domain/services/l
 import { getProfileService } from '~/.server/domain/services/profile-service';
 import { getUserService } from '~/.server/domain/services/user-service';
 import { requireAuthentication } from '~/.server/utils/auth-utils';
+import { mapProfileToPutModelWithOverrides } from '~/.server/utils/profile-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { BackLink } from '~/components/back-link';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
@@ -100,14 +101,12 @@ export async function action({ context, params, request }: Route.ActionArgs) {
 
   // Update the profile (without fields for updating user)
 
-  const profilePayload: ProfilePutModel = {
-    ...profile,
-    ...personalInformationForProfile,
-    preferredLanguages: [],
-    preferredCities: [],
-    preferredClassification: [],
-    preferredEmploymentOpportunities: [],
-  };
+  const profilePayload: ProfilePutModel = mapProfileToPutModelWithOverrides(profile, {
+    languageOfCorrespondenceId: personalInformationForProfile.languageOfCorrespondenceId,
+    personalEmailAddress: personalInformationForProfile.personalEmailAddress,
+    personalPhoneNumber: personalInformationForProfile.personalPhoneNumber,
+    additionalComment: personalInformationForProfile.additionalComment,
+  });
 
   const updateProfileResult = await profileService.updateProfileById(
     profile.id,

--- a/frontend/app/routes/hr-advisor/employee-profile/referral-preferences.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/referral-preferences.tsx
@@ -13,6 +13,7 @@ import { getLanguageReferralTypeService } from '~/.server/domain/services/langua
 import { getProfileService } from '~/.server/domain/services/profile-service';
 import { getProvinceService } from '~/.server/domain/services/province-service';
 import { requireAuthentication } from '~/.server/utils/auth-utils';
+import { mapProfileToPutModelWithOverrides } from '~/.server/utils/profile-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { BackLink } from '~/components/back-link';
 import { REQUIRE_OPTIONS } from '~/domain/constants';
@@ -65,15 +66,14 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     );
   }
 
-  const profilePayload: ProfilePutModel = {
-    ...profile,
+  const profilePayload: ProfilePutModel = mapProfileToPutModelWithOverrides(profile, {
     preferredLanguages: parseResult.output.preferredLanguages,
     preferredClassification: parseResult.output.preferredClassifications,
     preferredCities: parseResult.output.preferredCities,
     isAvailableForReferral: parseResult.output.isAvailableForReferral,
     isInterestedInAlternation: parseResult.output.isInterestedInAlternation,
     preferredEmploymentOpportunities: parseResult.output.preferredEmploymentOpportunities,
-  };
+  });
 
   const updateResult = await profileService.updateProfileById(
     profile.id,


### PR DESCRIPTION
## Summary

[AB#6805](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6805/)
Fixed this bug: 
Save all the data in profile, then edit the personal information or employment information section, the referral preferences section becomes empty.

## Types of changes

What types of changes does this PR introduce?

- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.

- [x] code has been linted and formatted locally

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>
