### PR TITLE
feat(frontend): hr advisor -> position information screen

### DIFF
--- a/frontend/app/.server/locales/app-en.ts
+++ b/frontend/app/.server/locales/app-en.ts
@@ -237,6 +237,7 @@ export default {
     'page-heading': 'Hiring manager dashboard',
     'requests': 'Requests',
   },
+  'referral-request': 'Referral request',
   'position-information': {
     'page-title': 'Position information',
     'position-number': 'Position number',

--- a/frontend/app/.server/locales/app-fr.ts
+++ b/frontend/app/.server/locales/app-fr.ts
@@ -240,6 +240,7 @@ export default {
     'page-heading': 'Tableau de bord du responsable du recrutement',
     'requests': 'Demandes',
   },
+  'referral-request': 'Demande de présentation de candidatures',
   'position-information': {
     'page-title': 'Informations sur le poste',
     'position-number': 'Numéro du poste',

--- a/frontend/app/routes/hiring-manager/request/position-information.tsx
+++ b/frontend/app/routes/hiring-manager/request/position-information.tsx
@@ -14,7 +14,6 @@ import { getProvinceService } from '~/.server/domain/services/province-service';
 import { getRequestService } from '~/.server/domain/services/request-service';
 import { getSecurityClearanceService } from '~/.server/domain/services/security-clearance-service';
 import { requireAuthentication } from '~/.server/utils/auth-utils';
-import { requirePrivacyConsentForOwnProfile } from '~/.server/utils/privacy-consent-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { BackLink } from '~/components/back-link';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
@@ -103,7 +102,6 @@ export async function action({ context, params, request }: Route.ActionArgs) {
 
 export async function loader({ context, request, params }: Route.LoaderArgs) {
   requireAuthentication(context.session, request);
-  await requirePrivacyConsentForOwnProfile(context.session, request);
 
   const requestResult = await getRequestService().getRequestById(
     Number(params.requestId),

--- a/frontend/app/routes/hr-advisor/request/position-information.tsx
+++ b/frontend/app/routes/hr-advisor/request/position-information.tsx
@@ -1,3 +1,174 @@
+import type { RouteHandle } from 'react-router';
+import { data } from 'react-router';
+
+import { useTranslation } from 'react-i18next';
+import * as v from 'valibot';
+
 import type { Route } from './+types/position-information';
 
-export default function HiringManagerRequestPositionInformation({ loaderData, actionData, params }: Route.ComponentProps) {}
+import type { RequestReadModel, RequestUpdateModel } from '~/.server/domain/models';
+import { getCityService } from '~/.server/domain/services/city-service';
+import { getClassificationService } from '~/.server/domain/services/classification-service';
+import { getLanguageRequirementService } from '~/.server/domain/services/language-requirement-service';
+import { getProvinceService } from '~/.server/domain/services/province-service';
+import { getRequestService } from '~/.server/domain/services/request-service';
+import { getSecurityClearanceService } from '~/.server/domain/services/security-clearance-service';
+import { requireAuthentication } from '~/.server/utils/auth-utils';
+import { i18nRedirect } from '~/.server/utils/route-utils';
+import { BackLink } from '~/components/back-link';
+import { HttpStatusCodes } from '~/errors/http-status-codes';
+import { getTranslation } from '~/i18n-config.server';
+import { handle as parentHandle } from '~/routes/layout';
+import { PositionInformationForm } from '~/routes/page-components/requests/position-information/form';
+import { positionInformationSchema } from '~/routes/page-components/requests/validation.server';
+import { formString } from '~/utils/string-utils';
+
+export const handle = {
+  i18nNamespace: [...parentHandle.i18nNamespace],
+} as const satisfies RouteHandle;
+
+export function meta({ loaderData }: Route.MetaArgs) {
+  return [{ title: loaderData.documentTitle }];
+}
+
+export async function action({ context, params, request }: Route.ActionArgs) {
+  requireAuthentication(context.session, request);
+
+  const formData = await request.formData();
+  const parseResult = v.safeParse(positionInformationSchema, {
+    positionNumber: formString(formData.get('positionNumber')),
+    groupAndLevel: formString(formData.get('groupAndLevel')),
+    titleEn: formString(formData.get('titleEn')),
+    titleFr: formString(formData.get('titleFr')),
+    province: formString(formData.get('province')),
+    city: formString(formData.get('city')),
+    languageRequirement: formString(formData.get('languageRequirement')),
+    readingEn: formString(formData.get('readingEn')),
+    readingFr: formString(formData.get('readingFr')),
+    writingEn: formString(formData.get('writingEn')),
+    writingFr: formString(formData.get('writingFr')),
+    oralEn: formString(formData.get('oralEn')),
+    oralFr: formString(formData.get('oralFr')),
+    securityRequirement: formString(formData.get('securityRequirement')),
+  });
+
+  if (!parseResult.success) {
+    return data(
+      { errors: v.flatten<typeof positionInformationSchema>(parseResult.issues).nested },
+      { status: HttpStatusCodes.BAD_REQUEST },
+    );
+  }
+
+  const requestService = getRequestService();
+  const requestResult = await requestService.getRequestById(Number(params.requestId), context.session.authState.accessToken);
+
+  if (requestResult.isErr()) {
+    throw new Response('Request not found', { status: HttpStatusCodes.NOT_FOUND });
+  }
+
+  const requestData: RequestReadModel = requestResult.unwrap();
+
+  const requestPayload: RequestUpdateModel = {
+    ...requestData,
+    positionNumbers: parseResult.output.positionNumber.split(',').map((num) => num.trim()),
+    classificationId: Number(parseResult.output.groupAndLevel),
+    englishTitle: parseResult.output.titleEn,
+    frenchTitle: parseResult.output.titleFr,
+    provinceId: Number(parseResult.output.province),
+    languageRequirementId: Number(parseResult.output.languageRequirement),
+    englishLanguageProfile: [parseResult.output.readingEn, parseResult.output.writingEn, parseResult.output.oralEn]
+      .filter(Boolean)
+      .join(''),
+    frenchLanguageProfile: [parseResult.output.readingFr, parseResult.output.writingFr, parseResult.output.oralFr]
+      .filter(Boolean)
+      .join(''),
+    securityClearanceId: Number(parseResult.output.securityRequirement),
+  };
+
+  const updateResult = await requestService.updateRequestById(
+    requestData.id,
+    requestPayload,
+    context.session.authState.accessToken,
+  );
+
+  if (updateResult.isErr()) {
+    throw updateResult.unwrapErr();
+  }
+
+  return i18nRedirect('routes/hr-advisor/request/index.tsx', request, {
+    params: { requestId: requestData.id.toString() },
+  });
+}
+
+export async function loader({ context, request, params }: Route.LoaderArgs) {
+  requireAuthentication(context.session, request);
+
+  const requestResult = await getRequestService().getRequestById(
+    Number(params.requestId),
+    context.session.authState.accessToken,
+  );
+
+  if (requestResult.isErr()) {
+    throw new Response('Request not found', { status: HttpStatusCodes.NOT_FOUND });
+  }
+
+  const requestData: RequestReadModel = requestResult.unwrap();
+
+  const { t, lang } = await getTranslation(request, handle.i18nNamespace);
+
+  const localizedLanguageRequirements = await getLanguageRequirementService().listAllLocalized(lang);
+  const localizedClassifications = await getClassificationService().listAllLocalized(lang);
+  const localizedProvinces = await getProvinceService().listAllLocalized(lang);
+  const localizedCities = await getCityService().listAllLocalized(lang);
+  const localizedSecurityClearances = await getSecurityClearanceService().listAllLocalized(lang);
+
+  return {
+    documentTitle: t('app:position-information.page-title'),
+    defaultValues: {
+      positionNumber: requestData.positionNumber,
+      classification: requestData.classification,
+      englishTitle: requestData.englishTitle,
+      frenchTitle: requestData.frenchTitle,
+      englishLanguageProfile: requestData.englishLanguageProfile,
+      frenchLanguageProfile: requestData.frenchLanguageProfile,
+      languageRequirementId: requestData.languageRequirement,
+      securityClearanceId: requestData.securityClearance,
+    },
+    languageRequirements: localizedLanguageRequirements,
+    classifications: localizedClassifications,
+    provinces: localizedProvinces,
+    cities: localizedCities,
+    securityClearances: localizedSecurityClearances,
+  };
+}
+
+export default function HiringManagerRequestPositionInformation({ loaderData, actionData, params }: Route.ComponentProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
+  const errors = actionData?.errors;
+
+  return (
+    <>
+      <BackLink
+        aria-label={t('app:hiring-manager-requests.back')}
+        className="mt-6"
+        file="routes/hr-advisor/request/index.tsx"
+        params={params}
+      >
+        {t('app:hiring-manager-requests.back')}
+      </BackLink>
+      <div className="max-w-prose">
+        <PositionInformationForm
+          cancelLink="routes/hr-advisor/request/index.tsx"
+          formErrors={errors}
+          formValues={loaderData.defaultValues}
+          languageRequirements={loaderData.languageRequirements}
+          classifications={loaderData.classifications}
+          provinces={loaderData.provinces}
+          cities={loaderData.cities}
+          securityClearances={loaderData.securityClearances}
+          params={params}
+        />
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/page-components/requests/position-information/form.tsx
+++ b/frontend/app/routes/page-components/requests/position-information/form.tsx
@@ -105,7 +105,9 @@ export function PositionInformationForm({
 
   return (
     <>
-      <PageTitle className="after:w-14">{t('position-information.page-title')}</PageTitle>
+      <PageTitle className="after:w-14" subTitle={t('referral-request')}>
+        {t('position-information.page-title')}
+      </PageTitle>
       <FormErrorSummary>
         <Form method="post" noValidate>
           <div className="space-y-6">

--- a/frontend/app/routes/page-components/requests/validation.server.ts
+++ b/frontend/app/routes/page-components/requests/validation.server.ts
@@ -1,85 +1,143 @@
 import * as v from 'valibot';
 
 import { getCityService } from '~/.server/domain/services/city-service';
+import { getLanguageRequirementService } from '~/.server/domain/services/language-requirement-service';
 import { getProvinceService } from '~/.server/domain/services/province-service';
 import { stringToIntegerSchema } from '~/.server/validation/string-to-integer-schema';
+import { LANGUAGE_REQUIREMENT_CODES } from '~/domain/constants';
 
 // Services that don't require authentication can be called at module level
 const allProvinces = await getProvinceService().listAll();
 const allCities = await getCityService().listAll();
+const allLanguageRequirements = await getLanguageRequirementService().listAll();
 
 export type Errors = Readonly<Record<string, [string, ...string[]] | undefined>>;
 
+const validLanguageRequirementForRequiredLanguageLevel = [
+  LANGUAGE_REQUIREMENT_CODES.bilingualImperative,
+  LANGUAGE_REQUIREMENT_CODES.bilingualNonImperative,
+] as const;
+
+const validLanguageRequirementForOptionalLanguageLevel = [
+  LANGUAGE_REQUIREMENT_CODES.englishEssential,
+  LANGUAGE_REQUIREMENT_CODES.frenchEssential,
+  LANGUAGE_REQUIREMENT_CODES.either,
+  LANGUAGE_REQUIREMENT_CODES.various,
+] as const;
+
+const selectedLanguageRequirementForRequiredLanguageLevel = allLanguageRequirements
+  .filter((c) => validLanguageRequirementForRequiredLanguageLevel.toString().includes(c.code))
+  .map((languageRequirement) => ({
+    id: languageRequirement.id,
+    code: languageRequirement.code,
+    nameEn: languageRequirement.nameEn,
+    nameFr: languageRequirement.nameFr,
+  }));
+
+const selectedLanguageRequirementForOptionalLanguageLevel = allLanguageRequirements
+  .filter((c) => validLanguageRequirementForOptionalLanguageLevel.toString().includes(c.code))
+  .map((languageRequirement) => ({
+    id: languageRequirement.id,
+    code: languageRequirement.code,
+    nameEn: languageRequirement.nameEn,
+    nameFr: languageRequirement.nameFr,
+  }));
+
 export const positionInformationSchema = v.pipe(
-  v.object({
-    positionNumber: v.pipe(
-      v.string('app:position-information.errors.position-number-required'),
-      v.trim(),
-      v.nonEmpty('app:position-information.errors.position-number-required'),
-      v.custom((input) => {
-        const value = input as string;
-        const numbers = value.split(',').map((n) => n.trim());
-        return numbers.every((n) => n.length === 6); // TODO: Need to confirm validation
-      }, 'app:position-information.errors.position-number-max-length'),
-    ),
-    groupAndLevel: v.pipe(
-      v.string('app:position-information.errors.group-and-level-required'),
-      v.trim(),
-      v.nonEmpty('app:position-information.errors.group-and-level-required'),
-    ),
-    titleEn: v.pipe(
-      v.string('app:position-information.errors.title-en-required'),
-      v.trim(),
-      v.nonEmpty('app:position-information.errors.title-en-required'),
-    ),
-    titleFr: v.pipe(
-      v.string('app:position-information.errors.title-fr-required'),
-      v.trim(),
-      v.nonEmpty('app:position-information.errors.title-fr-required'),
-    ),
-    province: v.lazy(() =>
-      v.pipe(
-        stringToIntegerSchema('app:position-information.errors.provinces-required'),
-        v.picklist(
-          allProvinces.map(({ id }) => id),
-          'app:position-information.errors.provinces-required',
+  v.intersect([
+    v.object({
+      positionNumber: v.pipe(
+        v.string('app:position-information.errors.position-number-required'),
+        v.trim(),
+        v.nonEmpty('app:position-information.errors.position-number-required'),
+        v.custom((input) => {
+          const value = input as string;
+          const numbers = value.split(',').map((n) => n.trim());
+          return numbers.every((n) => n.length === 6); // TODO: Need to confirm validation
+        }, 'app:position-information.errors.position-number-max-length'),
+      ),
+      groupAndLevel: v.pipe(
+        v.string('app:position-information.errors.group-and-level-required'),
+        v.trim(),
+        v.nonEmpty('app:position-information.errors.group-and-level-required'),
+      ),
+      titleEn: v.pipe(
+        v.string('app:position-information.errors.title-en-required'),
+        v.trim(),
+        v.nonEmpty('app:position-information.errors.title-en-required'),
+      ),
+      titleFr: v.pipe(
+        v.string('app:position-information.errors.title-fr-required'),
+        v.trim(),
+        v.nonEmpty('app:position-information.errors.title-fr-required'),
+      ),
+      province: v.lazy(() =>
+        v.pipe(
+          stringToIntegerSchema('app:position-information.errors.provinces-required'),
+          v.picklist(
+            allProvinces.map(({ id }) => id),
+            'app:position-information.errors.provinces-required',
+          ),
         ),
       ),
-    ),
-    city: v.lazy(() =>
-      v.pipe(
-        stringToIntegerSchema('app:position-information.errors.city-required'),
-        v.picklist(
-          allCities.map(({ id }) => id),
-          'app:position-information.errors.city-required',
+      city: v.lazy(() =>
+        v.pipe(
+          stringToIntegerSchema('app:position-information.errors.city-required'),
+          v.picklist(
+            allCities.map(({ id }) => id),
+            'app:position-information.errors.city-required',
+          ),
         ),
       ),
+      securityRequirement: v.pipe(
+        v.string('app:position-information.errors.security-requirement-required'),
+        v.trim(),
+        v.nonEmpty('app:position-information.errors.security-requirement-required'),
+      ),
+    }),
+    v.variant(
+      'languageRequirement',
+      [
+        v.object({
+          languageRequirement: v.pipe(
+            stringToIntegerSchema(),
+            v.picklist(selectedLanguageRequirementForOptionalLanguageLevel.map(({ id }) => id)),
+          ),
+          readingEn: v.optional(v.string()),
+          readingFr: v.optional(v.string()),
+          writingEn: v.optional(v.string()),
+          writingFr: v.optional(v.string()),
+          oralEn: v.optional(v.string()),
+          oralFr: v.optional(v.string()),
+        }),
+        v.object({
+          languageRequirement: v.pipe(
+            stringToIntegerSchema(),
+            v.picklist(selectedLanguageRequirementForRequiredLanguageLevel.map(({ id }) => id)),
+          ),
+          readingEn: v.pipe(
+            v.pipe(v.string('app:position-information.errors.language-profile.reading-comprehension-required'), v.trim()),
+          ),
+          readingFr: v.pipe(
+            v.pipe(v.string('app:position-information.errors.language-profile.reading-comprehension-required'), v.trim()),
+          ),
+          writingEn: v.pipe(
+            v.pipe(v.string('app:position-information.errors.language-profile.written-expression-required'), v.trim()),
+          ),
+          writingFr: v.pipe(
+            v.pipe(v.string('app:position-information.errors.language-profile.written-expression-required'), v.trim()),
+          ),
+          oralEn: v.pipe(
+            v.pipe(v.string('app:position-information.errors.language-profile.oral-proficiency-required'), v.trim()),
+          ),
+          oralFr: v.pipe(
+            v.pipe(v.string('app:position-information.errors.language-profile.oral-proficiency-required'), v.trim()),
+          ),
+        }),
+      ],
+      'app:position-information.errors.language-requirement-required',
     ),
-    languageRequirement: v.pipe(
-      v.string('app:position-information.errors.language-requirement-required'),
-      v.trim(),
-      v.nonEmpty('app:position-information.errors.language-requirement-required'),
-    ),
-    readingEn: v.pipe(
-      v.pipe(v.string('app:position-information.errors.language-profile.reading-comprehension-required'), v.trim()),
-    ),
-    readingFr: v.pipe(
-      v.pipe(v.string('app:position-information.errors.language-profile.reading-comprehension-required'), v.trim()),
-    ),
-    writingEn: v.pipe(
-      v.pipe(v.string('app:position-information.errors.language-profile.written-expression-required'), v.trim()),
-    ),
-    writingFr: v.pipe(
-      v.pipe(v.string('app:position-information.errors.language-profile.written-expression-required'), v.trim()),
-    ),
-    oralEn: v.pipe(v.pipe(v.string('app:position-information.errors.language-profile.oral-proficiency-required'), v.trim())),
-    oralFr: v.pipe(v.pipe(v.string('app:position-information.errors.language-profile.oral-proficiency-required'), v.trim())),
-    securityRequirement: v.pipe(
-      v.string('app:position-information.errors.security-requirement-required'),
-      v.trim(),
-      v.nonEmpty('app:position-information.errors.security-requirement-required'),
-    ),
-  }),
+  ]),
 );
 
 export const somcConditionsSchema = v.pipe(


### PR DESCRIPTION
## Summary

[AB#6887](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6887/)
[AB#6888](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6888)
Copied the position information screen from hiring manager to hr advisor route. Fixed some layout and validations, as the form didn't save when any "Language Requirement" option was selected that doesn't require the language profile.

##Additional information
To test: visit the route /hr-advisor/request/1/position-information

## Types of changes

What types of changes does this PR introduce?

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] ✨ **new feature** -- non-breaking change that adds functionality

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.

- [x] code has been linted and formatted locally

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>


## Screenshots (if applicable)

<img width="506" height="929" alt="image" src="https://github.com/user-attachments/assets/4272b839-5e97-4e9f-b245-4d331926ae05" />

On selecting Bilingual Imperative or Bilingual Non-imperative, Language profile (required) is displayed:
<img width="271" height="805" alt="image" src="https://github.com/user-attachments/assets/01ffeff8-dcc1-4f6f-8fbe-55aaab6a5743" />
When any option was selected from Language requirements other than the above two, the form wasn't Save and user stayed on the same, no error was shown either, so fixed that by updating the validation to accommodate the required and optional "Language profile" scenarios
<img width="522" height="799" alt="image" src="https://github.com/user-attachments/assets/e5900cee-7088-49b0-8d77-fc36b36a5931" />

