### PR TITLE
chore(workflow): add release branches to push and pull request triggers

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - main
+      - 'release/**'
+      - 'release-*'
   pull_request:
     branches:
       - main
+      - 'release/**'
+      - 'release-*'
   workflow_call: {}
   workflow_dispatch: {}
 


### PR DESCRIPTION
This pull request updates the build and test workflow configuration to trigger on additional branch patterns related to releases.

Workflow trigger updates:

* [`.github/workflows/build-and-test.yaml`](diffhunk://#diff-a551b322da0f9fe92abd1ec41e43c58dc5d138c0000430395e66f0c581387cd2R8-R14): Modified the workflow triggers so that the workflow now also runs on pushes and pull requests targeting branches matching the patterns `release/**` and `release-*`, in addition to `main`.