### PR TITLE
fix(frontend) remove role=heading from CardTitle span

### DIFF
--- a/frontend/app/components/dashboard-card.tsx
+++ b/frontend/app/components/dashboard-card.tsx
@@ -27,7 +27,7 @@ export function DashboardCard({ file, params, icon, title, body, ...props }: Das
           <CardHeader asChild className="p-0">
             <span>
               <CardTitle asChild className="flex items-center gap-2">
-                <span role="heading" aria-level={2}>
+                <span>
                   {title}
                   <FontAwesomeIcon icon={faChevronRight} />
                 </span>


### PR DESCRIPTION
## Summary

AB#6821

This span shouldn't have a `role='heading'` or `aria-level` on it since there's no content associated with this heading according to the ITAO.

