### PR TITLE
a11y(frontend): styled <p> elements must not be used as headings

### DIFF
--- a/frontend/app/components/profile-card.tsx
+++ b/frontend/app/components/profile-card.tsx
@@ -74,7 +74,7 @@ export function ProfileCard({
           'rounded-b-xs', // Re-apply bottom roundings
         )}
       >
-        {errorState && <p className="pb-4 text-lg font-bold text-[#333333]">{t('profile.field-incomplete')}</p>}
+        {errorState && <h3 className="pb-4 text-lg font-bold text-[#333333]">{t('profile.field-incomplete')}</h3>}
         <span className="flex items-center gap-x-2">
           {errorState && <FontAwesomeIcon icon={faTriangleExclamation} className="text-red-800" />}
           {!errorState && (isNew ? <FontAwesomeIcon icon={faPlus} /> : <FontAwesomeIcon icon={faPenToSquare} />)}


### PR DESCRIPTION
This pull request makes a small change to the `ProfileCard` component to improve accessibility and semantic HTML. The only change is replacing a paragraph tag with a heading tag for error messages.

- Changed the error message element from a `<p>` to an `<h3>` tag in `profile-card.tsx` to use more appropriate semantic HTML for headings.