### PR TITLE
refactor(frontend) unselect employment oppourtunities if not interested is selected

### DIFF
--- a/frontend/app/domain/constants.ts
+++ b/frontend/app/domain/constants.ts
@@ -152,3 +152,5 @@ export const USER_TYPE_HR_ADVISOR = {
   nameEn: 'HR Advisor',
   nameFr: 'Conseiller en R.H.',
 } as const;
+
+export const NOT_INTERESTED_EMPLOYMENT_OPPOURTUNITY_ID = 4;

--- a/frontend/app/routes/page-components/employees/referral-preferences/form.tsx
+++ b/frontend/app/routes/page-components/employees/referral-preferences/form.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import type { JSX } from 'react';
+import type { ChangeEvent, JSX } from 'react';
 
 import { Form } from 'react-router';
 import type { Params } from 'react-router';
@@ -31,7 +31,7 @@ import { InputMultiSelect } from '~/components/input-multiselect';
 import { InputRadios } from '~/components/input-radios';
 import type { InputRadiosProps } from '~/components/input-radios';
 import { InputSelect } from '~/components/input-select';
-import { REQUIRE_OPTIONS } from '~/domain/constants';
+import { NOT_INTERESTED_EMPLOYMENT_OPPOURTUNITY_ID, REQUIRE_OPTIONS } from '~/domain/constants';
 import type { I18nRouteFile } from '~/i18n-routes';
 import type { Errors } from '~/routes/page-components/employees/validation.server';
 import { extractValidationKey } from '~/utils/validation-utils';
@@ -72,6 +72,10 @@ export function ReferralPreferencesForm({
   const [selectedCities, setSelectedCities] = useState(formValues?.preferredCities?.map(({ id }) => id.toString()) ?? []);
   const [province, setProvince] = useState(preferredProvince?.toString());
   const [srAnnouncement, setSrAnnouncement] = useState(''); //screen reader announcement
+
+  const [checkedEmploymentTypes, setCheckedEmploymentTypes] = useState<number[]>(
+    formValues?.preferredEmploymentOpportunities?.map(({ id }) => id) ?? [],
+  );
 
   const languageReferralTypeOptions = languageReferralTypes.map((langReferral) => ({
     value: String(langReferral.id),
@@ -121,10 +125,25 @@ export function ReferralPreferencesForm({
       onChange: ({ target }) => setAlternateOpportunity(target.value === REQUIRE_OPTIONS.yes),
     },
   ];
+
+  const handlecheckedEmploymentTypesChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = Number(e.target.value);
+    const isChecked = e.target.checked;
+    if (value === NOT_INTERESTED_EMPLOYMENT_OPPOURTUNITY_ID) {
+      setCheckedEmploymentTypes(isChecked ? [NOT_INTERESTED_EMPLOYMENT_OPPOURTUNITY_ID] : []);
+    } else {
+      setCheckedEmploymentTypes((prev) =>
+        isChecked
+          ? [...prev.filter((id) => id !== NOT_INTERESTED_EMPLOYMENT_OPPOURTUNITY_ID), value]
+          : prev.filter((id) => id !== value),
+      );
+    }
+  };
   const employmentOpportunityOptions = employmentOpportunities.map((employmentOpportunity) => ({
     value: String(employmentOpportunity.id),
     children: employmentOpportunity.name,
-    defaultChecked: !!formValues?.preferredEmploymentOpportunities?.find((p) => p.id === employmentOpportunity.id),
+    checked: checkedEmploymentTypes.includes(employmentOpportunity.id),
+    onChange: handlecheckedEmploymentTypesChange,
   }));
 
   // Choice tags for classification


### PR DESCRIPTION
## Summary

In the employment-information form, if "not selected" is checked, all other checked boxes should be unselected.  If a user then selects another box while "not interested" is checked, the "not interested" box should then become unchecked.

