### PR TITLE
feat(frontend) /hiring-manager/requests

### DIFF
--- a/frontend/app/.server/locales/app-en.ts
+++ b/frontend/app/.server/locales/app-en.ts
@@ -231,4 +231,12 @@ export default {
     'page-heading': 'Get started',
     'requests': 'Requests',
   },
+  'hiring-manager-requests': {
+    'page-title': 'Requests',
+    'create-request': 'Create request',
+    'active-requests': 'Active requests',
+    'no-active-requests': "You don't have any active requests at the moment.",
+    'archived-requests': 'Archived requests',
+    'no-archived-requests': "You don't have any archived requests at the moment.",
+  },
 };

--- a/frontend/app/.server/locales/app-fr.ts
+++ b/frontend/app/.server/locales/app-fr.ts
@@ -234,4 +234,12 @@ export default {
     'page-heading': 'Débuter',
     'requests': 'Demandes',
   },
+  'hiring-manager-requests': {
+    'page-title': 'Demandes',
+    'create-request': 'Créer une demande',
+    'active-requests': 'Demandes actives',
+    'no-active-requests': "Vous n'avez aucune demande active pour le moment.",
+    'archived-requests': 'Demandes archivées',
+    'no-archived-requests': "Vous n'avez aucune demande archivée pour le moment.",
+  },
 } satisfies typeof appEn;

--- a/frontend/app/routes/hiring-manager/requests.tsx
+++ b/frontend/app/routes/hiring-manager/requests.tsx
@@ -1,3 +1,54 @@
+import { Form, useNavigation } from 'react-router';
+import type { RouteHandle } from 'react-router';
+
+import { useTranslation } from 'react-i18next';
+
 import type { Route } from './+types/requests';
 
-export default function HiringManagerRequests({ loaderData, params }: Route.ComponentProps) {}
+import { requireAuthentication } from '~/.server/utils/auth-utils';
+import { Button } from '~/components/button';
+import { PageTitle } from '~/components/page-title';
+import { getTranslation } from '~/i18n-config.server';
+import { handle as parentHandle } from '~/routes/layout';
+
+export const handle = {
+  i18nNamespace: [...parentHandle.i18nNamespace],
+} as const satisfies RouteHandle;
+
+export function meta({ loaderData }: Route.MetaArgs) {
+  return [{ title: loaderData.documentTitle }];
+}
+
+export function action({ context, request }: Route.ActionArgs) {
+  requireAuthentication(context.session, request);
+}
+
+export async function loader({ context, request }: Route.LoaderArgs) {
+  requireAuthentication(context.session, request);
+
+  const { t } = await getTranslation(request, handle.i18nNamespace);
+  return { documentTitle: t('app:hiring-manager-requests.page-title') };
+}
+
+export default function HiringManagerRequests({ loaderData, params }: Route.ComponentProps) {
+  const navigation = useNavigation();
+  const { t } = useTranslation(handle.i18nNamespace);
+
+  return (
+    <div className="mb-8 space-y-4">
+      <PageTitle className="after:w-14">{t('app:hiring-manager-requests.page-title')}</PageTitle>
+
+      <Form method="post" noValidate>
+        <Button name="action" variant="primary" disabled={navigation.state !== 'idle'}>
+          {t('app:hiring-manager-requests.create-request')}
+        </Button>
+      </Form>
+
+      <h2 className="font-lato text-xl font-bold">{t('app:hiring-manager-requests.active-requests')}</h2>
+      <div>{t('app:hiring-manager-requests.no-active-requests')}</div>
+
+      <h2 className="font-lato text-xl font-bold">{t('app:hiring-manager-requests.archived-requests')}</h2>
+      <div>{t('app:hiring-manager-requests.no-archived-requests')}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
[AB#6712](https://dev.azure.com/DTS-STN/4c33b941-c811-479f-b181-dfd5292182ff/_workitems/edit/6712)

Adds the content for when a hiring manager first hits /hiring-manager/requests and they have no active or archived requests.  Future PR(s) will address posting to the api to create new requests, and for displaying tables of requests.

