### PR TITLE
refactor(backend): switch to query-by-example in ProfileService

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/repository/ProfileStatusRepository.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/repository/ProfileStatusRepository.java
@@ -5,14 +5,4 @@ import org.springframework.stereotype.Repository;
 import ca.gov.dtsstn.vacman.api.data.entity.ProfileStatusEntity;
 
 @Repository
-public interface ProfileStatusRepository extends AbstractBaseRepository<ProfileStatusEntity> {
-
-	/**
-	 * Retrieve a profile status based on the provided code value.
-	 *
-	 * @param code The profile status code to return.
-	 * @return The profile status.
-	 */
-	ProfileStatusEntity findByCode(String code);
-
-}
+public interface ProfileStatusRepository extends AbstractBaseRepository<ProfileStatusEntity> {}


### PR DESCRIPTION
## Summary

There was a hidden `NullPointerException` in the way that profile statuses were being fetched and used in `ProfileService`. This PR switches to find-by-example along with a throw `asResourceNotFoundException()` to instead alert the consumer about the missing resource with a 404 response code.

## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
