### PR TITLE
refactor(frontend) componentize requests tables

### DIFF
--- a/frontend/app/.server/locales/app-en.ts
+++ b/frontend/app/.server/locales/app-en.ts
@@ -276,6 +276,20 @@ export default {
   },
   'hiring-manager-requests': {
     'page-title': 'Requests',
+    'back': 'Back to request details',
+  },
+  'somc-conditions': {
+    'page-title': 'Statement of merit criteria and conditions of employment',
+    'english-somc-label': 'English statement of merit criteria of employment',
+    'english-somc-help-message': 'Please enter the full English criteria here',
+    'french-somc-label': 'French statement of merit criteria of employment',
+    'french-somc-help-message': 'Please enter the full French criteria here',
+    'errors': {
+      'english-somc-required': 'English statement of merit criteria is required',
+      'french-somc-required': 'French statement of merit criteria is required',
+    },
+  },
+  'requests-tables': {
     'create-request': 'Create request',
     'active-requests': 'Active requests',
     'no-active-requests': "You don't have any active requests at the moment.",
@@ -290,16 +304,5 @@ export default {
     'view': 'View',
     'view-link': 'View request with ID {{requestId}}',
     'next-page': 'Next',
-  },
-  'somc-conditions': {
-    'page-title': 'Statement of merit criteria and conditions of employment',
-    'english-somc-label': 'English statement of merit criteria of employment',
-    'english-somc-help-message': 'Please enter the full English criteria here',
-    'french-somc-label': 'French statement of merit criteria of employment',
-    'french-somc-help-message': 'Please enter the full French criteria here',
-    'errors': {
-      'english-somc-required': 'English statement of merit criteria is required',
-      'french-somc-required': 'French statement of merit criteria is required',
-    },
   },
 };

--- a/frontend/app/.server/locales/app-fr.ts
+++ b/frontend/app/.server/locales/app-fr.ts
@@ -279,6 +279,20 @@ export default {
   },
   'hiring-manager-requests': {
     'page-title': 'Demandes',
+    'back': "Retour à l'information sur la demande",
+  },
+  'somc-conditions': {
+    'page-title': "Énoncé de critères de mérite et conditions d'emploi",
+    'english-somc-label': "Énoncé de critères de mérite et conditions d'emploi - Anglais",
+    'english-somc-help-message': "Veuillez saisir l'intégralité des critères en anglais",
+    'french-somc-label': "Énoncé de critères de mérite et conditions d'emploi - Français",
+    'french-somc-help-message': "Veuillez saisir l'intégralité des critères en français",
+    'errors': {
+      'english-somc-required': '(FR) English statement of merit criteria is required',
+      'french-somc-required': '(FR) French statement of merit criteria is required',
+    },
+  },
+  'requests-tables': {
     'create-request': 'Créer une demande',
     'active-requests': 'Demandes actives',
     'no-active-requests': "Vous n'avez aucune demande active pour le moment.",
@@ -293,16 +307,5 @@ export default {
     'view': 'Affiché',
     'view-link': "Afficher la demande avec l'identifiant {{requestId}}",
     'next-page': 'Suivant',
-  },
-  'somc-conditions': {
-    'page-title': "Énoncé de critères de mérite et conditions d'emploi",
-    'english-somc-label': "Énoncé de critères de mérite et conditions d'emploi - Anglais",
-    'english-somc-help-message': "Veuillez saisir l'intégralité des critères en anglais",
-    'french-somc-label': "Énoncé de critères de mérite et conditions d'emploi - Français",
-    'french-somc-help-message': "Veuillez saisir l'intégralité des critères en français",
-    'errors': {
-      'english-somc-required': '(FR) English statement of merit criteria is required',
-      'french-somc-required': '(FR) French statement of merit criteria is required',
-    },
   },
 } satisfies typeof appEn;

--- a/frontend/app/routes/hiring-manager/requests.tsx
+++ b/frontend/app/routes/hiring-manager/requests.tsx
@@ -1,29 +1,19 @@
-import { useEffect, useMemo, useState } from 'react';
-import type { JSX } from 'react';
-
-import { useFetcher } from 'react-router';
 import type { RouteHandle } from 'react-router';
 
-import type { ColumnDef } from '@tanstack/react-table';
 import { useTranslation } from 'react-i18next';
 
+import RequestsTables from '../page-components/requests/tables/requests-tables';
 import type { Route } from './+types/requests';
 
-import type { LocalizedLookupModel, LookupModel, RequestReadModel, RequestStatus } from '~/.server/domain/models';
 import { getRequestService } from '~/.server/domain/services/request-service';
 import { getRequestStatusService } from '~/.server/domain/services/request-status-service';
 import { serverEnvironment } from '~/.server/environment';
 import { requireAuthentication } from '~/.server/utils/auth-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
-import { DataTable, DataTableColumnHeader, DataTableColumnHeaderWithOptions } from '~/components/data-table';
-import { InlineLink } from '~/components/links';
-import { LoadingButton } from '~/components/loading-button';
 import { PageTitle } from '~/components/page-title';
 import { REQUEST_CATEGORY, REQUEST_STATUSES } from '~/domain/constants';
-import { useFetcherState } from '~/hooks/use-fetcher-state';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/layout';
-import { formatDateTimeInZone } from '~/utils/date-utils';
 
 export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace],
@@ -80,136 +70,12 @@ export async function loader({ context, request }: Route.LoaderArgs) {
 }
 
 export default function HiringManagerRequests({ loaderData, params }: Route.ComponentProps) {
-  const fetcher = useFetcher();
-  const fetcherState = useFetcherState(fetcher);
-  const isSubmitting = fetcherState.submitting;
   const { t } = useTranslation(handle.i18nNamespace);
-
-  const [browserTZ, setBrowserTZ] = useState<string | null>(null);
-
-  useEffect(() => {
-    setBrowserTZ(Intl.DateTimeFormat().resolvedOptions().timeZone);
-  }, []);
-
-  const formatDateYMD = useMemo(
-    () => (iso?: string) =>
-      iso ? formatDateTimeInZone(iso, browserTZ ?? loaderData.baseTimeZone, 'yyyy-MM-dd') : '0000-00-00',
-    [browserTZ, loaderData.baseTimeZone],
-  );
-
-  function createColumns(
-    isActive: boolean,
-  ): ColumnDef<RequestReadModel & { classification?: LookupModel; requestStatus?: LocalizedLookupModel }>[] {
-    return [
-      {
-        accessorKey: 'id',
-        header: ({ column }) => <DataTableColumnHeader column={column} title={t('app:hiring-manager-requests.requestId')} />,
-        cell: (info) => <p>{info.getValue() as string}</p>,
-      },
-      {
-        accessorKey: 'classification.id',
-        header: ({ column }) => (
-          <DataTableColumnHeader column={column} title={t('app:hiring-manager-requests.classification')} />
-        ),
-        cell: (info) => <p>{info.row.original.classification?.code}</p>,
-      },
-      {
-        accessorKey: 'dateUpdated',
-        header: ({ column }) => <DataTableColumnHeader column={column} title={t('app:hiring-manager-requests.updated')} />,
-        cell: (info) => {
-          const lastModifiedDate = info.row.original.lastModifiedDate;
-          const userUpdated = info.row.original.lastModifiedBy ?? 'Unknown User';
-          const dateUpdated = formatDateYMD(lastModifiedDate);
-          return <p className="text-neutral-600">{`${dateUpdated}: ${userUpdated}`}</p>;
-        },
-      },
-      {
-        accessorKey: 'requestStatus.id',
-        accessorFn: (row) => row.requestStatus?.name,
-        header: ({ column }) => (
-          <DataTableColumnHeaderWithOptions
-            column={column}
-            title={t('app:hiring-manager-requests.status')}
-            options={isActive ? loaderData.activeRequestNames : loaderData.inactiveRequestNames}
-          />
-        ),
-        cell: (info) => {
-          const status = info.row.original.status;
-          return status && statusTag(status, loaderData.lang);
-        },
-        filterFn: (row, columnId, filterValue: string[]) => {
-          const status = row.getValue(columnId) as string;
-          return filterValue.length === 0 || filterValue.includes(status);
-        },
-        enableColumnFilter: true,
-      },
-      {
-        header: t('app:hiring-manager-requests.action'),
-        id: 'action',
-        cell: (info) => {
-          const requestId = info.row.original.id.toString();
-          return (
-            <InlineLink
-              className="text-sky-800 no-underline decoration-slate-400 decoration-2 hover:underline"
-              file="routes/hiring-manager/request/index.tsx"
-              params={{ requestId }}
-              aria-label={t('app:hiring-manager-requests.view-link', {
-                requestId,
-              })}
-            >
-              {t('app:hiring-manager-requests.view')}
-            </InlineLink>
-          );
-        },
-      },
-    ];
-  }
 
   return (
     <div className="mb-8 space-y-4">
       <PageTitle className="after:w-14">{t('app:hiring-manager-requests.page-title')}</PageTitle>
-
-      <fetcher.Form method="post" noValidate className="mb-8">
-        <LoadingButton name="action" variant="primary" size="sm" disabled={isSubmitting} loading={isSubmitting}>
-          {t('app:hiring-manager-requests.create-request')}
-        </LoadingButton>
-      </fetcher.Form>
-
-      <section className="mb-8">
-        <h2 className="font-lato text-xl font-bold">{t('app:hiring-manager-requests.active-requests')}</h2>
-        {loaderData.activeRequests.length === 0 ? (
-          <div>{t('app:hiring-manager-requests.no-active-requests')}</div>
-        ) : (
-          <DataTable columns={createColumns(true)} data={loaderData.activeRequests} />
-        )}
-      </section>
-
-      <section>
-        <h2 className="font-lato text-xl font-bold">{t('app:hiring-manager-requests.archived-requests')}</h2>
-        {loaderData.archivedRequests.length === 0 ? (
-          <div>{t('app:hiring-manager-requests.no-archived-requests')}</div>
-        ) : (
-          <DataTable columns={createColumns(false)} data={loaderData.archivedRequests} />
-        )}
-      </section>
-    </div>
-  );
-}
-
-function statusTag(status: RequestStatus, lang: Language): JSX.Element {
-  const styleMap: Record<string, string> = {
-    SUBMIT: 'bg-sky-100 text-sky-700',
-    HR_REVIEW: 'bg-sky-100 text-sky-700',
-    FDBK_PEND_APPR: 'bg-sky-100 text-sky-700',
-    PENDING_PSC: 'bg-sky-100 text-sky-700',
-    DRAFT: 'bg-amber-100 text-yellow-900',
-    FDBK_PENDING: 'bg-amber-100 text-yellow-900',
-    DEFAULT: 'bg-transparent',
-  };
-  const style = styleMap[status.code] ?? styleMap.DEFAULT;
-  return (
-    <div className={`${style} flex w-fit items-center gap-2 rounded-md px-3 py-1 text-sm font-semibold`}>
-      <p>{lang === 'en' ? status.nameEn : status.nameFr}</p>
+      <RequestsTables {...loaderData} />
     </div>
   );
 }

--- a/frontend/app/routes/page-components/requests/tables/requests-tables.tsx
+++ b/frontend/app/routes/page-components/requests/tables/requests-tables.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { JSX } from 'react';
+
+import { useFetcher } from 'react-router';
+
+import type { ColumnDef } from '@tanstack/react-table';
+import { useTranslation } from 'react-i18next';
+
+import type { LocalizedLookupModel, LookupModel, RequestReadModel, RequestStatus } from '~/.server/domain/models';
+import { DataTable, DataTableColumnHeader, DataTableColumnHeaderWithOptions } from '~/components/data-table';
+import { InlineLink } from '~/components/links';
+import { LoadingButton } from '~/components/loading-button';
+import { useFetcherState } from '~/hooks/use-fetcher-state';
+import { formatDateTimeInZone } from '~/utils/date-utils';
+
+interface RequestTablesProps {
+  activeRequests: RequestReadModel[];
+  archivedRequests: RequestReadModel[];
+  activeRequestNames: string[];
+  inactiveRequestNames: string[];
+  baseTimeZone: string;
+  lang: Language;
+}
+
+export default function RequestsTables({
+  activeRequests,
+  archivedRequests,
+  activeRequestNames,
+  inactiveRequestNames,
+  baseTimeZone,
+  lang,
+}: RequestTablesProps): JSX.Element {
+  const fetcher = useFetcher();
+  const fetcherState = useFetcherState(fetcher);
+  const isSubmitting = fetcherState.submitting;
+  const { t } = useTranslation('app');
+
+  const [browserTZ, setBrowserTZ] = useState<string | null>(null);
+
+  useEffect(() => {
+    setBrowserTZ(Intl.DateTimeFormat().resolvedOptions().timeZone);
+  }, []);
+
+  const formatDateYMD = useMemo(
+    () => (iso?: string) => (iso ? formatDateTimeInZone(iso, browserTZ ?? baseTimeZone, 'yyyy-MM-dd') : '0000-00-00'),
+    [browserTZ, baseTimeZone],
+  );
+
+  function createColumns(
+    isActive: boolean,
+  ): ColumnDef<RequestReadModel & { classification?: LookupModel; requestStatus?: LocalizedLookupModel }>[] {
+    return [
+      {
+        accessorKey: 'id',
+        header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests-tables.requestId')} />,
+        cell: (info) => <p>{info.getValue() as string}</p>,
+      },
+      {
+        accessorKey: 'classification.id',
+        header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests-tables.classification')} />,
+        cell: (info) => <p>{info.row.original.classification?.code}</p>,
+      },
+      {
+        accessorKey: 'dateUpdated',
+        header: ({ column }) => <DataTableColumnHeader column={column} title={t('requests-tables.updated')} />,
+        cell: (info) => {
+          const lastModifiedDate = info.row.original.lastModifiedDate;
+          const userUpdated = info.row.original.lastModifiedBy ?? 'Unknown User';
+          const dateUpdated = formatDateYMD(lastModifiedDate);
+          return <p className="text-neutral-600">{`${dateUpdated}: ${userUpdated}`}</p>;
+        },
+      },
+      {
+        accessorKey: 'requestStatus.id',
+        accessorFn: (row) => row.requestStatus?.name,
+        header: ({ column }) => (
+          <DataTableColumnHeaderWithOptions
+            column={column}
+            title={t('requests-tables.status')}
+            options={isActive ? activeRequestNames : inactiveRequestNames}
+          />
+        ),
+        cell: (info) => {
+          const status = info.row.original.status;
+          return status && statusTag(status, lang);
+        },
+        filterFn: (row, columnId, filterValue: string[]) => {
+          const status = row.getValue(columnId) as string;
+          return filterValue.length === 0 || filterValue.includes(status);
+        },
+        enableColumnFilter: true,
+      },
+      {
+        header: t('requests-tables.action'),
+        id: 'action',
+        cell: (info) => {
+          const requestId = info.row.original.id.toString();
+          return (
+            <InlineLink
+              className="text-sky-800 no-underline decoration-slate-400 decoration-2 hover:underline"
+              file="routes/hiring-manager/request/index.tsx"
+              params={{ requestId }}
+              aria-label={t('requests-tables.view-link', {
+                requestId,
+              })}
+            >
+              {t('requests-tables.view')}
+            </InlineLink>
+          );
+        },
+      },
+    ];
+  }
+
+  return (
+    <div className="mb-8 space-y-4">
+      <fetcher.Form method="post" noValidate className="mb-8">
+        <LoadingButton name="action" variant="primary" size="sm" disabled={isSubmitting} loading={isSubmitting}>
+          {t('requests-tables.create-request')}
+        </LoadingButton>
+      </fetcher.Form>
+
+      <section className="mb-8">
+        <h2 className="font-lato text-xl font-bold">{t('requests-tables.active-requests')}</h2>
+        {activeRequests.length === 0 ? (
+          <div>{t('requests-tables.no-active-requests')}</div>
+        ) : (
+          <DataTable columns={createColumns(true)} data={activeRequests} />
+        )}
+      </section>
+
+      <section>
+        <h2 className="font-lato text-xl font-bold">{t('requests-tables.archived-requests')}</h2>
+        {archivedRequests.length === 0 ? (
+          <div>{t('requests-tables.no-archived-requests')}</div>
+        ) : (
+          <DataTable columns={createColumns(false)} data={archivedRequests} />
+        )}
+      </section>
+    </div>
+  );
+}
+
+function statusTag(status: RequestStatus, lang: Language): JSX.Element {
+  const styleMap: Record<string, string> = {
+    SUBMIT: 'bg-sky-100 text-sky-700',
+    HR_REVIEW: 'bg-sky-100 text-sky-700',
+    FDBK_PEND_APPR: 'bg-sky-100 text-sky-700',
+    PENDING_PSC: 'bg-sky-100 text-sky-700',
+    DRAFT: 'bg-amber-100 text-yellow-900',
+    FDBK_PENDING: 'bg-amber-100 text-yellow-900',
+    DEFAULT: 'bg-transparent',
+  };
+  const style = styleMap[status.code] ?? styleMap.DEFAULT;
+  return (
+    <div className={`${style} flex w-fit items-center gap-2 rounded-md px-3 py-1 text-sm font-semibold`}>
+      <p>{lang === 'en' ? status.nameEn : status.nameFr}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Since the active/inactive requests tables will be used in multiple routes (hr-advisor + hiring-manager), they are are candidate for compentizing.  This PR does exactly that and a future PR will add this component to `/hr-advisor/requests`.
