### PR TITLE
fix(frontend) decorative background svg

### DIFF
--- a/frontend/app/routes/layout.tsx
+++ b/frontend/app/routes/layout.tsx
@@ -74,17 +74,15 @@ export default function Layout({ loaderData }: Route.ComponentProps) {
                   <PageDetails buildDate={BUILD_DATE} buildVersion={BUILD_VERSION} pageId={pageId} />
                 </div>
               </div>
-              <div className="relative col-span-4">
-                <aside className="absolute top-0 right-0 bottom-0 left-0 z-0 hidden bg-[rgba(9,28,45,1)] sm:block">
-                  <div
-                    role="presentation"
-                    className="absolute top-0 right-0 h-1/2 w-full bg-[url('/VacMan-design-element-07.svg')] bg-contain bg-top bg-no-repeat"
-                  />
-                  <div
-                    role="presentation"
-                    className="absolute bottom-0 left-0 h-1/2 w-full bg-[url('/VacMan-design-element-06.svg')] bg-contain bg-bottom bg-no-repeat"
-                  />
-                </aside>
+              <div className="col-span-4 grid grid-rows-2 bg-[rgba(9,28,45,1)]">
+                <div
+                  role="presentation"
+                  className="row-start-1 h-full w-full place-self-start bg-[url('/VacMan-design-element-07.svg')] bg-right-top bg-no-repeat"
+                />
+                <div
+                  role="presentation"
+                  className="row-start-2 h-full w-full place-self-end bg-[url('/VacMan-design-element-06.svg')] bg-left-bottom bg-no-repeat"
+                />
               </div>
             </div>
           ) : (


### PR DESCRIPTION
## Summary

The decorative layout side banner (yet again), has a styling issue where the top svg wasn't occupying the full width of the container.  No wonder everybody hates css.

before:
<img width="1797" height="836" alt="image" src="https://github.com/user-attachments/assets/9e6d187a-db63-4ee7-a8e4-00ea491669f2" />


after:
<img width="1819" height="860" alt="image" src="https://github.com/user-attachments/assets/8ef931a7-4760-44c9-a182-cb02ad62dcaf" />
