### PR TITLE
refactor(frontend) add roles for dev user John Doe

### DIFF
--- a/frontend/app/routes/dev/oidc-provider.tsx
+++ b/frontend/app/routes/dev/oidc-provider.tsx
@@ -136,7 +136,7 @@ async function handleAuthorizeRequest({ request }: Route.LoaderArgs): Promise<Re
     jti: randomUUID(),
     name: 'John Doe',
     nonce: nonce,
-    roles: [],
+    roles: ['hr-advisor', 'hiring-manager'],
     scopes: scope.split(' '),
     sub: '00000000-0000-0000-0000-000000000000',
     oid: '00000000-0000-0000-0000-000000000000',

--- a/frontend/app/routes/layout.tsx
+++ b/frontend/app/routes/layout.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import type { Route } from './+types/layout';
 
 import { requireAuthentication } from '~/.server/utils/auth-utils';
-import { checkHrAdvisorRouteRegistration } from '~/.server/utils/registration-utils';
+import { checkHiringManagerRouteRegistration, checkHrAdvisorRouteRegistration } from '~/.server/utils/registration-utils';
 import { AppBar } from '~/components/app-bar';
 import { LanguageSwitcher } from '~/components/language-switcher';
 import { AppLink } from '~/components/links';
@@ -25,9 +25,7 @@ export async function loader({ context, request }: Route.LoaderArgs) {
   // First ensure the user is authenticated (no specific roles required)
   requireAuthentication(context.session, request);
 
-  // Check hiring manager registration for hiring manager routes
-  // TODO uncomment when registration-utils.ts is updated; commented only for development
-  // await checkHiringManagerRouteRegistration(context.session, request);
+  await checkHiringManagerRouteRegistration(context.session, request);
 
   await checkHrAdvisorRouteRegistration(context.session, request);
 


### PR DESCRIPTION
## Summary

Adds roles to the the dev user John Doe so we can effectively navigate to the hr-advisor/hiring-manager routes in `dev` without having to comment out auth checks in the root loader, or add and remove these roles during development.  This has the implication of being redirected to `/hr-advisor/index` instead of `/employees/index` upon hitting the root since the user is now an hr-advisor.

