### PR TITLE
fix(frontend): enhance BackLink component for improved accessibility …

### DIFF
--- a/frontend/app/components/back-link.tsx
+++ b/frontend/app/components/back-link.tsx
@@ -1,36 +1,18 @@
-import type { Params, Path } from 'react-router';
+import type { ComponentProps } from 'react';
 
 import { faAngleLeft } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { useTranslation } from 'react-i18next';
 
 import { InlineLink } from '~/components/links';
-import type { I18nRouteFile } from '~/i18n-routes';
 import { cn } from '~/utils/tailwind-utils';
 
-interface BackLinkProps {
-  file: I18nRouteFile;
-  params?: Params;
-  className?: string;
-  hash?: Path['hash'];
-  search?: Path['search'];
-  translationKey?: string;
-}
+type BackLinkProps = ComponentProps<typeof InlineLink>;
 
-export function BackLink({ className, file, params, hash, search, translationKey = 'app:profile.back' }: BackLinkProps) {
-  const { t } = useTranslation();
-  const linkText = t(translationKey);
+export function BackLink({ children, className, ...props }: BackLinkProps) {
   return (
-    <InlineLink
-      className={cn('inline-flex items-center', className)}
-      file={file}
-      params={params}
-      hash={hash}
-      search={search}
-      aria-label={linkText}
-    >
+    <InlineLink className={cn('inline-flex items-center', className)} {...props}>
       <FontAwesomeIcon icon={faAngleLeft} />
-      {linkText}
+      {children}
     </InlineLink>
   );
 }

--- a/frontend/app/routes/employee/profile/employment-information.tsx
+++ b/frontend/app/routes/employee/profile/employment-information.tsx
@@ -1,6 +1,7 @@
 import type { RouteHandle } from 'react-router';
 import { data } from 'react-router';
 
+import { useTranslation } from 'react-i18next';
 import * as v from 'valibot';
 
 import type { Route } from '../profile/+types/employment-information';
@@ -133,11 +134,14 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 }
 
 export default function EmploymentInformation({ loaderData, actionData, params }: Route.ComponentProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
   const errors = actionData?.errors;
 
   return (
     <>
-      <BackLink className="mt-6" file="routes/employee/profile/index.tsx" params={params} />
+      <BackLink aria-label={t('app:profile.back')} className="mt-6" file="routes/employee/profile/index.tsx" params={params}>
+        {t('app:profile.back')}
+      </BackLink>
       <div className="max-w-prose">
         <EmploymentInformationForm
           cancelLink={'routes/employee/profile/index.tsx'}

--- a/frontend/app/routes/employee/profile/personal-information.tsx
+++ b/frontend/app/routes/employee/profile/personal-information.tsx
@@ -1,6 +1,7 @@
 import type { RouteHandle } from 'react-router';
 import { data } from 'react-router';
 
+import { useTranslation } from 'react-i18next';
 import * as v from 'valibot';
 
 import type { Route } from '../profile/+types/personal-information';
@@ -152,11 +153,14 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 }
 
 export default function PersonalInformation({ loaderData, actionData, params }: Route.ComponentProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
   const errors = actionData?.errors;
 
   return (
     <>
-      <BackLink className="mt-6" file="routes/employee/profile/index.tsx" params={params} />
+      <BackLink aria-label={t('app:profile.back')} className="mt-6" file="routes/employee/profile/index.tsx" params={params}>
+        {t('app:profile.back')}
+      </BackLink>
       <div className="max-w-prose">
         <PersonalInformationForm
           cancelLink={'routes/employee/profile/index.tsx'}

--- a/frontend/app/routes/employee/profile/referral-preferences.tsx
+++ b/frontend/app/routes/employee/profile/referral-preferences.tsx
@@ -1,6 +1,7 @@
 import type { RouteHandle } from 'react-router';
 import { data } from 'react-router';
 
+import { useTranslation } from 'react-i18next';
 import * as v from 'valibot';
 
 import type { Route } from './+types/referral-preferences';
@@ -141,11 +142,14 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 }
 
 export default function PersonalDetails({ loaderData, actionData, params }: Route.ComponentProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
   const errors = actionData?.errors;
 
   return (
     <>
-      <BackLink className="mt-6" file="routes/employee/profile/index.tsx" params={params} />
+      <BackLink aria-label={t('app:profile.back')} className="mt-6" file="routes/employee/profile/index.tsx" params={params}>
+        {t('app:profile.back')}
+      </BackLink>
       <div className="max-w-prose">
         <ReferralPreferencesForm
           cancelLink={'routes/employee/profile/index.tsx'}

--- a/frontend/app/routes/hr-advisor/employee-profile/employment-information.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/employment-information.tsx
@@ -1,6 +1,7 @@
 import type { RouteHandle } from 'react-router';
 import { data } from 'react-router';
 
+import { useTranslation } from 'react-i18next';
 import * as v from 'valibot';
 
 import type { Route } from '../employee-profile/+types/employment-information';
@@ -124,11 +125,14 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 }
 
 export default function EmploymentInformation({ loaderData, actionData, params }: Route.ComponentProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
   const errors = actionData?.errors;
 
   return (
     <>
-      <BackLink className="mt-6" file="routes/hr-advisor/employee-profile/index.tsx" params={params} />
+      <BackLink aria-label={t('app:profile.back')} className="mt-6" file="routes/employee/profile/index.tsx" params={params}>
+        {t('app:profile.back')}
+      </BackLink>
       <div className="max-w-prose">
         <EmploymentInformationForm
           cancelLink={'routes/hr-advisor/employee-profile/index.tsx'}

--- a/frontend/app/routes/hr-advisor/employee-profile/personal-information.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/personal-information.tsx
@@ -1,6 +1,7 @@
-import { data } from 'react-router';
 import type { RouteHandle } from 'react-router';
+import { data } from 'react-router';
 
+import { useTranslation } from 'react-i18next';
 import * as v from 'valibot';
 
 import type { Route } from '../employee-profile/+types/personal-information';
@@ -157,11 +158,14 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 }
 
 export default function PersonalInformation({ loaderData, actionData, params }: Route.ComponentProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
   const errors = actionData?.errors;
 
   return (
     <>
-      <BackLink className="mt-6" file="routes/hr-advisor/employee-profile/index.tsx" params={params} />
+      <BackLink aria-label={t('app:profile.back')} className="mt-6" file="routes/employee/profile/index.tsx" params={params}>
+        {t('app:profile.back')}
+      </BackLink>
       <div className="max-w-prose">
         <PersonalInformationForm
           cancelLink={'routes/hr-advisor/employee-profile/index.tsx'}

--- a/frontend/app/routes/hr-advisor/employee-profile/referral-preferences.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/referral-preferences.tsx
@@ -1,6 +1,7 @@
 import type { RouteHandle } from 'react-router';
 import { data } from 'react-router';
 
+import { useTranslation } from 'react-i18next';
 import * as v from 'valibot';
 
 import type { Route } from './+types/referral-preferences';
@@ -131,11 +132,14 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 }
 
 export default function PersonalDetails({ loaderData, actionData, params }: Route.ComponentProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
   const errors = actionData?.errors;
 
   return (
     <>
-      <BackLink className="mt-6" file="routes/hr-advisor/employee-profile/index.tsx" params={params} />
+      <BackLink aria-label={t('app:profile.back')} className="mt-6" file="routes/employee/profile/index.tsx" params={params}>
+        {t('app:profile.back')}
+      </BackLink>
       <div className="max-w-prose">
         <ReferralPreferencesForm
           cancelLink={'routes/hr-advisor/employee-profile/index.tsx'}

--- a/frontend/app/routes/hr-advisor/employees.tsx
+++ b/frontend/app/routes/hr-advisor/employees.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
 import type { JSX } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import type { RouteHandle } from 'react-router';
 import { useSearchParams } from 'react-router';
@@ -181,11 +181,12 @@ export default function EmployeeDashboard({ loaderData, params }: Route.Componen
     <div className="mb-8">
       <PageTitle className="after:w-14">{t('app:index.employees')}</PageTitle>
       <BackLink
+        aria-label={t('app:hr-advisor-employees-table.back-to-dashboard')}
         file="routes/hr-advisor/index.tsx"
         params={params}
-        translationKey="app:hr-advisor-employees-table.back-to-dashboard"
-      />
-
+      >
+        {t('app:hr-advisor-employees-table.back-to-dashboard')}
+      </BackLink>
       <InputSelect
         id="selectEmployees"
         name="selectEmployees"


### PR DESCRIPTION
## Summary

The use of `useTranslation()` in the `<BackLink>` component was causing the application to load a non-existent `translations` i18n namespace. While everything rendered fine, this led to 404 errors being returned from the application in the background.

This fix involves removing the `useTranslation()` call, instead relying on the parent component to supply the text strings.

## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] code has been linted and formatted locally

## Additional Notes

Component HTML with these changes applied:

``` html
<a class="text-slate-700 underline hover:text-blue-700 focus:text-blue-700 inline-flex items-center mt-6" aria-label="Retour au profil" href="/fr/employe/profil" data-discover="true">
  <svg data-prefix="fas" data-icon="angle-left" class="svg-inline--fa fa-angle-left " role="img" viewBox="0 0 256 512" aria-hidden="true"><path fill="currentColor" d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l160 160c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L77.3 256 214.6 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-160 160z"></path></svg>
  Retour au profil
</a>
```
