### PR TITLE
refactor(frontend): screen reader would read the legend

### DIFF
--- a/frontend/app/components/date-picker-field.tsx
+++ b/frontend/app/components/date-picker-field.tsx
@@ -36,6 +36,7 @@ type DatePickerDefaultValue = string | { year?: string; month?: string; day?: st
  * Props for the DatePickerField component
  */
 export interface DatePickerFieldProps {
+  ariaDescribedbyId?: string;
   defaultValue?: DatePickerDefaultValue;
   disabled?: boolean;
   errorMessages?: {
@@ -65,6 +66,7 @@ export interface DatePickerFieldProps {
  * @returns JSX.Element
  */
 export const DatePickerField = ({
+  ariaDescribedbyId,
   defaultValue,
   disabled,
   errorMessages,
@@ -175,7 +177,7 @@ export const DatePickerField = ({
 
   return (
     <div id={ids.wrapper}>
-      <fieldset className="space-y-2">
+      <fieldset className="space-y-2" aria-describedby={ariaDescribedbyId}>
         <InputLegend id={ids.legend} required={required}>
           {legend}
         </InputLegend>

--- a/frontend/app/components/input-legend.tsx
+++ b/frontend/app/components/input-legend.tsx
@@ -7,15 +7,16 @@ import { cn } from '~/utils/tailwind-utils';
 export interface InputLegendProps extends ComponentProps<'legend'> {
   children: ReactNode;
   required?: boolean;
+  childrenClassName?: string;
 }
 
 export function InputLegend(props: InputLegendProps) {
   const { t } = useTranslation('gcweb');
-  const { children, className, required, ...restProps } = props;
+  const { children, className, required, childrenClassName, ...restProps } = props;
 
   return (
     <legend className={cn('block', className)} {...restProps}>
-      <span className="font-semibold">{children}</span>
+      <span className={cn('font-semibold', childrenClassName)}>{children}</span>
       {required && (
         // Using a regular space entity (&#32;) to ensure consistent spacing before the required text,
         // preventing accidental collapse or omission in rendering.

--- a/frontend/app/components/input-radios.tsx
+++ b/frontend/app/components/input-radios.tsx
@@ -7,6 +7,7 @@ import { InputRadio } from '~/components/input-radio';
 import { cn } from '~/utils/tailwind-utils';
 
 export interface InputRadiosProps {
+  ariaDescribedbyId?: string;
   errorMessage?: string;
   helpMessagePrimary?: React.ReactNode;
   helpMessagePrimaryClassName?: string;
@@ -24,6 +25,7 @@ export interface InputRadiosProps {
 }
 
 export function InputRadios({
+  ariaDescribedbyId,
   errorMessage,
   helpMessagePrimary,
   helpMessagePrimaryClassName,
@@ -50,7 +52,7 @@ export function InputRadios({
   }
 
   return (
-    <fieldset id={inputWrapperId} data-testid={inputWrapperId}>
+    <fieldset id={inputWrapperId} data-testid={inputWrapperId} aria-describedby={ariaDescribedbyId}>
       <InputLegend id={inputLegendId} className={cn('mb-2', legendClassName)} required={required}>
         {legend}
       </InputLegend>

--- a/frontend/app/components/input-select.tsx
+++ b/frontend/app/components/input-select.tsx
@@ -16,6 +16,7 @@ export interface InputSelectProps
     ComponentProps<'select'>,
     'aria-describedby' | 'aria-errormessage' | 'aria-invalid' | 'aria-labelledby' | 'aria-required'
   > {
+  ariaDescribedbyId?: string;
   errorMessage?: string;
   helpMessage?: ReactNode;
   id: string;
@@ -25,7 +26,8 @@ export interface InputSelectProps
 }
 
 export function InputSelect(props: InputSelectProps) {
-  const { errorMessage, helpMessage, id, label, options, className, ref, required, ...restInputProps } = props;
+  const { ariaDescribedbyId, errorMessage, helpMessage, id, label, options, className, ref, required, ...restInputProps } =
+    props;
 
   const inputErrorId = `input-${id}-error`;
   const inputHelpMessageId = `input-${id}-help`;
@@ -34,7 +36,7 @@ export function InputSelect(props: InputSelectProps) {
   const inputWrapperId = `input-${id}`;
 
   return (
-    <div id={inputWrapperId} data-testid={inputWrapperId}>
+    <fieldset id={inputWrapperId} data-testid={inputWrapperId} aria-describedby={ariaDescribedbyId}>
       <InputLabel id={inputLabelId} htmlFor={id} className="mb-2" required={required}>
         {label}
       </InputLabel>
@@ -66,6 +68,6 @@ export function InputSelect(props: InputSelectProps) {
           {helpMessage}
         </InputHelp>
       )}
-    </div>
+    </fieldset>
   );
 }

--- a/frontend/app/routes/page-components/employees/employment-information/form.tsx
+++ b/frontend/app/routes/page-components/employees/employment-information/form.tsx
@@ -20,6 +20,7 @@ import { Button } from '~/components/button';
 import { ButtonLink } from '~/components/button-link';
 import { DatePickerField } from '~/components/date-picker-field';
 import { FormErrorSummary } from '~/components/error-summary';
+import { InputLegend } from '~/components/input-legend';
 import type { InputRadiosProps } from '~/components/input-radios';
 import { InputRadios } from '~/components/input-radios';
 import { InputSelect } from '~/components/input-select';
@@ -210,67 +211,76 @@ export function EmploymentInformationForm({
             )}
 
             <h2 className="font-lato text-2xl font-bold">{t('employment-information.wfa-detils-heading')}</h2>
-            <p>{t('employment-information.wfa-detils')}</p>
-            <div className="w-full sm:w-1/2">
-              <InputRadios
-                id="wfaStatus"
-                name="wfaStatus"
-                errorMessage={t(extractValidationKey(formErrors?.wfaStatusId))}
-                required
-                options={wfaStatusOptions}
-                legend={t('employment-information.wfa-status')}
-              />
-            </div>
-            <DatePickerField
-              defaultValue={formValues?.wfaStartDate ?? ''}
-              id="wfaStartDate"
-              legend={t('employment-information.wfa-effective-date')}
-              names={{
-                day: 'wfaStartDateDay',
-                month: 'wfaStartDateMonth',
-                year: 'wfaStartDateYear',
-              }}
-              errorMessages={{
-                all: t(extractValidationKey(formErrors?.wfaStartDate)),
-                year: t(extractValidationKey(formErrors?.wfaStartDateYear)),
-                month: t(extractValidationKey(formErrors?.wfaStartDateMonth)),
-                day: t(extractValidationKey(formErrors?.wfaStartDateDay)),
-              }}
-              required
-            />
-            {(wfaStatusCode === EMPLOYEE_WFA_STATUS.opting ||
-              wfaStatusCode === EMPLOYEE_WFA_STATUS.exOpting ||
-              wfaStatusCode === EMPLOYEE_WFA_STATUS.surplusOptingOptionA ||
-              wfaStatusCode === EMPLOYEE_WFA_STATUS.exSurplusCPA) && (
-              <>
-                <DatePickerField
-                  defaultValue={formValues?.wfaEndDate ?? ''}
-                  id="wfaEndDate"
-                  legend={t('employment-information.wfa-end-date')}
-                  names={{
-                    day: 'wfaEndDateDay',
-                    month: 'wfaEndDateMonth',
-                    year: 'wfaEndDateYear',
-                  }}
-                  errorMessages={{
-                    all: t(extractValidationKey(formErrors?.wfaEndDate)),
-                    year: t(extractValidationKey(formErrors?.wfaEndDateYear)),
-                    month: t(extractValidationKey(formErrors?.wfaEndDateMonth)),
-                    day: t(extractValidationKey(formErrors?.wfaEndDateDay)),
-                  }}
+            <fieldset id="wfaDetilsFieldset" className="space-y-6">
+              <InputLegend id="wfaDetilsLegend" childrenClassName="font-normal">
+                {t('employment-information.wfa-detils')}
+              </InputLegend>
+              <div className="w-full sm:w-1/2">
+                <InputRadios
+                  ariaDescribedbyId="wfaDetilsLegend"
+                  id="wfaStatus"
+                  name="wfaStatus"
+                  errorMessage={t(extractValidationKey(formErrors?.wfaStatusId))}
+                  required
+                  options={wfaStatusOptions}
+                  legend={t('employment-information.wfa-status')}
                 />
-              </>
-            )}
-            <InputSelect
-              id="hrAdvisorId"
-              name="hrAdvisorId"
-              errorMessage={t(extractValidationKey(formErrors?.hrAdvisorId))}
-              required
-              options={hrAdvisorOptions}
-              label={t('employment-information.hr-advisor')}
-              defaultValue={formValues?.hrAdvisorId ? String(formValues.hrAdvisorId) : ''}
-              className="w-full sm:w-1/2"
-            />
+              </div>
+              <DatePickerField
+                ariaDescribedbyId="wfaDetilsLegend"
+                defaultValue={formValues?.wfaStartDate ?? ''}
+                id="wfaStartDate"
+                legend={t('employment-information.wfa-effective-date')}
+                names={{
+                  day: 'wfaStartDateDay',
+                  month: 'wfaStartDateMonth',
+                  year: 'wfaStartDateYear',
+                }}
+                errorMessages={{
+                  all: t(extractValidationKey(formErrors?.wfaStartDate)),
+                  year: t(extractValidationKey(formErrors?.wfaStartDateYear)),
+                  month: t(extractValidationKey(formErrors?.wfaStartDateMonth)),
+                  day: t(extractValidationKey(formErrors?.wfaStartDateDay)),
+                }}
+                required
+              />
+              {(wfaStatusCode === EMPLOYEE_WFA_STATUS.opting ||
+                wfaStatusCode === EMPLOYEE_WFA_STATUS.exOpting ||
+                wfaStatusCode === EMPLOYEE_WFA_STATUS.surplusOptingOptionA ||
+                wfaStatusCode === EMPLOYEE_WFA_STATUS.exSurplusCPA) && (
+                <>
+                  <DatePickerField
+                    ariaDescribedbyId="wfaDetilsLegend"
+                    defaultValue={formValues?.wfaEndDate ?? ''}
+                    id="wfaEndDate"
+                    legend={t('employment-information.wfa-end-date')}
+                    names={{
+                      day: 'wfaEndDateDay',
+                      month: 'wfaEndDateMonth',
+                      year: 'wfaEndDateYear',
+                    }}
+                    errorMessages={{
+                      all: t(extractValidationKey(formErrors?.wfaEndDate)),
+                      year: t(extractValidationKey(formErrors?.wfaEndDateYear)),
+                      month: t(extractValidationKey(formErrors?.wfaEndDateMonth)),
+                      day: t(extractValidationKey(formErrors?.wfaEndDateDay)),
+                    }}
+                  />
+                </>
+              )}
+              <InputSelect
+                ariaDescribedbyId="wfaDetilsLegend"
+                id="hrAdvisorId"
+                name="hrAdvisorId"
+                errorMessage={t(extractValidationKey(formErrors?.hrAdvisorId))}
+                required
+                options={hrAdvisorOptions}
+                label={t('employment-information.hr-advisor')}
+                defaultValue={formValues?.hrAdvisorId ? String(formValues.hrAdvisorId) : ''}
+                className="w-full sm:w-1/2"
+              />
+            </fieldset>
+
             <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
               <Button name="action" variant="primary" id="save-button">
                 {t('form.save')}

--- a/frontend/app/routes/page-components/employees/referral-preferences/form.tsx
+++ b/frontend/app/routes/page-components/employees/referral-preferences/form.tsx
@@ -207,6 +207,7 @@ export function ReferralPreferencesForm({
               </InputLegend>
               <InputHelp id="workLocationHelpMessage">{tApp('form.select-all-that-apply')}</InputHelp>
               <InputSelect
+                ariaDescribedbyId="workLocationHelpMessage"
                 className="w-full sm:w-1/2"
                 id="preferred-province"
                 name="preferredProvince"

--- a/frontend/tests/components/__snapshots__/input-select.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/input-select.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`InputSelect > should render input select component > expected html 1`] = `
 <div>
-  <div
+  <fieldset
     data-testid="input-some-id"
     id="input-some-id"
   >
@@ -41,13 +41,13 @@ exports[`InputSelect > should render input select component > expected html 1`] 
         second option
       </option>
     </select>
-  </div>
+  </fieldset>
 </div>
 `;
 
 exports[`InputSelect > should render input select component with error message > expected html 1`] = `
 <div>
-  <div
+  <fieldset
     data-testid="input-some-id"
     id="input-some-id"
   >
@@ -99,13 +99,13 @@ exports[`InputSelect > should render input select component with error message >
         second option
       </option>
     </select>
-  </div>
+  </fieldset>
 </div>
 `;
 
 exports[`InputSelect > should render input select component with help message > expected html 1`] = `
 <div>
-  <div
+  <fieldset
     data-testid="input-some-id"
     id="input-some-id"
   >
@@ -152,13 +152,13 @@ exports[`InputSelect > should render input select component with help message > 
     >
       help message
     </div>
-  </div>
+  </fieldset>
 </div>
 `;
 
 exports[`InputSelect > should render input select component with required > expected html 1`] = `
 <div>
-  <div
+  <fieldset
     data-testid="input-some-id"
     id="input-some-id"
   >
@@ -207,6 +207,6 @@ exports[`InputSelect > should render input select component with required > expe
         second option
       </option>
     </select>
-  </div>
+  </fieldset>
 </div>
 `;


### PR DESCRIPTION
## Summary

[AB#6820](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6820/)
Screen reader wasn't reading some information provided in the screen shot, refer the task above.
Added the aria-describedby to the fieldset of input-select, input-radio and date-picker components, as recommended by the ITAO accessor. The screen reader NVDA now reads the information.

## Types of changes

What types of changes does this PR introduce?

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>


## Screenshots (if applicable)

<img width="1237" height="652" alt="image" src="https://github.com/user-attachments/assets/45158d7d-603f-4492-b799-7be602676826" />

