### PR TITLE
refactor(frontend) remove getRequestProfileById from request-service

### DIFF
--- a/frontend/app/.server/domain/services/request-service-default.ts
+++ b/frontend/app/.server/domain/services/request-service-default.ts
@@ -7,7 +7,6 @@ import type {
   PagedRequestResponse,
   CollectionRequestResponse,
   RequestQueryParams,
-  Profile,
   PagedProfileResponse,
 } from '~/.server/domain/models';
 import { apiClient } from '~/.server/domain/services/api-client';
@@ -271,27 +270,6 @@ export function getDefaultRequestService(): RequestService {
         const error = result.unwrapErr();
         if (error.httpStatusCode === HttpStatusCodes.NOT_FOUND) {
           return Err(new AppError(`Request with ID ${requestId} not found.`, ErrorCodes.REQUEST_NOT_FOUND));
-        }
-        return Err(error);
-      }
-
-      return Ok(result.unwrap());
-    },
-
-    /**
-     * Gets a specific candidate profile for a request.
-     */
-    async getRequestProfileById(requestId: number, profileId: number, accessToken: string): Promise<Result<Profile, AppError>> {
-      const result = await apiClient.get<Profile>(
-        `/requests/${requestId}/profiles/${profileId}`,
-        `retrieve profile ${profileId} for request ID ${requestId}`,
-        accessToken,
-      );
-
-      if (result.isErr()) {
-        const error = result.unwrapErr();
-        if (error.httpStatusCode === HttpStatusCodes.NOT_FOUND) {
-          return Err(new AppError(`Profile ${profileId} for request ID ${requestId} not found.`, ErrorCodes.PROFILE_NOT_FOUND));
         }
         return Err(error);
       }

--- a/frontend/app/.server/domain/services/request-service-mock.ts
+++ b/frontend/app/.server/domain/services/request-service-mock.ts
@@ -7,7 +7,6 @@ import type {
   PagedRequestResponse,
   CollectionRequestResponse,
   RequestQueryParams,
-  Profile,
   PagedProfileResponse,
   RequestStatus,
 } from '~/.server/domain/models';
@@ -242,15 +241,6 @@ export function getMockRequestService(): RequestService {
         },
       };
       return Promise.resolve(Ok(response));
-    },
-
-    /**
-     * Gets a specific candidate profile for a request.
-     */
-    async getRequestProfileById(requestId: number, profileId: number, accessToken: string): Promise<Result<Profile, AppError>> {
-      return Promise.resolve(
-        Err(new AppError(`Profile ${profileId} for request ID ${requestId} not found.`, ErrorCodes.PROFILE_NOT_FOUND)),
-      );
     },
 
     /**

--- a/frontend/app/.server/domain/services/request-service.ts
+++ b/frontend/app/.server/domain/services/request-service.ts
@@ -6,7 +6,6 @@ import type {
   PagedRequestResponse,
   CollectionRequestResponse,
   RequestQueryParams,
-  Profile,
   PagedProfileResponse,
 } from '~/.server/domain/models';
 import { getDefaultRequestService } from '~/.server/domain/services/request-service-default';
@@ -60,9 +59,6 @@ export type RequestService = {
 
   // GET /api/v1/requests/{id}/profiles - Get candidate profiles for a request
   getRequestProfiles(requestId: number, accessToken: string): Promise<Result<PagedProfileResponse, AppError>>;
-
-  // GET /api/v1/requests/{id}/profiles/{profileId} - Get specific candidate profile for a request
-  getRequestProfileById(requestId: number, profileId: number, accessToken: string): Promise<Result<Profile, AppError>>;
 
   // Optional method for finding request by ID
   findRequestById(requestId: number, accessToken: string): Promise<Option<RequestReadModel>>;


### PR DESCRIPTION
## Summary

This method is no longer needed.

