### PR TITLE
refactor(backend): remove setters for immutable entity fields

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/entity/AbstractBaseEntity.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/entity/AbstractBaseEntity.java
@@ -80,40 +80,20 @@ public abstract class AbstractBaseEntity {
 		return id;
 	}
 
-	public void setId(Long id) {
-		this.id = id;
-	}
-
 	public String getCreatedBy() {
 		return createdBy;
-	}
-
-	public void setCreatedBy(String createdBy) {
-		this.createdBy = createdBy;
 	}
 
 	public Instant getCreatedDate() {
 		return createdDate;
 	}
 
-	public void setCreatedDate(Instant createdDate) {
-		this.createdDate = createdDate;
-	}
-
 	public String getLastModifiedBy() {
 		return lastModifiedBy;
 	}
 
-	public void setLastModifiedBy(String lastModifiedBy) {
-		this.lastModifiedBy = lastModifiedBy;
-	}
-
 	public Instant getLastModifiedDate() {
 		return lastModifiedDate;
-	}
-
-	public void setLastModifiedDate(Instant lastModifiedDate) {
-		this.lastModifiedDate = lastModifiedDate;
 	}
 
 	@Override

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/entity/AbstractCodeEntity.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/entity/AbstractCodeEntity.java
@@ -64,40 +64,20 @@ public abstract class AbstractCodeEntity extends AbstractBaseEntity {
 		return code;
 	}
 
-	public void setCode(String code) {
-		this.code = code;
-	}
-
 	public Instant getEffectiveDate() {
 		return effectiveDate;
-	}
-
-	public void setEffectiveDate(Instant effectiveDate) {
-		this.effectiveDate = effectiveDate;
 	}
 
 	public Instant getExpiryDate() {
 		return expiryDate;
 	}
 
-	public void setExpiryDate(Instant expiryDate) {
-		this.expiryDate = expiryDate;
-	}
-
 	public String getNameEn() {
 		return nameEn;
 	}
 
-	public void setNameEn(String nameEn) {
-		this.nameEn = nameEn;
-	}
-
 	public String getNameFr() {
 		return nameFr;
-	}
-
-	public void setNameFr(String nameFr) {
-		this.nameFr = nameFr;
 	}
 
 	@Override


### PR DESCRIPTION
## Summary

This pull request hardens JPA entity design by removing unnecessary setters from the abstract base classes (`AbstractBaseEntity` and `AbstractCodeEntity`). This improves the overall robustness and safety of our domain model by enforcing immutability where intended.

## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] code has been linted and formatted locally