### PR TITLE
a11y(frontend): fix issue with label "for=" attributes being inaccurate

### DIFF
--- a/frontend/app/components/input-field.tsx
+++ b/frontend/app/components/input-field.tsx
@@ -60,7 +60,7 @@ export function InputField({
 
   return (
     <div id={ids.wrapper} className="space-y-2">
-      <InputLabel id={ids.label} htmlFor={id} required={required}>
+      <InputLabel id={ids.label} htmlFor={ids.input} required={required}>
         {label}
       </InputLabel>
       {errorMessage && (

--- a/frontend/tests/components/__snapshots__/app-bar.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/app-bar.test.tsx.snap
@@ -154,7 +154,7 @@ exports[`AppBar > should render render an AppBar with a profile item provided > 
           aria-haspopup="menu"
           class="flex h-full flex-nowrap space-x-2 bg-slate-600 px-2 text-sm text-white hover:bg-slate-500 hover:underline focus:ring-2 focus:ring-black focus:ring-offset-2 focus:outline-hidden aria-expanded:bg-slate-800 aria-expanded:text-white sm:space-x-4 sm:px-4"
           data-state="closed"
-          id="radix-«r2»"
+          id="radix-«r6»"
           type="button"
         >
           <span

--- a/frontend/tests/components/__snapshots__/input-field.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/input-field.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`InputField > should render input field component > expected html 1`] = 
   >
     <label
       class="block"
-      for="test-id"
+      for="input-text-field-test-id-input"
       id="input-text-field-test-id-label"
     >
       <span
@@ -37,7 +37,7 @@ exports[`InputField > should render input field with error message > expected ht
   >
     <label
       class="block"
-      for="test-id"
+      for="input-text-field-test-id-input"
       id="input-text-field-test-id-label"
     >
       <span
@@ -78,7 +78,7 @@ exports[`InputField > should render input field with help message > expected htm
   >
     <label
       class="block"
-      for="test-id"
+      for="input-text-field-test-id-input"
       id="input-text-field-test-id-label"
     >
       <span
@@ -115,7 +115,7 @@ exports[`InputField > should render input field with required > expected html 1`
   >
     <label
       class="block"
-      for="test-id"
+      for="input-text-field-test-id-input"
       id="input-text-field-test-id-label"
     >
       <span

--- a/frontend/tests/components/__snapshots__/loading-button.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/loading-button.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`LoadingButton > renders the custom loading icon > expected html 1`] = `
     </span>
     <svg
       aria-hidden="true"
-      class="svg-inline--fa fa-check fa-spin fa-fw ms-1"
+      class="svg-inline--fa fa-check ms-1 fa-spin fa-fw"
       data-icon="check"
       data-prefix="fas"
       role="img"
@@ -49,7 +49,7 @@ exports[`LoadingButton > renders the loading spinner at the end position > expec
     </span>
     <svg
       aria-hidden="true"
-      class="svg-inline--fa fa-spinner fa-spin fa-fw ms-1 animate-spin"
+      class="svg-inline--fa fa-spinner ms-1 animate-spin fa-spin fa-fw"
       data-icon="spinner"
       data-prefix="fas"
       role="img"
@@ -72,7 +72,7 @@ exports[`LoadingButton > renders the loading spinner at the start position > exp
   >
     <svg
       aria-hidden="true"
-      class="svg-inline--fa fa-spinner fa-spin fa-fw me-1 animate-spin"
+      class="svg-inline--fa fa-spinner me-1 animate-spin fa-spin fa-fw"
       data-icon="spinner"
       data-prefix="fas"
       role="img"

--- a/frontend/tests/components/__snapshots__/menu.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/menu.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`Menu > should correctly render a Menu with a MenuItem when the to prope
     aria-haspopup="menu"
     class="flex h-full flex-nowrap space-x-2 bg-slate-700 px-2 text-white hover:bg-slate-600 hover:underline focus:ring-2 focus:ring-black focus:ring-offset-2 focus:outline-hidden aria-expanded:bg-slate-900 aria-expanded:text-white sm:space-x-3 sm:px-4"
     data-state="closed"
-    id="radix-«r2»"
+    id="radix-«r4»"
     type="button"
   >
     <span

--- a/frontend/tests/components/__snapshots__/search-bar.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/search-bar.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`SearchBar > should render search bar component > expected html 1`] = `
     >
       <label
         class="block"
-        for="test-id"
+        for="input-search-field-test-id-input"
         id="input-search-field-test-id-label"
       >
         <span
@@ -28,7 +28,7 @@ exports[`SearchBar > should render search bar component > expected html 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="svg-inline--fa fa-magnifying-glass "
+            class="svg-inline--fa fa-magnifying-glass"
             data-icon="magnifying-glass"
             data-prefix="fas"
             role="img"
@@ -65,7 +65,7 @@ exports[`SearchBar > should render search bar suggestions > expected html 1`] = 
     >
       <label
         class="block"
-        for="test-id"
+        for="input-search-field-test-id-input"
         id="input-search-field-test-id-label"
       >
         <span
@@ -82,7 +82,7 @@ exports[`SearchBar > should render search bar suggestions > expected html 1`] = 
         >
           <svg
             aria-hidden="true"
-            class="svg-inline--fa fa-magnifying-glass "
+            class="svg-inline--fa fa-magnifying-glass"
             data-icon="magnifying-glass"
             data-prefix="fas"
             role="img"
@@ -111,7 +111,7 @@ exports[`SearchBar > should render search bar suggestions > expected html 1`] = 
         <li>
           <button
             class="inline-flex w-full border-none px-4 py-2 hover:bg-neutral-500 hover:text-white focus:bg-gray-600 focus:text-white focus:outline-none"
-            id="«r2»0"
+            id="«r4»0"
             tabindex="-1"
             type="button"
           >
@@ -121,7 +121,7 @@ exports[`SearchBar > should render search bar suggestions > expected html 1`] = 
         <li>
           <button
             class="inline-flex w-full border-none px-4 py-2 hover:bg-neutral-500 hover:text-white focus:bg-gray-600 focus:text-white focus:outline-none"
-            id="«r2»1"
+            id="«r4»1"
             tabindex="-1"
             type="button"
           >


### PR DESCRIPTION
Addresses [6833](https://dev.azure.com/DTS-STN/VacMan/_boards/board/t/VacMan%20Team/Stories?System.IterationPath=VacMan%5CCurrent%20Work%2CVacMan%5CMVP%20-%20GET%20IT%20DONE%2CVacMan%5CMVP%20Iteration%202&workitem=6833)

This pull request updates the `InputField` component to ensure the label's `htmlFor` attribute correctly matches the input's `id`, improving accessibility and test reliability. The associated tests and snapshots have been updated to reflect this change.

Accessibility improvements:

* Updated the `InputField` component so that the `InputLabel`'s `htmlFor` prop uses `ids.input` instead of the generic `id`, ensuring it matches the actual input element's id.

Test updates:

* Updated all relevant test snapshots in `input-field.test.tsx.snap` to expect the correct `for` attribute value on the label, matching the new input id format. [[1]](diffhunk://#diff-e7bf543e4e6a8e63642d388bd74c864026aa9f5b956e551f6605125abcde3128L11-R11) [[2]](diffhunk://#diff-e7bf543e4e6a8e63642d388bd74c864026aa9f5b956e551f6605125abcde3128L40-R40) [[3]](diffhunk://#diff-e7bf543e4e6a8e63642d388bd74c864026aa9f5b956e551f6605125abcde3128L81-R81) [[4]](diffhunk://#diff-e7bf543e4e6a8e63642d388bd74c864026aa9f5b956e551f6605125abcde3128L118-R118)