### PR TITLE
fix(frontend): profile submission would not present error with incomplete profile

### DIFF
--- a/frontend/app/routes/employee/profile/index.tsx
+++ b/frontend/app/routes/employee/profile/index.tsx
@@ -275,9 +275,12 @@ export default function EditProfile({ loaderData, params }: Route.ComponentProps
   const fetcherState = useFetcherState(fetcher);
   const isSubmitting = fetcherState.submitting;
 
+  // Use fetcher.data instead of actionData since we're using fetcher.Form
+  const formActionData = fetcher.data ?? actionData;
+
   const alertRef = useRef<HTMLDivElement>(null);
 
-  if (actionData && alertRef.current) {
+  if (formActionData && alertRef.current) {
     alertRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
     alertRef.current.focus();
   }
@@ -346,7 +349,7 @@ export default function EditProfile({ loaderData, params }: Route.ComponentProps
         </fetcher.Form>
       </div>
 
-      {actionData && (
+      {formActionData && (
         <AlertMessage
           ref={alertRef}
           type={loaderData.isProfileComplete ? 'success' : 'error'}
@@ -381,7 +384,7 @@ export default function EditProfile({ loaderData, params }: Route.ComponentProps
           isComplete={loaderData.personalInformation.isComplete}
           isNew={loaderData.personalInformation.isNew}
           params={params}
-          errorState={actionData?.personalInfoComplete === false}
+          errorState={formActionData?.personalInfoComplete === false}
           required
           showStatus
         >
@@ -428,7 +431,7 @@ export default function EditProfile({ loaderData, params }: Route.ComponentProps
           isNew={loaderData.employmentInformation.isNew}
           params={params}
           required
-          errorState={actionData?.employmentInfoComplete === false}
+          errorState={formActionData?.employmentInfoComplete === false}
           showStatus
         >
           {loaderData.employmentInformation.isNew ? (
@@ -486,7 +489,7 @@ export default function EditProfile({ loaderData, params }: Route.ComponentProps
           isNew={loaderData.referralPreferences.isNew}
           params={params}
           required
-          errorState={actionData?.referralComplete === false}
+          errorState={formActionData?.referralComplete === false}
           showStatus
         >
           {loaderData.referralPreferences.isNew ? (


### PR DESCRIPTION
Addresses [bug 6844](https://dev.azure.com/DTS-STN/VacMan/_boards/board/t/VacMan%20Team/Stories?System.IterationPath=VacMan%5CCurrent%20Work%2CVacMan%5CMVP%20-%20GET%20IT%20DONE%2CVacMan%5CMVP%20Iteration%202&workitem=6844)

When submitting an incomplete profile, the user should be presented with "Please complete all required fields before submitting your profile"

This pull request updates the `EditProfile` component in `frontend/app/routes/employee/profile/index.tsx` to consistently use `fetcher.data` (now referenced as `formActionData`) instead of `actionData` for displaying form submission results and error states. This change ensures that the component correctly reflects the latest form state when using `fetcher.Form`.

**Form state management improvements:**

* Introduced `formActionData`, which uses `fetcher.data` if available, falling back to `actionData` for compatibility with `fetcher.Form` submissions.
* Updated all references from `actionData` to `formActionData` for rendering alert messages and determining error states in the personal information, employment information, and referral preferences sections. [[1]](diffhunk://#diff-95bd843a205ab4d44d00d5f5db6cd1a8aef8b38bb687ec19e833f8e348068c0eL349-R352) [[2]](diffhunk://#diff-95bd843a205ab4d44d00d5f5db6cd1a8aef8b38bb687ec19e833f8e348068c0eL384-R387) [[3]](diffhunk://#diff-95bd843a205ab4d44d00d5f5db6cd1a8aef8b38bb687ec19e833f8e348068c0eL431-R434) [[4]](diffhunk://#diff-95bd843a205ab4d44d00d5f5db6cd1a8aef8b38bb687ec19e833f8e348068c0eL489-R492)