### PR TITLE
a11y(frontend): announce data table column sorting state and actions to screen readers

### DIFF
--- a/frontend/app/.server/locales/gcweb-en.ts
+++ b/frontend/app/.server/locales/gcweb-en.ts
@@ -97,6 +97,11 @@ export default {
       'next-page': 'Go to next page',
       'last-page': 'Go to last page',
     },
+    'sorting': {
+      'sorted-ascending': '{{column}}, sorted ascending. Click to sort descending.',
+      'sorted-descending': '{{column}}, sorted descending. Click to remove sorting.',
+      'not-sorted': '{{column}}, not sorted. Click to sort ascending.',
+    },
   },
   'search-bar': {
     search: 'Search',

--- a/frontend/app/.server/locales/gcweb-fr.ts
+++ b/frontend/app/.server/locales/gcweb-fr.ts
@@ -99,6 +99,11 @@ export default {
       'next-page': 'Aller à la page suivante',
       'last-page': 'Aller à la dernière page',
     },
+    'sorting': {
+      'sorted-ascending': '{{column}}, trié en ordre croissant. Cliquez pour trier en ordre décroissant.',
+      'sorted-descending': '{{column}}, trié en ordre décroissant. Cliquez pour supprimer le tri.',
+      'not-sorted': '{{column}}, non trié. Cliquez pour trier en ordre croissant.',
+    },
   },
   'search-bar': {
     search: 'Rechercher',

--- a/frontend/app/components/data-table.tsx
+++ b/frontend/app/components/data-table.tsx
@@ -50,10 +50,20 @@ export function DataTable<TData, TValue>({ columns, data }: DataTableProps<TData
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id}>
               {headerGroup.headers.map((header) => {
+                const sortDirection = header.column.getIsSorted();
+                const ariaSortValue = header.column.getCanSort()
+                  ? sortDirection === 'asc'
+                    ? 'ascending'
+                    : sortDirection === 'desc'
+                      ? 'descending'
+                      : 'none'
+                  : undefined;
+
                 return (
                   <TableHead
                     key={header.id}
                     className={cn('text-left text-sm font-semibold', header.column.columnDef.meta?.headerClassName)}
+                    aria-sort={ariaSortValue}
                   >
                     {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
                   </TableHead>
@@ -207,19 +217,32 @@ export function DataTableColumnHeaderWithOptions<TData, TValue>({
 }
 
 export function DataTableColumnHeader<TData, TValue>({ column, title, className }: DataTableColumnHeaderProps<TData, TValue>) {
+  const { t } = useTranslation(['gcweb']);
+
   if (!column.getCanSort()) {
     return <div className={cn('flex items-center', className)}>{title}</div>;
   }
 
   const sortDirection = column.getIsSorted();
 
+  // Create accessible label that describes the current state and action
+  const getAriaLabel = () => {
+    if (sortDirection === 'asc') {
+      return t('gcweb:data-table.sorting.sorted-ascending', { column: title });
+    } else if (sortDirection === 'desc') {
+      return t('gcweb:data-table.sorting.sorted-descending', { column: title });
+    }
+    return t('gcweb:data-table.sorting.not-sorted', { column: title });
+  };
+
   return (
     <button
       onClick={() => column.toggleSorting()}
       className={cn('flex items-center gap-1 text-left text-sm font-semibold hover:underline', className)}
+      aria-label={getAriaLabel()}
     >
       {title}
-      <span className="rounded-sm p-1 text-neutral-500 hover:bg-slate-300">
+      <span className="rounded-sm p-1 text-neutral-500 hover:bg-slate-300" aria-hidden="true">
         <FontAwesomeIcon icon={sortDirection === 'desc' ? faSortDown : faSortUp} />
       </span>
     </button>


### PR DESCRIPTION
This pull request improves the accessibility and internationalization of sortable table columns in the data table component. The main changes add proper ARIA attributes and localized labels for sorting controls, making the table more usable for screen readers and users in both English and French.

**Accessibility improvements:**

* Added the `aria-sort` attribute to each sortable column header in the `DataTable` component, reflecting the current sort state for assistive technologies.
* Updated the `DataTableColumnHeader` component to provide an `aria-label` describing the current sort state and the action triggered by clicking, using localized strings. Also marked the sort icon as `aria-hidden`.

**Internationalization:**

* Added English translations for sorting states and actions under the `data-table.sorting` key in `gcweb-en.ts`.
* Added French translations for sorting states and actions under the `data-table.sorting` key in `gcweb-fr.ts`.