### PR TITLE
refactor(frontend) request/process-information

### DIFF
--- a/frontend/app/routes/hiring-manager/request/process-information.tsx
+++ b/frontend/app/routes/hiring-manager/request/process-information.tsx
@@ -1,5 +1,7 @@
 import type { RouteHandle } from 'react-router';
 
+import { useTranslation } from 'react-i18next';
+
 import type { Route } from './+types/process-information';
 
 import type { RequestReadModel } from '~/.server/domain/models';
@@ -76,11 +78,19 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 }
 
 export default function HiringManagerRequestProcessInformation({ loaderData, actionData, params }: Route.ComponentProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
   const errors = undefined; //actionData?.errors;
 
   return (
     <>
-      <BackLink className="mt-6" file="routes/hiring-manager/request/index.tsx" params={params} />
+      <BackLink
+        className="mt-6"
+        file="routes/hiring-manager/request/index.tsx"
+        params={params}
+        aria-label={t('app:hiring-manager-requests.back')}
+      >
+        {t('app:hiring-manager-requests.back')}
+      </BackLink>
       <div className="max-w-prose">
         <ProcessInformationForm
           selectionProcessTypes={loaderData.localizedSelectionProcessTypesResult}

--- a/frontend/app/routes/hr-advisor/request/process-information.tsx
+++ b/frontend/app/routes/hr-advisor/request/process-information.tsx
@@ -1,3 +1,110 @@
+import type { RouteHandle } from 'react-router';
+
+import { useTranslation } from 'react-i18next';
+
 import type { Route } from './+types/process-information';
 
-export default function HiringManagerRequestProcessInformation({ loaderData, actionData, params }: Route.ComponentProps) {}
+import type { RequestReadModel } from '~/.server/domain/models';
+import { getEmploymentEquityService } from '~/.server/domain/services/employment-equity-service';
+import { getEmploymentTenureService } from '~/.server/domain/services/employment-tenure-service';
+import { getNonAdvertisedAppointmentService } from '~/.server/domain/services/non-advertised-appointment-service';
+import { getRequestService } from '~/.server/domain/services/request-service';
+import { getSelectionProcessTypeService } from '~/.server/domain/services/selection-process-type-service';
+import { getWorkScheduleService } from '~/.server/domain/services/work-schedule-service';
+import { requireAuthentication } from '~/.server/utils/auth-utils';
+import { BackLink } from '~/components/back-link';
+import { HttpStatusCodes } from '~/errors/http-status-codes';
+import { getTranslation } from '~/i18n-config.server';
+import { handle as parentHandle } from '~/routes/layout';
+import { ProcessInformationForm } from '~/routes/page-components/requests/process-information/form';
+
+export const handle = {
+  i18nNamespace: [...parentHandle.i18nNamespace],
+} as const satisfies RouteHandle;
+
+export function meta({ loaderData }: Route.MetaArgs) {
+  return [{ title: loaderData.documentTitle }];
+}
+
+export async function action({ context, params, request }: Route.ActionArgs) {
+  //TODO: add action and validation logic
+}
+
+export async function loader({ context, request, params }: Route.LoaderArgs) {
+  requireAuthentication(context.session, request);
+
+  const requestResult = await getRequestService().getRequestById(
+    Number(params.requestId),
+    context.session.authState.accessToken,
+  );
+
+  if (requestResult.isErr()) {
+    throw new Response('Request not found', { status: HttpStatusCodes.NOT_FOUND });
+  }
+
+  const requestData: RequestReadModel = requestResult.unwrap();
+
+  const { lang, t } = await getTranslation(request, handle.i18nNamespace);
+
+  const localizedSelectionProcessTypesResult = await getSelectionProcessTypeService().listAllLocalized(lang);
+  const localizedNonAdvertisedAppointmentsResult = await getNonAdvertisedAppointmentService().listAllLocalized(lang);
+  const localizedEmploymentTenures = await getEmploymentTenureService().listAllLocalized(lang);
+  const localizedWorkSchedules = await getWorkScheduleService().listAllLocalized(lang);
+  const localizedEmploymentEquities = await getEmploymentEquityService().listAllLocalized(lang);
+
+  return {
+    documentTitle: t('app:process-information.page-title'),
+    defaultValues: {
+      selectionProcessNumber: requestData.selectionProcessNumber,
+      approvalReceived: requestData.workforceMgmtApprovalRecvd,
+      priorityEntitlement: requestData.priorityEntitlement,
+      priorityEntitlementRationale: requestData.priorityEntitlementRationale,
+      preferredSelectionProcessType: requestData.selectionProcessType,
+      performedDuties: requestData.hasPerformedSameDuties,
+      nonAdvertisedAppointment: requestData.appointmentNonAdvertised,
+      employmentTenure: requestData.employmentTenure,
+      projectedStartDate: requestData.projectedStartDate,
+      projectedEndDate: requestData.projectedEndDate,
+      workSchedule: requestData.workSchedule,
+      employmentEquityIdentified: requestData.equityNeeded,
+      preferredEmploymentEquities: requestData.employmentEquities,
+    },
+    localizedSelectionProcessTypesResult,
+    localizedNonAdvertisedAppointmentsResult,
+    localizedEmploymentTenures,
+    localizedWorkSchedules,
+    localizedEmploymentEquities,
+  };
+}
+
+export default function HrAdvisorRequestProcessInformation({ loaderData, actionData, params }: Route.ComponentProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
+  const errors = undefined; //actionData?.errors;
+
+  return (
+    <>
+      <BackLink
+        className="mt-6"
+        file="routes/hr-advisor/request/index.tsx"
+        params={params}
+        aria-label={t('app:hr-advisor-requests.back')}
+      >
+        {t('app:hr-advisor-requests.back')}
+      </BackLink>
+      <div className="max-w-prose">
+        <ProcessInformationForm
+          selectionProcessTypes={loaderData.localizedSelectionProcessTypesResult}
+          nonAdvertisedAppointments={loaderData.localizedNonAdvertisedAppointmentsResult}
+          employmentTenures={loaderData.localizedEmploymentTenures}
+          workSchedules={loaderData.localizedWorkSchedules}
+          employmentEquities={loaderData.localizedEmploymentEquities}
+          cancelLink={'routes/hr-advisor/request/index.tsx'}
+          formErrors={errors}
+          formValues={loaderData.defaultValues}
+          isReadOnly={false}
+          params={params}
+        />
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/page-components/requests/process-information/form.tsx
+++ b/frontend/app/routes/page-components/requests/process-information/form.tsx
@@ -177,7 +177,9 @@ export function ProcessInformationForm({
 
   return (
     <>
-      <PageTitle className="after:w-14">{tApp('process-information.page-title')}</PageTitle>
+      <PageTitle className="after:w-14" subTitle={tApp('referral-request')}>
+        {tApp('process-information.page-title')}
+      </PageTitle>
       <FormErrorSummary>
         <Form method="post" noValidate>
           <div className="space-y-6">


### PR DESCRIPTION
## Summary

Adds content/loader for `request/process-information`.  The action still needs to be implemented for both hr-advisor/hiring-manager.

