### PR TITLE
request submission screen on hiring manager

### DIFF
--- a/frontend/app/routes/hiring-manager/request/submission-details.tsx
+++ b/frontend/app/routes/hiring-manager/request/submission-details.tsx
@@ -1,3 +1,109 @@
+import { data } from 'react-router';
+import type { RouteHandle } from 'react-router';
+
+import { useTranslation } from 'react-i18next';
+import * as v from 'valibot';
+
 import type { Route } from './+types/submission-details';
 
-export default function HiringManagerRequestSubmissionDetails({ loaderData, params }: Route.ComponentProps) {}
+import { getDirectorateService } from '~/.server/domain/services/directorate-service';
+import { getLanguageForCorrespondenceService } from '~/.server/domain/services/language-for-correspondence-service';
+import { requireAuthentication } from '~/.server/utils/auth-utils';
+import { extractUniqueBranchesFromDirectorates } from '~/.server/utils/directorate-utils';
+import { i18nRedirect } from '~/.server/utils/route-utils';
+import { BackLink } from '~/components/back-link';
+import { HttpStatusCodes } from '~/errors/http-status-codes';
+import { getTranslation } from '~/i18n-config.server';
+import { handle as parentHandle } from '~/routes/layout';
+import { SubmissionDetailsForm } from '~/routes/page-components/requests/submission-detail/form';
+import { submissionDetailSchema } from '~/routes/page-components/requests/validation.server';
+import { formString } from '~/utils/string-utils';
+
+export const handle = {
+  i18nNamespace: [...parentHandle.i18nNamespace],
+} as const satisfies RouteHandle;
+
+export function meta({ loaderData }: Route.MetaArgs) {
+  return [{ title: loaderData.documentTitle }];
+}
+
+export async function action({ context, params, request }: Route.ActionArgs) {
+  requireAuthentication(context.session, request);
+
+  const formData = await request.formData();
+  const parseResult = v.safeParse(submissionDetailSchema, {
+    branchOrServiceCanadaRegion: formString(formData.get('branchOrServiceCanadaRegion')),
+    directorate: formString(formData.get('directorate')),
+    languageOfCorrespondenceId: formString(formData.get('languageOfCorrespondenceId')),
+    additionalComment: formString(formData.get('additionalComment')),
+  });
+
+  if (!parseResult.success) {
+    return data(
+      { errors: v.flatten<typeof submissionDetailSchema>(parseResult.issues).nested },
+      { status: HttpStatusCodes.BAD_REQUEST },
+    );
+  }
+
+  //TODO: call request service to update data
+
+  return i18nRedirect('routes/hiring-manager/request/index.tsx', request, { params });
+}
+
+export async function loader({ context, params, request }: Route.LoaderArgs) {
+  requireAuthentication(context.session, request);
+
+  //TODO: call request service to get default values
+
+  const { lang, t } = await getTranslation(request, handle.i18nNamespace);
+
+  const directorates = await getDirectorateService().listAllLocalized(lang);
+  // Extract unique branches from directorates that have parents
+  const branchOrServiceCanadaRegions = extractUniqueBranchesFromDirectorates(directorates);
+  const languagesOfCorrespondence = await getLanguageForCorrespondenceService().listAllLocalized(lang);
+
+  return {
+    documentTitle: t('app:submission-details.page-title'),
+    defaultValues: {
+      submitter: undefined,
+      hiringManager: undefined,
+      subDelegatedManager: undefined,
+      hrAdvisor: undefined,
+      workUnit: undefined,
+      languageOfCorrespondence: undefined,
+      additionalComment: undefined,
+    },
+    branchOrServiceCanadaRegions,
+    directorates,
+    languagesOfCorrespondence,
+  };
+}
+
+export default function HiringManagerRequestSubmissionDetails({ loaderData, actionData, params }: Route.ComponentProps) {
+  const { t } = useTranslation(handle.i18nNamespace);
+  const errors = actionData?.errors;
+
+  return (
+    <>
+      <BackLink
+        className="mt-6"
+        file="routes/hiring-manager/request/index.tsx"
+        params={params}
+        aria-label={t('app:hiring-manager-requests.back')}
+      >
+        {t('app:hiring-manager-requests.back')}
+      </BackLink>
+      <div className="max-w-prose">
+        <SubmissionDetailsForm
+          cancelLink="routes/hiring-manager/request/index.tsx"
+          formErrors={errors}
+          formValues={loaderData.defaultValues}
+          branchOrServiceCanadaRegions={loaderData.branchOrServiceCanadaRegions}
+          directorates={loaderData.directorates}
+          languagesOfCorrespondence={loaderData.languagesOfCorrespondence}
+          params={params}
+        />
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

[AB#6736](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6736/)
Following up the same pattern as done for hr advisor route in this [pr695](https://github.com/DTS-STN/vacman/pull/695)
To validate navigate to: /hiring-manager/request/1/submission-details
New fields will be added in next prs

## Types of changes

What types of changes does this PR introduce?

- [x] ✨ **new feature** -- non-breaking change that adds functionality

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.

- [x] code has been linted and formatted locally

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

<img width="526" height="671" alt="image" src="https://github.com/user-attachments/assets/bb05b26e-c8e4-4228-9455-c886cc07c8cb" />
