### PR TITLE
fix(frontend): prevent keyboard interaction on nested controls in InputMultiSelect

### DIFF
--- a/frontend/app/components/input-multiselect.tsx
+++ b/frontend/app/components/input-multiselect.tsx
@@ -191,13 +191,14 @@ export function InputMultiSelect(props: InputMultiSelectProps) {
                 className="relative cursor-pointer p-2 text-gray-900 select-none hover:bg-gray-100 focus:bg-gray-100 focus:outline-none"
               >
                 <InputCheckbox
-                  aria-required={required ? true : undefined}
                   id={`${optionId}-checkbox`}
                   name={`${name}-${optionProps.value}`}
                   checked={isSelected}
                   readOnly={true}
                   required={required}
                   hasError={!!errorMessage}
+                  tabIndex={-1}
+                  className="pointer-events-none"
                   {...optionProps}
                 >
                   {optionProps.label}


### PR DESCRIPTION
Addresses a11y ticket [6826](https://dev.azure.com/DTS-STN/VacMan/_boards/board/t/VacMan%20Team/Stories?System.IterationPath=VacMan%5CCurrent%20Work%2CVacMan%5CMVP%20-%20GET%20IT%20DONE%2CVacMan%5CMVP%20Iteration%202&workitem=6826)

This pull request makes a small update to the `InputMultiSelect` component to improve accessibility and user interaction. The main change is ensuring the checkbox within each option is not directly focusable or clickable, which helps prevent nested input selection and keeps the focus behavior consistent.

- Accessibility and interaction improvements:
  * In `frontend/app/components/input-multiselect.tsx`, removed the `aria-required` prop from `InputCheckbox`, set `tabIndex={-1}` and added `pointer-events-none` to make the checkbox non-focusable and non-interactive directly.