### PR TITLE
feat(backend): implement JsonPatchProcessor to allow for JSON-Patch endpoints

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -48,6 +48,7 @@
 		<!-- dependency/plugin versions -->
 
 		<immutables.version>2.11.3</immutables.version>
+		<johnzon.version>1.2.21</johnzon.version>
 		<mapstruct.version>1.6.3</mapstruct.version>
 		<record-builder.version>48</record-builder.version>
 		<spring-boot-configuration-processor.version>3.5.5</spring-boot-configuration-processor.version>
@@ -56,6 +57,10 @@
 
 
 	<dependencies>
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr353</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>com.github.ben-manes.caffeine</groupId>
 			<artifactId>caffeine</artifactId>
@@ -67,15 +72,23 @@
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
-			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-registry-otlp</artifactId>
 		</dependency>
 		<dependency>
-        	<groupId>org.liquibase</groupId>
-        	<artifactId>liquibase-core</artifactId>
+			<groupId>jakarta.json</groupId>
+			<artifactId>jakarta.json-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.johnzon</groupId>
+			<artifactId>johnzon-core</artifactId>
+			<version>${johnzon.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.liquibase</groupId>
+			<artifactId>liquibase-core</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.immutables</groupId>

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/config/SpringDocConfig.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/config/SpringDocConfig.java
@@ -1,8 +1,11 @@
 package ca.gov.dtsstn.vacman.api.config;
 
+import javax.json.JsonPatch;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springdoc.core.utils.SpringDocUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.info.GitProperties;
 import org.springframework.context.annotation.Bean;
@@ -16,8 +19,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
 import ca.gov.dtsstn.vacman.api.config.properties.SwaggerUiProperties;
+import ca.gov.dtsstn.vacman.api.json.JsonPatchOperation;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.security.OAuthFlow;
 import io.swagger.v3.oas.models.security.OAuthFlows;
 import io.swagger.v3.oas.models.security.SecurityScheme;
@@ -62,6 +69,12 @@ public class SpringDocConfig {
 	}
 
 	@Bean OpenApiCustomizer openApiCustomizer() {
+		log.info("Registering JsonPatch OpenAPI schema");
+
+		final var jsonPatchOperationSchema = ModelConverters.getInstance().resolveAsResolvedSchema(new AnnotatedType(JsonPatchOperation.class));
+		final var jsonPatchSchema = new ArraySchema().items(jsonPatchOperationSchema.schema);
+		SpringDocUtils.getConfig().replaceWithSchema(JsonPatch.class, jsonPatchSchema);
+
 		log.info("Creating 'openApiCustomizer' bean");
 
 		return openApi -> {

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/json/JsonMergePatchHttpMessageConverter.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/json/JsonMergePatchHttpMessageConverter.java
@@ -1,0 +1,50 @@
+package ca.gov.dtsstn.vacman.api.json;
+
+import javax.json.Json;
+import javax.json.JsonMergePatch;
+
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.stereotype.Component;
+
+/**
+ * An {@link AbstractHttpMessageConverter} that can read and write {@link JsonMergePatch} objects.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc7396">RFC 7396: JSON Merge Patch</a>
+ */
+@Component
+public class JsonMergePatchHttpMessageConverter extends AbstractHttpMessageConverter<JsonMergePatch> {
+
+	public JsonMergePatchHttpMessageConverter() {
+		super(JsonPatchMediaTypes.JSON_MERGE_PATCH);
+	}
+
+	@Override
+	protected boolean supports(Class<?> clazz) {
+		return JsonMergePatch.class.isAssignableFrom(clazz);
+	}
+
+	@Override
+	protected JsonMergePatch readInternal(Class<? extends JsonMergePatch> clazz, HttpInputMessage httpInputMessage) {
+		try (final var jsonReader = Json.createReader(httpInputMessage.getBody())) {
+			return Json.createMergePatch(jsonReader.readValue());
+		}
+		catch (final Exception exception) {
+			throw new HttpMessageNotReadableException("Could not read JSON merge-patch: " + exception.getMessage(), exception, httpInputMessage);
+		}
+	}
+
+	@Override
+	protected void writeInternal(JsonMergePatch jsonMergePatch, HttpOutputMessage httpOutputMessage) {
+		try (final var jsonWriter = Json.createWriter(httpOutputMessage.getBody())) {
+			jsonWriter.write(jsonMergePatch.toJsonValue());
+		}
+		catch (final Exception exception) {
+			throw new HttpMessageNotWritableException("Could not write JSON merge-patch: " + exception.getMessage(), exception);
+		}
+	}
+
+}

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/json/JsonPatchException.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/json/JsonPatchException.java
@@ -1,0 +1,40 @@
+package ca.gov.dtsstn.vacman.api.json;
+
+import org.springframework.core.NestedRuntimeException;
+import org.springframework.lang.Nullable;
+
+/**
+ * Thrown by the JSON subsystem when a JSON processing error occurs.
+ */
+@SuppressWarnings({ "serial" })
+public class JsonPatchException extends NestedRuntimeException {
+
+	/**
+	 * Constructs a new exception with the specified detail message.
+	 * The cause is not initialized, and may subsequently be initialized by a
+	 * call to {@link #initCause}.
+	 *
+	 * @param message the detail message. The detail message is saved for later
+	 *        retrieval by the {@link #getMessage()} method.
+	 */
+	public JsonPatchException(String message) {
+		this(message, null);
+	}
+
+	/**
+	 * Constructs a new exception with the specified detail message and cause.
+	 * <p>
+	 * Note that the detail message associated with <code>cause</code> is
+	 * <i>not</i> automatically incorporated in this exception's detail message.
+	 *
+	 * @param message the detail message (which is saved for later retrieval by
+	 *        the {@link #getMessage()} method).
+	 * @param cause the cause (which is saved for later retrieval by the
+	 *        {@link #getCause()} method). (A <tt>null</tt> value is permitted,
+	 *        and indicates that the cause is nonexistent or unknown.)
+	 */
+	public JsonPatchException(String message, @Nullable Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/json/JsonPatchHttpMessageConverter.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/json/JsonPatchHttpMessageConverter.java
@@ -1,0 +1,50 @@
+package ca.gov.dtsstn.vacman.api.json;
+
+import javax.json.Json;
+import javax.json.JsonPatch;
+
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.stereotype.Component;
+
+/**
+ * An {@link AbstractHttpMessageConverter} that can read and write {@link JsonPatch} objects.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc6902">RFC 6902: JavaScript Object Notation (JSON) Patch</a>
+ */
+@Component
+public class JsonPatchHttpMessageConverter extends AbstractHttpMessageConverter<JsonPatch> {
+
+	public JsonPatchHttpMessageConverter() {
+		super(JsonPatchMediaTypes.JSON_PATCH);
+	}
+
+	@Override
+	protected boolean supports(Class<?> clazz) {
+		return JsonPatch.class.isAssignableFrom(clazz);
+	}
+
+	@Override
+	protected JsonPatch readInternal(Class<? extends JsonPatch> clazz, HttpInputMessage httpInputMessage) {
+		try (final var jsonReader = Json.createReader(httpInputMessage.getBody())) {
+			return Json.createPatch(jsonReader.readArray());
+		}
+		catch (final Exception exception) {
+			throw new HttpMessageNotReadableException("Could not read JSON patch: " + exception.getMessage(), exception, httpInputMessage);
+		}
+	}
+
+	@Override
+	protected void writeInternal(JsonPatch jsonPatch, HttpOutputMessage httpOutputMessage) {
+		try (final var jsonWriter = Json.createWriter(httpOutputMessage.getBody())) {
+			jsonWriter.write(jsonPatch.toJsonArray());
+		}
+		catch (final Exception exception) {
+			throw new HttpMessageNotWritableException("Could not write JSON patch: " + exception.getMessage(), exception);
+		}
+	}
+
+}

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/json/JsonPatchMediaTypes.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/json/JsonPatchMediaTypes.java
@@ -1,0 +1,24 @@
+package ca.gov.dtsstn.vacman.api.json;
+
+import org.springframework.http.MediaType;
+
+/**
+ * Defines custom media type constants for JSON Patch and JSON Merge Patch operations.
+ * <p>
+ * These media types are used to specify the content type of HTTP requests
+ * that apply partial updates to resources.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc7396">RFC 7396: JSON Merge Patch</a>
+ * @see <a href="https://tools.ietf.org/html/rfc6902">RFC 6902: JavaScript Object Notation (JSON) Patch</a>
+ */
+public class JsonPatchMediaTypes {
+
+	public static final String JSON_MERGE_PATCH_VALUE = "application/merge-patch+json";
+
+	public static final MediaType JSON_MERGE_PATCH = MediaType.valueOf(JSON_MERGE_PATCH_VALUE);
+
+	public static final String JSON_PATCH_VALUE = "application/json-patch+json";
+
+	public static final MediaType JSON_PATCH = MediaType.valueOf(JSON_PATCH_VALUE);
+
+}

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/json/JsonPatchOperation.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/json/JsonPatchOperation.java
@@ -1,0 +1,63 @@
+package ca.gov.dtsstn.vacman.api.json;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+
+/**
+ * A SpringDoc Schema for a single JSON Patch operation as defined by
+ * <a href="https://datatracker.ietf.org/doc/html/rfc6902">RFC 6902</a>.
+ *
+ * Note: a JSON Patch is a sequence (array) of these operations.
+ */
+public class JsonPatchOperation {
+
+	@Schema(
+		allowableValues = { "add", "copy", "move", "remove", "replace", "test" },
+		description = """
+			The operation to perform.
+
+			Supported operations (from RFC 6902):
+			- `add` — Adds a value at the target location.
+			- `remove` — Removes the value at the target location.
+			- `replace` — Replaces the value at the target location with a new value.
+			- `copy` — Copies a value from a specified source location to a target location.
+			- `move` — Moves a value from a specified source location to a target location.
+			- `test` — Tests that a value at the target location is equal to a specified value.
+		""",
+		example = "replace",
+		requiredMode = RequiredMode.REQUIRED
+	)
+	public String op;
+
+	@Schema(
+		description = """
+			A JSON Pointer string (RFC 6901) that identifies the location within the target
+			document where the operation is performed.
+
+			For example:
+			- `/name` — the `name` property of the root object
+			- `/addresses/0/city` — the `city` property of the first element in the `addresses` array
+		""",
+		example = "/name",
+		requiredMode = RequiredMode.REQUIRED)
+	public String path;
+
+	@Schema(
+		description = """
+			The source location (a JSON Pointer string, RFC 6901) used by `move` and `copy` operations.
+			Required for `move` and `copy`, ignored otherwise.
+		""",
+		example = "/oldName"
+	)
+	public String from;
+
+	@Schema(
+		description = """
+			The value to apply within the operation. Required for `add`, `replace`, and `test` operations.
+
+			The value can be any valid JSON type (string, number, object, array, boolean, or null).
+		""",
+		requiredMode = RequiredMode.NOT_REQUIRED)
+	public String value;
+
+}

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/json/JsonPatchProcessor.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/json/JsonPatchProcessor.java
@@ -1,0 +1,103 @@
+package ca.gov.dtsstn.vacman.api.json;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+
+import java.util.Set;
+import java.util.function.Function;
+
+import javax.json.JsonMergePatch;
+import javax.json.JsonPatch;
+import javax.json.JsonStructure;
+import javax.json.JsonValue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validator;
+
+/**
+ * A component that applies JSON Patch and JSON Merge Patch operations to Java objects.
+ * This class ensures that the patch operations are applied to a copy of the original
+ * object and that the resulting object is validated before being returned.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc6902">RFC 6902: JSON Patch</a>
+ * @see <a href="https://tools.ietf.org/html/rfc7396">RFC 7396: JSON Merge Patch</a>
+ */
+@Component
+public class JsonPatchProcessor {
+
+	private static final Logger log = LoggerFactory.getLogger(JsonPatchProcessor.class);
+
+	private final ObjectMapper objectMapper = new ObjectMapper()
+		.disable(FAIL_ON_UNKNOWN_PROPERTIES)
+		.findAndRegisterModules();
+
+	private final Validator validator;
+
+	public JsonPatchProcessor(Validator validator) {
+		this.validator = validator;
+	}
+
+	/**
+	 * Applies a JSON Merge Patch to the given object.
+	 *
+	 * @param <T> the type of the object to patch
+	 * @param object the object to patch
+	 * @param jsonMergePatch the JSON Merge Patch to apply
+	 * @return the patched object
+	 * @throws ConstraintViolationException if the patched object is not valid
+	 */
+	public <T> T patch(T object, JsonMergePatch jsonMergePatch) {
+		return patch(object, value -> jsonMergePatch.apply(objectMapper.convertValue(value, JsonValue.class)));
+	}
+
+	/**
+	 * Applies a JSON Patch to the given object.
+	 *
+	 * @param <T> the type of the object to patch
+	 * @param object the object to patch
+	 * @param jsonPatch the JSON Patch to apply
+	 * @return the patched object
+	 * @throws ConstraintViolationException if the patched object is not valid
+	 */
+	public <T> T patch(T object, JsonPatch jsonPatch) {
+		return patch(object, value -> jsonPatch.apply(objectMapper.convertValue(value, JsonStructure.class)));
+	}
+
+	/**
+	 * Generic JSON patching method that delegates the actual patch application to a passed-in function.
+	 * <p>
+	 * This method first creates a deep copy of the input object. The patch function is then applied to this copy.
+	 * Finally, the patched copy is validated. If validation is successful, the patched copy is returned.
+	 *
+	 * @param <T> the type of the object to patch
+	 * @param object the object to patch
+	 * @param patchFn a function that applies the patch to a {@link JsonValue} representation of the object
+	 * @return the patched and validated object
+	 * @throws ConstraintViolationException if the patched object does not pass validation
+	 */
+	protected <T> T patch(T object, Function<? super Object, ? extends JsonValue> patchFn) {
+		Assert.notNull(object, "object is required; it must not be null");
+		Assert.notNull(patchFn, "patchFn is required; it must not be null");
+
+		log.debug("Patching object of type {}", object.getClass().getSimpleName());
+
+		// copy the existing data into a new object that will be patched and validated..
+		final Object objectCopy = objectMapper.convertValue(object, object.getClass());
+		final Object patchedObjectCopy = objectMapper.convertValue(patchFn.apply(objectCopy), object.getClass());
+
+		log.debug("Performing JSON patch validation");
+		final Set<ConstraintViolation<Object>> constraintViolations = validator.validate(patchedObjectCopy);
+		if (constraintViolations.isEmpty() == false) { throw new ConstraintViolationException(constraintViolations); }
+		log.debug("No validation errors for {}", object.getClass().getSimpleName());
+
+		return (T) patchedObjectCopy;
+	}
+
+}

--- a/backend/src/test/java/ca/gov/dtsstn/vacman/api/json/JsonMergePatchHttpMessageConverterTests.java
+++ b/backend/src/test/java/ca/gov/dtsstn/vacman/api/json/JsonMergePatchHttpMessageConverterTests.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2021 Her Majesty the Queen in Right of Canada, as represented by the Employment and Social Development Canada
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE.md file in the root directory of this source tree.
+ */
+
+package ca.gov.dtsstn.vacman.api.json;
+
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+
+import javax.json.Json;
+import javax.json.JsonMergePatch;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+
+/**
+ * Tests for {@link JsonMergePatchHttpMessageConverter}.
+ */
+class JsonMergePatchHttpMessageConverterTests {
+
+	JsonMergePatchHttpMessageConverter jsonMergePatchHttpMessageConverter;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		this.jsonMergePatchHttpMessageConverter = new JsonMergePatchHttpMessageConverter();
+	}
+
+	@Test
+	void testSupportsClass() {
+		assertThat(jsonMergePatchHttpMessageConverter.supports(JsonMergePatch.class)).isTrue();
+		assertThat(jsonMergePatchHttpMessageConverter.supports(Object.class)).isFalse();
+	}
+
+	@Test
+	void testReadInternal() throws Exception {
+		final InputStream body = new ByteArrayInputStream("{ \"key\":\"value\" }".getBytes());
+
+		final var httpInputMessage = mock(HttpInputMessage.class);
+		when(httpInputMessage.getBody()).thenReturn(body);
+
+		final var jsonValue = jsonMergePatchHttpMessageConverter.readInternal(JsonMergePatch.class, httpInputMessage).toJsonValue();
+
+		assertThat(jsonValue.asJsonObject().getString("key")).isEqualTo("value");
+	}
+
+	@Test
+	void testWriteInternal() throws Exception {
+		final var jsonPatchObject = Json.createObjectBuilder(singletonMap("key", "value")).build();
+		final var byteArrayOutputStream = new ByteArrayOutputStream();
+
+		final var httpOutputMessage = mock(HttpOutputMessage.class);
+		when(httpOutputMessage.getBody()).thenReturn(byteArrayOutputStream);
+
+		jsonMergePatchHttpMessageConverter.writeInternal(Json.createMergePatch(jsonPatchObject), httpOutputMessage);
+
+		assertThat(byteArrayOutputStream).hasToString("{\"key\":\"value\"}");
+	}
+
+}

--- a/backend/src/test/java/ca/gov/dtsstn/vacman/api/json/JsonPatchHttpMessageConverterImplTests.java
+++ b/backend/src/test/java/ca/gov/dtsstn/vacman/api/json/JsonPatchHttpMessageConverterImplTests.java
@@ -1,0 +1,65 @@
+package ca.gov.dtsstn.vacman.api.json;
+
+import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Map;
+
+import javax.json.Json;
+import javax.json.JsonPatch;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+
+/**
+ * Tests for {@link JsonPatchHttpMessageConverter}.
+ */
+class JsonPatchHttpMessageConverterTests {
+
+	JsonPatchHttpMessageConverter jsonPatchHttpMessageConverter;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		this.jsonPatchHttpMessageConverter = new JsonPatchHttpMessageConverter();
+	}
+
+	@Test
+	void testSupportsClass() {
+		assertThat(jsonPatchHttpMessageConverter.supports(JsonPatch.class)).isTrue();
+		assertThat(jsonPatchHttpMessageConverter.supports(Object.class)).isFalse();
+	}
+
+	@Test
+	void testReadInternal() throws Exception {
+		final var httpInputMessage = mock(HttpInputMessage.class);
+		when(httpInputMessage.getBody()).thenReturn(new ByteArrayInputStream("[{ \"op\":\"replace\", \"path\":\"/id\", \"value\":\"value\" }]".getBytes()));
+
+		final var jsonObject = jsonPatchHttpMessageConverter.readInternal(JsonPatch.class, httpInputMessage).toJsonArray().get(0).asJsonObject();
+
+		assertThat(jsonObject.getString("op")).isEqualTo("replace");
+		assertThat(jsonObject.getString("path")).isEqualTo("/id");
+		assertThat(jsonObject.getString("value")).isEqualTo("value");
+	}
+
+	@Test
+	void testWriteInternal() throws Exception {
+		final Map<String, String> map = Map.of("op", "replace", "path", "/id", "value", "value");
+
+		final var jsonPatchObject = Json.createArrayBuilder(singleton(map)).build();
+		final var byteArrayOutputStream = new ByteArrayOutputStream();
+
+		final var httpOutputMessage = mock(HttpOutputMessage.class);
+		when(httpOutputMessage.getBody()).thenReturn(byteArrayOutputStream);
+
+		jsonPatchHttpMessageConverter.writeInternal(Json.createPatch(jsonPatchObject), httpOutputMessage);
+
+		assertThat(byteArrayOutputStream).hasToString("[{\"op\":\"replace\",\"path\":\"/id\",\"value\":\"value\"}]");
+	}
+
+}

--- a/backend/src/test/java/ca/gov/dtsstn/vacman/api/json/JsonPatchProcessorTests.java
+++ b/backend/src/test/java/ca/gov/dtsstn/vacman/api/json/JsonPatchProcessorTests.java
@@ -1,0 +1,101 @@
+package ca.gov.dtsstn.vacman.api.json;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.io.Serializable;
+
+import javax.json.Json;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validation;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Tests for {@link JsonPatchProcessor}.
+ * <p>
+ * This is not <i>strictly</i> a unit test because it makes calls to Jackson's
+ * {@link ObjectMapper}. The tests were designed in this way because of the very deep
+ * reliance on ObjectMapper's configuration state and JSON parsing abilities.
+ */
+class JsonPatchProcessorTests {
+
+	JsonPatchProcessor jsonPatchProcessor;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		this.jsonPatchProcessor = new JsonPatchProcessor(Validation.buildDefaultValidatorFactory().getValidator());
+	}
+
+	@Test
+	void testPatchJsonMergePatch() {
+		final var entity = new MyEntity("id", "name");
+		final var patchObject = Json.createObjectBuilder().add("name", "updated name").build();
+		final var jsonMergePatch = Json.createMergePatch(Json.createObjectBuilder(patchObject).build());
+		final var patchedEntity = jsonPatchProcessor.patch(entity, jsonMergePatch);
+
+		assertThat(patchedEntity)
+			.isNotSameAs(entity)
+			.hasFieldOrPropertyWithValue("id", "id")
+			.hasFieldOrPropertyWithValue("name", "updated name");
+	}
+
+	@Test
+	void testPatchJsonMergePatch_validationError_throws() {
+		final var entity = new MyEntity("id", "name");
+		final var patchObject = Json.createObjectBuilder().add("name", "").build();
+		final var jsonMergePatch = Json.createMergePatch(Json.createObjectBuilder(patchObject).build());
+
+		assertThatExceptionOfType(ConstraintViolationException.class)
+			.isThrownBy(() -> jsonPatchProcessor.patch(entity, jsonMergePatch))
+			.withMessage("name: must not be blank");
+	}
+
+	@Test
+	void testPatchJsonPatch() {
+		final var entity = new MyEntity("id", "name");
+		final var patchObject = Json.createObjectBuilder().add("op", "replace").add("path", "/name").add("value", "updated name").build();
+		final var jsonPatch = Json.createPatch(Json.createArrayBuilder().add(patchObject).build());
+		final var patchedEntity = jsonPatchProcessor.patch(entity, jsonPatch);
+
+		assertThat(patchedEntity)
+			.isNotSameAs(entity)
+			.hasFieldOrPropertyWithValue("id", "id")
+			.hasFieldOrPropertyWithValue("name", "updated name");
+	}
+
+	@Test
+	void testPatchJsonPatch_validationError_throws() {
+		final var entity = new MyEntity("id", "name");
+		final var patchObject = Json.createObjectBuilder().add("op", "replace").add("path", "/name").add("value", "").build();
+		final var jsonPatch = Json.createPatch(Json.createArrayBuilder().add(patchObject).build());
+
+		assertThatExceptionOfType(ConstraintViolationException.class)
+			.isThrownBy(() -> jsonPatchProcessor.patch(entity, jsonPatch))
+			.withMessage("name: must not be blank");
+	}
+
+	@SuppressWarnings({ "serial" })
+	static class MyEntity implements Serializable {
+
+		@NotBlank
+		public String id;
+
+		@NotBlank
+		public String name;
+
+		public MyEntity() {}
+
+		public MyEntity(String id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Summary

Add a JsonPatch processor and Spring message converters to allow for `application/json-patch+json` patch endpoints

## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] ✨ **new feature** -- non-breaking change that adds functionality

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [x] added adequate logging for new or updated functionality
