### PR TITLE
refactor(frontend) add env to playwright.config

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -21,5 +21,13 @@ export default defineConfig({
     command: 'tsx --import ./app/.server/telemetry.ts ./app/.server/express/server.ts',
     reuseExistingServer: !process.env.CI,
     url: `http://localhost:3000/`,
+    env: {
+      AUTH_DEFAULT_PROVIDER: 'local',
+      NODE_ENV: 'development',
+      ENABLE_DEVMODE_OIDC: 'true',
+      AZUREAD_ISSUER_URL: '',
+      AZUREAD_CLIENT_ID: '',
+      AZUREAD_CLIENT_SECRET: '',
+    },
   },
 });

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -21,13 +21,5 @@ export default defineConfig({
     command: 'tsx --import ./app/.server/telemetry.ts ./app/.server/express/server.ts',
     reuseExistingServer: !process.env.CI,
     url: `http://localhost:3000/`,
-    env: {
-      AUTH_DEFAULT_PROVIDER: 'local',
-      NODE_ENV: 'development',
-      ENABLE_DEVMODE_OIDC: 'true',
-      AZUREAD_ISSUER_URL: '',
-      AZUREAD_CLIENT_ID: '',
-      AZUREAD_CLIENT_SECRET: '',
-    },
   },
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
   build: {
     target: 'es2022',
   },
+  envDir: false,
   optimizeDeps: {
     entries: ['./app/entry.client.tsx', './app/root.tsx', './app/routes/**/*.tsx'],
   },


### PR DESCRIPTION
## Summary

[AB#6907](https://dev.azure.com/DTS-STN/4c33b941-c811-479f-b181-dfd5292182ff/_workitems/edit/6907)

Presumably during e2e tests there's a `302` to `login.ms.com` when the tests expect `/`.  This would suggest that the environment is using the `AZURAD` auth provider outside of development.  I believe overriding the webSever env in the playwright config is the way to go here.