### PR TITLE
feat(frontend) add somc-conditions page content

### DIFF
--- a/frontend/app/.server/locales/app-en.ts
+++ b/frontend/app/.server/locales/app-en.ts
@@ -279,4 +279,11 @@ export default {
     'view-link': 'View request with ID {{requestId}}',
     'next-page': 'Next',
   },
+  'somc-conditions': {
+    'page-title': 'Statement of merit criteria and conditions of employment',
+    'english-somc-label': 'English statement of merit criteria of employment',
+    'english-somc-help-message': 'Please enter the full English criteria here',
+    'french-somc-label': 'French statement of merit criteria of employment',
+    'french-somc-help-message': 'Please enter the full French criteria here',
+  },
 };

--- a/frontend/app/.server/locales/app-fr.ts
+++ b/frontend/app/.server/locales/app-fr.ts
@@ -282,4 +282,11 @@ export default {
     'view-link': "Afficher la demande avec l'identifiant {{requestId}}",
     'next-page': 'Suivant',
   },
+  'somc-conditions': {
+    'page-title': "Énoncé de critères de mérite et conditions d'emploi",
+    'english-somc-label': "Énoncé de critères de mérite et conditions d'emploi - Anglais",
+    'english-somc-help-message': "Veuillez saisir l'intégralité des critères en anglais",
+    'french-somc-label': "Énoncé de critères de mérite et conditions d'emploi - Français",
+    'french-somc-help-message': "Veuillez saisir l'intégralité des critères en français",
+  },
 } satisfies typeof appEn;

--- a/frontend/app/components/input-textarea.tsx
+++ b/frontend/app/components/input-textarea.tsx
@@ -57,7 +57,7 @@ export function InputTextarea({
           {helpMessage}
         </InputHelp>
       )}
-      <div className="relative">
+      <div>
         <textarea
           aria-describedby={helpMessage ? inputHelpMessageId : undefined}
           aria-errormessage={errorMessage && inputErrorId}
@@ -79,9 +79,11 @@ export function InputTextarea({
           onChange={(e) => setCharacterCount(e.target.value.length)}
           {...restInputProps}
         />
-        <span className="absolute right-0 text-sm text-gray-500" aria-live="polite" aria-atomic="true">
-          {`${characterCount}/${maxLength} ${t('form.maximum-characters')}`}
-        </span>
+        {maxLength && (
+          <p className="text-right text-sm text-gray-500" aria-live="polite" aria-atomic="true">
+            {`${characterCount}/${maxLength} ${t('form.maximum-characters')}`}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/frontend/app/routes/hiring-manager/request/somc-conditions.tsx
+++ b/frontend/app/routes/hiring-manager/request/somc-conditions.tsx
@@ -1,3 +1,95 @@
+import { Form } from 'react-router';
+import type { RouteHandle } from 'react-router';
+
+import { useTranslation } from 'react-i18next';
+
 import type { Route } from './+types/somc-conditions';
 
-export default function HiringManagerRequestSomcConditions({ loaderData, params }: Route.ComponentProps) {}
+import { requireAuthentication } from '~/.server/utils/auth-utils';
+import { BackLink } from '~/components/back-link';
+import { Button } from '~/components/button';
+import { ButtonLink } from '~/components/button-link';
+import { FormErrorSummary } from '~/components/error-summary';
+import { InputTextarea } from '~/components/input-textarea';
+import { getTranslation } from '~/i18n-config.server';
+import { handle as parentHandle } from '~/routes/layout';
+
+export const handle = {
+  i18nNamespace: [...parentHandle.i18nNamespace],
+} as const satisfies RouteHandle;
+
+export function meta({ loaderData }: Route.MetaArgs) {
+  return [{ title: loaderData.documentTitle }];
+}
+
+export function action({ context, params, request }: Route.ActionArgs) {
+  requireAuthentication(context.session, request);
+
+  // TODO update the current request
+}
+
+export async function loader({ context, request }: Route.LoaderArgs) {
+  requireAuthentication(context.session, request);
+
+  const { t } = await getTranslation(request, handle.i18nNamespace);
+
+  // TODO fetch the current request
+
+  return {
+    documentTitle: t('app:somc-conditions.page-title'),
+  };
+}
+
+export default function HiringManagerRequestSomcConditions({ loaderData, params }: Route.ComponentProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
+  return (
+    <>
+      <BackLink
+        className="mt-6"
+        translationKey="app:hiring-manager-requests.back"
+        file="routes/hiring-manager/request/index.tsx"
+        params={params}
+      />
+      <div className="max-w-prose">
+        {/* TODO: componentize the form */}
+        <h1 className="my-5 text-3xl font-semibold">{t('app:somc-conditions.page-title')}</h1>
+        <FormErrorSummary>
+          <Form method="post" noValidate>
+            <div className="space-y-6">
+              <InputTextarea
+                id="english-somc"
+                className="w-full"
+                label={t('app:somc-conditions.english-somc-label')}
+                name="englishSomc"
+                helpMessage={t('app:somc-conditions.english-somc-help-message')}
+                required
+              />
+
+              <InputTextarea
+                id="french-somc"
+                className="w-full"
+                label={t('app:somc-conditions.french-somc-label')}
+                name="frenchSomc"
+                helpMessage={t('app:somc-conditions.french-somc-help-message')}
+                required
+              />
+              <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+                <Button name="action" variant="primary" id="save-button">
+                  {t('app:form.save')}
+                </Button>
+                <ButtonLink
+                  file="routes/hiring-manager/request/index.tsx"
+                  params={params}
+                  id="cancel-button"
+                  variant="alternative"
+                >
+                  {t('app:form.cancel')}
+                </ButtonLink>
+              </div>
+            </div>
+          </Form>
+        </FormErrorSummary>
+      </div>
+    </>
+  );
+}

--- a/frontend/tests/components/__snapshots__/input-textarea.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/input-textarea.test.tsx.snap
@@ -18,9 +18,7 @@ exports[`InputTextarea > should render > expected html 1`] = `
         label test
       </span>
     </label>
-    <div
-      class="relative"
-    >
+    <div>
       <textarea
         aria-invalid="false"
         aria-labelledby="input-test-id-label"
@@ -31,13 +29,6 @@ exports[`InputTextarea > should render > expected html 1`] = `
       >
         default value
       </textarea>
-      <span
-        aria-atomic="true"
-        aria-live="polite"
-        class="absolute right-0 text-sm text-gray-500"
-      >
-        0/undefined form.maximum-characters
-      </span>
     </div>
   </div>
 </div>
@@ -69,9 +60,7 @@ exports[`InputTextarea > should render with error message > expected html 1`] = 
     >
       error message
     </span>
-    <div
-      class="relative"
-    >
+    <div>
       <textarea
         aria-errormessage="input-test-id-error"
         aria-invalid="true"
@@ -83,13 +72,6 @@ exports[`InputTextarea > should render with error message > expected html 1`] = 
       >
         default value
       </textarea>
-      <span
-        aria-atomic="true"
-        aria-live="polite"
-        class="absolute right-0 text-sm text-gray-500"
-      >
-        0/undefined form.maximum-characters
-      </span>
     </div>
   </div>
 </div>
@@ -120,9 +102,7 @@ exports[`InputTextarea > should render with help message > expected html 1`] = `
     >
       help message
     </div>
-    <div
-      class="relative"
-    >
+    <div>
       <textarea
         aria-describedby="input-test-id-help"
         aria-invalid="false"
@@ -134,13 +114,6 @@ exports[`InputTextarea > should render with help message > expected html 1`] = `
       >
         default value
       </textarea>
-      <span
-        aria-atomic="true"
-        aria-live="polite"
-        class="absolute right-0 text-sm text-gray-500"
-      >
-        0/undefined form.maximum-characters
-      </span>
     </div>
   </div>
 </div>
@@ -172,9 +145,7 @@ exports[`InputTextarea > should render with required > expected html 1`] = `
         )
       </span>
     </label>
-    <div
-      class="relative"
-    >
+    <div>
       <textarea
         aria-invalid="false"
         aria-labelledby="input-test-id-label"
@@ -187,13 +158,6 @@ exports[`InputTextarea > should render with required > expected html 1`] = `
       >
         default value
       </textarea>
-      <span
-        aria-atomic="true"
-        aria-live="polite"
-        class="absolute right-0 text-sm text-gray-500"
-      >
-        0/undefined form.maximum-characters
-      </span>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary

[AB#6727](https://dev.azure.com/DTS-STN/4c33b941-c811-479f-b181-dfd5292182ff/_workitems/edit/6727)

To make this more palatable, I'm breaking this PR into smaller incremental chunks.  This PR adds the page content for the SOMC screen.  I've added todos for future work.  I've also changed the text-area component.  The absolute positions of the character limit was causing elements to overlap.  

<img width="1494" height="807" alt="image" src="https://github.com/user-attachments/assets/5fb41836-d7b1-4d72-8a00-fadea8fda269" />

