### PR TITLE
refator(frontend) add containerClassName prop to PageTitle

### DIFF
--- a/frontend/app/components/page-title.tsx
+++ b/frontend/app/components/page-title.tsx
@@ -5,11 +5,12 @@ import { cn } from '~/utils/tailwind-utils';
 export type PageTitleProps = Omit<ComponentProps<'h1'>, 'id' | 'property'> & {
   subTitle?: string;
   subTitleClassName?: string;
+  containerClassName?: string;
 };
 
-export function PageTitle({ children, className, subTitle, subTitleClassName, ...props }: PageTitleProps) {
+export function PageTitle({ children, className, subTitle, subTitleClassName, containerClassName, ...props }: PageTitleProps) {
   return (
-    <div className="mt-10 mb-8">
+    <div className={cn('mt-10 mb-8', containerClassName)}>
       {subTitle && <h2 className={subTitleClassName}>{subTitle}</h2>}
       <h1 id="wb-cont" tabIndex={-1} className={cn('font-lato text-3xl font-bold focus-visible:ring-3', className)} {...props}>
         {children}

--- a/frontend/app/routes/employee/profile/index.tsx
+++ b/frontend/app/routes/employee/profile/index.tsx
@@ -26,6 +26,7 @@ import { AlertMessage } from '~/components/alert-message';
 import { ButtonLink } from '~/components/button-link';
 import { DescriptionList, DescriptionListItem } from '~/components/description-list';
 import { LoadingButton } from '~/components/loading-button';
+import { PageTitle } from '~/components/page-title';
 import { ProfileCard } from '~/components/profile-card';
 import { Progress } from '~/components/progress';
 import { StatusTag } from '~/components/status-tag';
@@ -337,16 +338,16 @@ export default function EditProfile({ loaderData, params }: Route.ComponentProps
                 : loaderData.profileStatus.name,
           }}
         />
-        <h1 id="wb-cont" tabIndex={-1} className="mt-6 text-3xl font-semibold">
+        <PageTitle className="after:w-14" containerClassName="my-6">
           {loaderData.name}
-        </h1>
+        </PageTitle>
         {loaderData.email && <p className="mt-1">{loaderData.email}</p>}
         <p className="font-normal text-[#9FA3AD]">
           {t('app:profile.last-updated', { date: browserTZ, name: loaderData.lastUpdatedBy })}
         </p>
         <div
           role="presentation"
-          className="absolute top-25 left-0 -z-10 h-60 w-full scale-x-[-1] bg-[rgba(9,28,45,1)] bg-[url('/VacMan-design-element-06.svg')] bg-size-[450px] bg-left-bottom bg-no-repeat"
+          className="absolute top-25 left-0 -z-10 h-70 w-full scale-x-[-1] bg-[rgba(9,28,45,1)] bg-[url('/VacMan-design-element-06.svg')] bg-size-[450px] bg-left-bottom bg-no-repeat sm:h-60"
         />
       </div>
       <div className="justify-between md:grid md:grid-cols-2">

--- a/frontend/app/routes/hr-advisor/employee-profile/index.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/index.tsx
@@ -23,6 +23,7 @@ import { AlertMessage } from '~/components/alert-message';
 import { DescriptionList, DescriptionListItem } from '~/components/description-list';
 import { InlineLink } from '~/components/links';
 import { LoadingButton } from '~/components/loading-button';
+import { PageTitle } from '~/components/page-title';
 import { ProfileCard } from '~/components/profile-card';
 import { StatusTag } from '~/components/status-tag';
 import { EMPLOYEE_WFA_STATUS, PROFILE_STATUS_APPROVED } from '~/domain/constants';
@@ -215,16 +216,16 @@ export default function EditProfile({ loaderData, params }: Route.ComponentProps
         {loaderData.profileStatus && (
           <StatusTag status={{ code: loaderData.profileStatus.code, name: loaderData.profileStatus.name }} />
         )}
-        <h1 id="wb-cont" tabIndex={-1} className="mt-6 text-3xl font-semibold">
+        <PageTitle className="after:w-14" containerClassName="my-6">
           {loaderData.name}
-        </h1>
+        </PageTitle>
         {loaderData.email && <p className="mt-1">{loaderData.email}</p>}
         <p className="font-normal text-[#9FA3AD]">
           {t('app:profile.last-updated', { date: browserTZ, name: loaderData.lastUpdatedBy })}
         </p>
         <div
           role="presentation"
-          className="absolute top-25 left-0 -z-10 h-60 w-full scale-x-[-1] bg-[rgba(9,28,45,1)] bg-[url('/VacMan-design-element-06.svg')] bg-size-[450px] bg-left-bottom bg-no-repeat"
+          className="absolute top-25 left-0 -z-10 h-70 w-full scale-x-[-1] bg-[rgba(9,28,45,1)] bg-[url('/VacMan-design-element-06.svg')] bg-size-[450px] bg-left-bottom bg-no-repeat sm:h-60"
         />
       </div>
       <div className="justify-between md:grid md:grid-cols-2">


### PR DESCRIPTION
## Summary

The idiomatic vacman way to add an `h1` heading to the page is via the `PageTitle` component.  The only problem with this approach is that the container `div` has default styles on it which we sometimes might want to override.  No matter...we can just throw on an additional prop for that.

There's also some weird text overflow for the timestamp when the viewport is scaled to a mobile device.  Adding additional responsiveness to the decorative banner for that..
