### PR TITLE
refactor(frontend): use the background image in layout for hiring manager dashboard

### DIFF
--- a/frontend/app/routes/hiring-manager/index.tsx
+++ b/frontend/app/routes/hiring-manager/index.tsx
@@ -17,6 +17,7 @@ import { getLanguage } from '~/utils/i18n-utils';
 
 export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace],
+  layoutHasDecorativeBackground: true,
 } as const satisfies RouteHandle;
 
 export function meta({ loaderData }: Route.MetaArgs) {
@@ -39,27 +40,13 @@ export default function HiringManagerDashboard() {
   const { t } = useTranslation(handle.i18nNamespace);
 
   return (
-    <div className="flex h-screen">
-      <aside className="absolute inset-y-0 right-0 z-0 hidden w-2/5 bg-[rgba(9,28,45,1)] sm:block">
-        <div
-          role="presentation"
-          className="absolute top-0 right-0 size-1/2 w-full bg-[url('/VacMan-design-element-07.svg')] bg-contain bg-top bg-no-repeat"
-        />
-        <div
-          role="presentation"
-          className="absolute inset-x-0 bottom-0 h-1/2 bg-[url('/VacMan-design-element-06.svg')] bg-contain bg-bottom bg-no-repeat"
-        />
-      </aside>
-      <div className="mb-8 w-full px-4 sm:w-3/5 sm:px-6">
-        <PageTitle className="after:w-14">{t('app:hiring-manager-dashboard.page-heading')}</PageTitle>
-        <div className="grid gap-4">
-          <DashboardCard
-            file="routes/hiring-manager/requests.tsx"
-            icon={faUser}
-            title={t('app:hiring-manager-dashboard.requests')}
-          />
-        </div>
-      </div>
-    </div>
+    <>
+      <PageTitle className="after:w-14">{t('app:hiring-manager-dashboard.page-heading')}</PageTitle>
+      <DashboardCard
+        file="routes/hiring-manager/requests.tsx"
+        icon={faUser}
+        title={t('app:hiring-manager-dashboard.requests')}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Summary

 Used the background image in layout for hiring manager dashboard keeping it consistent with other index pages (avoid scroll bar on dashboard)

## Types of changes

What types of changes does this PR introduce?

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.

- [x] code has been linted and formatted locally

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

<img width="1095" height="827" alt="image" src="https://github.com/user-attachments/assets/7fed5d01-8d9e-4a71-92a2-a7d221eb4008" />