### PR TITLE
a11y(frontend): conditionally render label and aria-labelledby based on label presence

### DIFF
--- a/frontend/app/components/input-select.tsx
+++ b/frontend/app/components/input-select.tsx
@@ -37,9 +37,11 @@ export function InputSelect(props: InputSelectProps) {
 
   return (
     <fieldset id={inputWrapperId} data-testid={inputWrapperId} aria-describedby={ariaDescribedbyId}>
-      <InputLabel id={inputLabelId} htmlFor={id} className="mb-2" required={required}>
-        {label}
-      </InputLabel>
+      {label && (
+        <InputLabel id={inputLabelId} htmlFor={id} className="mb-2" required={required}>
+          {label}
+        </InputLabel>
+      )}
       {errorMessage && (
         <p className="mb-2">
           <InputError id={inputErrorId}>{errorMessage}</InputError>
@@ -50,7 +52,7 @@ export function InputSelect(props: InputSelectProps) {
         aria-describedby={helpMessage ? inputHelpMessageId : undefined}
         aria-errormessage={errorMessage && inputErrorId}
         aria-invalid={!!errorMessage}
-        aria-labelledby={inputLabelId}
+        aria-labelledby={label ? inputLabelId : undefined}
         aria-required={required}
         className={cn(inputBaseClassName, inputDisabledClassName, errorMessage && inputErrorClassName, className)}
         data-testid={inputTestId}

--- a/frontend/tests/components/input-select.test.tsx
+++ b/frontend/tests/components/input-select.test.tsx
@@ -74,4 +74,31 @@ describe('InputSelect', () => {
 
     expect(container).toMatchSnapshot('expected html');
   });
+
+  it('should not render label or aria-labelledby when label is empty', () => {
+    const { container } = render(
+      <InputSelect
+        id="empty-label-id"
+        name="test"
+        label=""
+        aria-label="Test aria label"
+        defaultValue="first"
+        options={[
+          { children: 'first option', value: 'first' },
+          { children: 'second option', value: 'second' },
+        ]}
+      />,
+    );
+
+    // Should not render a label element
+    expect(container.querySelector('label')).toBeNull();
+
+    // Should not have aria-labelledby attribute
+    const selectElement = container.querySelector('select');
+    expect(selectElement).toBeDefined();
+    expect(selectElement?.getAttribute('aria-labelledby')).toBeNull();
+
+    // Should still have aria-label attribute
+    expect(selectElement?.getAttribute('aria-label')).toBe('Test aria label');
+  });
 });


### PR DESCRIPTION
Addresses [6839](https://dev.azure.com/DTS-STN/VacMan/_boards/board/t/VacMan%20Team/Stories?System.IterationPath=VacMan%5CCurrent%20Work%2CVacMan%5CMVP%20-%20GET%20IT%20DONE%2CVacMan%5CMVP%20Iteration%202&workitem=6839)

This pull request improves the accessibility and behavior of the `InputSelect` component when the `label` prop is empty. The main changes ensure that the label element and related ARIA attributes are only rendered when a label is provided, and adds a test to verify this behavior.

Accessibility and conditional rendering improvements:

* Updated the `InputSelect` component to only render the label element and set the `aria-labelledby` attribute if the `label` prop is provided, preventing unnecessary or empty ARIA attributes when the label is empty. [[1]](diffhunk://#diff-c2f25287d30ed8af973540f72414ec55575bdcda26f336497e29f982869d8306R40-R44) [[2]](diffhunk://#diff-c2f25287d30ed8af973540f72414ec55575bdcda26f336497e29f982869d8306L53-R55)

Testing enhancements:

* Added a test to confirm that when the `label` prop is empty, no label element or `aria-labelledby` attribute is rendered, but the `aria-label` attribute is still present on the select element.