### PR TITLE
feat(frontend): Request submission form submitter information

### DIFF
--- a/frontend/app/.server/domain/services/mockData.ts
+++ b/frontend/app/.server/domain/services/mockData.ts
@@ -431,10 +431,10 @@ export const mockRequests: RequestReadModel[] = [
       nameFr: 'Demande soumise',
     },
     workUnit: undefined,
-    submitter: mockUsers[0], // Jane Doe
-    hiringManager: mockUsers[3], // Bob Johnson
+    submitter: mockUsers[0], // John Doe
+    hiringManager: mockUsers[0], // John Doe
     subDelegatedManager: undefined,
-    hrAdvisor: mockUsers[0], // Jane Doe
+    hrAdvisor: mockUsers[3], // Bob Johnson
     languageOfCorrespondence: undefined,
     employmentTenure: undefined,
     priorityClearanceNumber: undefined,
@@ -479,9 +479,9 @@ export function createMockRequest(accessToken: string): RequestReadModel {
     status: undefined,
     workUnit: undefined,
     submitter: mockUsers[0],
-    hiringManager: mockUsers[3],
+    hiringManager: mockUsers[0],
     subDelegatedManager: undefined,
-    hrAdvisor: undefined,
+    hrAdvisor: mockUsers[3],
     languageOfCorrespondence: undefined,
     employmentTenure: undefined,
     priorityClearanceNumber: undefined,

--- a/frontend/app/.server/locales/app-en.ts
+++ b/frontend/app/.server/locales/app-en.ts
@@ -296,12 +296,12 @@ export default {
   'submission-details': {
     'page-title': 'Submission details',
     'hr-advisor': {
-      'request-submitted-by': 'Request submitted by {{name}}',
+      'request-submitted-by': 'Request submitted by: {{name}}',
       'is-submitter-hiring-manager': 'Is {{name}} the hiring manager for this request?',
       'is-submitter-a-sub-delegate': 'Is {{name}} a sub-delegate?',
     },
     'hiring-manager': {
-      'submitter': 'Submitter {{name}}',
+      'submitter': 'Submitter: {{name}}',
       'are-you-hiring-manager-for-request': 'Are you the hiring manager for this request?',
       'are-you-a-subdelegate': 'Are you a sub-delegate?',
     },

--- a/frontend/app/routes/hiring-manager/request/submission-details.tsx
+++ b/frontend/app/routes/hiring-manager/request/submission-details.tsx
@@ -6,12 +6,16 @@ import * as v from 'valibot';
 
 import type { Route } from './+types/submission-details';
 
+import type { RequestReadModel } from '~/.server/domain/models';
 import { getDirectorateService } from '~/.server/domain/services/directorate-service';
 import { getLanguageForCorrespondenceService } from '~/.server/domain/services/language-for-correspondence-service';
+import { getRequestService } from '~/.server/domain/services/request-service';
+import { getUserService } from '~/.server/domain/services/user-service';
 import { requireAuthentication } from '~/.server/utils/auth-utils';
 import { extractUniqueBranchesFromDirectorates } from '~/.server/utils/directorate-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { BackLink } from '~/components/back-link';
+import { REQUIRE_OPTIONS } from '~/domain/constants';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/layout';
@@ -32,6 +36,9 @@ export async function action({ context, params, request }: Route.ActionArgs) {
 
   const formData = await request.formData();
   const parseResult = v.safeParse(submissionDetailSchema, {
+    isSubmiterHiringManager: formData.get('isSubmiterHiringManager')
+      ? formData.get('isSubmiterHiringManager') === REQUIRE_OPTIONS.yes
+      : undefined,
     branchOrServiceCanadaRegion: formString(formData.get('branchOrServiceCanadaRegion')),
     directorate: formString(formData.get('directorate')),
     languageOfCorrespondenceId: formString(formData.get('languageOfCorrespondenceId')),
@@ -52,8 +59,19 @@ export async function action({ context, params, request }: Route.ActionArgs) {
 
 export async function loader({ context, params, request }: Route.LoaderArgs) {
   requireAuthentication(context.session, request);
+  const currentUserData = await getUserService().getCurrentUser(context.session.authState.accessToken);
+  const currentUser = currentUserData.unwrap();
 
-  //TODO: call request service to get default values
+  const requestResult = await getRequestService().getRequestById(
+    Number(params.requestId),
+    context.session.authState.accessToken,
+  );
+
+  if (requestResult.isErr()) {
+    throw new Response('Request not found', { status: HttpStatusCodes.NOT_FOUND });
+  }
+
+  const requestData: RequestReadModel = requestResult.unwrap();
 
   const { lang, t } = await getTranslation(request, handle.i18nNamespace);
 
@@ -65,13 +83,14 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
   return {
     documentTitle: t('app:submission-details.page-title'),
     defaultValues: {
-      submitter: undefined,
-      hiringManager: undefined,
-      subDelegatedManager: undefined,
-      hrAdvisor: undefined,
-      workUnit: undefined,
-      languageOfCorrespondence: undefined,
-      additionalComment: undefined,
+      // The submitter's information is coming from saved Request, but while creating a new request, the submitter is the logged in user,
+      submitter: requestData.submitter ?? currentUser,
+      hiringManager: requestData.hiringManager,
+      subDelegatedManager: requestData.subDelegatedManager,
+      hrAdvisor: requestData.hrAdvisor,
+      workUnit: requestData.workUnit,
+      languageOfCorrespondence: requestData.languageOfCorrespondence,
+      additionalComment: requestData.additionalComment,
     },
     branchOrServiceCanadaRegions,
     directorates,
@@ -102,6 +121,7 @@ export default function HiringManagerRequestSubmissionDetails({ loaderData, acti
           directorates={loaderData.directorates}
           languagesOfCorrespondence={loaderData.languagesOfCorrespondence}
           params={params}
+          view="hiring-manager"
         />
       </div>
     </>

--- a/frontend/app/routes/hiring-manager/request/submission-details.tsx
+++ b/frontend/app/routes/hiring-manager/request/submission-details.tsx
@@ -35,7 +35,12 @@ export async function action({ context, params, request }: Route.ActionArgs) {
   requireAuthentication(context.session, request);
 
   const formData = await request.formData();
-  const parseResult = v.safeParse(submissionDetailSchema, {
+  const view = formString(formData.get('view')) as 'hr-advisor' | 'hiring-manager' | undefined;
+
+  const dynamicSubmissionDetailSchema = submissionDetailSchema(view);
+
+  const parseResult = v.safeParse(dynamicSubmissionDetailSchema, {
+    view: view,
     isSubmiterHiringManager: formData.get('isSubmiterHiringManager')
       ? formData.get('isSubmiterHiringManager') === REQUIRE_OPTIONS.yes
       : undefined,
@@ -47,7 +52,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
 
   if (!parseResult.success) {
     return data(
-      { errors: v.flatten<typeof submissionDetailSchema>(parseResult.issues).nested },
+      { errors: v.flatten<typeof dynamicSubmissionDetailSchema>(parseResult.issues).nested },
       { status: HttpStatusCodes.BAD_REQUEST },
     );
   }

--- a/frontend/app/routes/hr-advisor/request/submission-details.tsx
+++ b/frontend/app/routes/hr-advisor/request/submission-details.tsx
@@ -34,7 +34,12 @@ export async function action({ context, params, request }: Route.ActionArgs) {
   requireAuthentication(context.session, request);
 
   const formData = await request.formData();
-  const parseResult = v.safeParse(submissionDetailSchema, {
+  const view = formString(formData.get('view')) as 'hr-advisor' | 'hiring-manager' | undefined;
+
+  const dynamicSubmissionDetailSchema = submissionDetailSchema(view);
+
+  const parseResult = v.safeParse(dynamicSubmissionDetailSchema, {
+    view: view,
     isSubmiterHiringManager: formData.get('isSubmiterHiringManager')
       ? formData.get('isSubmiterHiringManager') === REQUIRE_OPTIONS.yes
       : undefined,
@@ -46,7 +51,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
 
   if (!parseResult.success) {
     return data(
-      { errors: v.flatten<typeof submissionDetailSchema>(parseResult.issues).nested },
+      { errors: v.flatten<typeof dynamicSubmissionDetailSchema>(parseResult.issues).nested },
       { status: HttpStatusCodes.BAD_REQUEST },
     );
   }

--- a/frontend/app/routes/page-components/requests/submission-detail/form.tsx
+++ b/frontend/app/routes/page-components/requests/submission-detail/form.tsx
@@ -115,6 +115,7 @@ export function SubmissionDetailsForm({
         <Form method="post" noValidate>
           <div className="space-y-6">
             <div className="rounded-2xl border bg-gray-100 px-3 py-0.5 text-sm font-semibold text-black">
+              <input type="hidden" name="view" value={view} />
               {view === 'hiring-manager'
                 ? tApp('submission-details.hiring-manager.submitter', {
                     name: submitterName,

--- a/frontend/app/routes/page-components/requests/validation.server.ts
+++ b/frontend/app/routes/page-components/requests/validation.server.ts
@@ -221,43 +221,55 @@ const allDirectorates = await getDirectorateService().listAll();
 const allBranchOrServiceCanadaRegions = extractUniqueBranchesFromDirectoratesNonLocalized(allDirectorates);
 const allLanguagesOfCorrespondence = await getLanguageForCorrespondenceService().listAll();
 
-export const submissionDetailSchema = v.object({
-  isSubmiterHiringManager: v.boolean('app:submission-details.errors.is-submitter-hiring-manager-required'),
-  branchOrServiceCanadaRegion: v.lazy(() =>
-    v.pipe(
-      stringToIntegerSchema('app:submission-details.errors.branch-or-service-canada-region-required'),
-      v.picklist(
-        allBranchOrServiceCanadaRegions.map(({ id }) => id),
-        'app:submission-details.errors.branch-or-service-canada-region-required',
+const getIsSubmiterHiringManagerErrorMessage = (view: 'hr-advisor' | 'hiring-manager' | undefined) => {
+  if (view === 'hiring-manager') {
+    return 'app:submission-details.errors.are-you-hiring-manager-for-request-required';
+  }
+  // Default for 'hr-advisor' or if view is not provided/unexpected
+  return 'app:submission-details.errors.is-submitter-hiring-manager-required';
+};
+export const submissionDetailSchema = (view: 'hr-advisor' | 'hiring-manager' | undefined) => {
+  return v.object({
+    view: v.optional(v.string()),
+    isSubmiterHiringManager: v.boolean(
+      getIsSubmiterHiringManagerErrorMessage(view), // Pass the view to get the correct error message
+    ),
+    branchOrServiceCanadaRegion: v.lazy(() =>
+      v.pipe(
+        stringToIntegerSchema('app:submission-details.errors.branch-or-service-canada-region-required'),
+        v.picklist(
+          allBranchOrServiceCanadaRegions.map(({ id }) => id),
+          'app:submission-details.errors.branch-or-service-canada-region-required',
+        ),
       ),
     ),
-  ),
-  directorate: v.lazy(() =>
-    v.pipe(
-      stringToIntegerSchema('app:submission-details.errors.directorate-required'),
-      v.picklist(
-        allDirectorates.map(({ id }) => id),
-        'app:submission-details.errors.directorate-required',
+    directorate: v.lazy(() =>
+      v.pipe(
+        stringToIntegerSchema('app:submission-details.errors.directorate-required'),
+        v.picklist(
+          allDirectorates.map(({ id }) => id),
+          'app:submission-details.errors.directorate-required',
+        ),
       ),
     ),
-  ),
-  languageOfCorrespondenceId: v.lazy(() =>
-    v.pipe(
-      stringToIntegerSchema('app:submission-details.errors.preferred-language-of-correspondence-required'),
-      v.picklist(
-        allLanguagesOfCorrespondence.map(({ id }) => id),
-        'app:submission-details.errors.preferred-language-of-correspondence-required',
+    languageOfCorrespondenceId: v.lazy(() =>
+      v.pipe(
+        stringToIntegerSchema('app:submission-details.errors.preferred-language-of-correspondence-required'),
+        v.picklist(
+          allLanguagesOfCorrespondence.map(({ id }) => id),
+          'app:submission-details.errors.preferred-language-of-correspondence-required',
+        ),
       ),
     ),
-  ),
-  additionalComment: v.optional(
-    v.pipe(
-      v.string('app:submission-details.errors.additional-information-required'),
-      v.trim(),
-      v.maxLength(100, 'app:submission-details.errors.additional-information-max-length'),
+    additionalComment: v.optional(
+      v.pipe(
+        v.string('app:submission-details.errors.additional-information-required'),
+        v.trim(),
+        v.maxLength(100, 'app:submission-details.errors.additional-information-max-length'),
+      ),
     ),
-  ),
-});
+  });
+};
 
 export const processInformationSchema = v.pipe(
   v.intersect([

--- a/frontend/app/routes/page-components/requests/validation.server.ts
+++ b/frontend/app/routes/page-components/requests/validation.server.ts
@@ -221,44 +221,43 @@ const allDirectorates = await getDirectorateService().listAll();
 const allBranchOrServiceCanadaRegions = extractUniqueBranchesFromDirectoratesNonLocalized(allDirectorates);
 const allLanguagesOfCorrespondence = await getLanguageForCorrespondenceService().listAll();
 
-export const submissionDetailSchema = v.pipe(
-  v.object({
-    branchOrServiceCanadaRegion: v.lazy(() =>
-      v.pipe(
-        stringToIntegerSchema('app:submission-details.errors.branch-or-service-canada-region-required'),
-        v.picklist(
-          allBranchOrServiceCanadaRegions.map(({ id }) => id),
-          'app:submission-details.errors.branch-or-service-canada-region-required',
-        ),
+export const submissionDetailSchema = v.object({
+  isSubmiterHiringManager: v.boolean('app:submission-details.errors.is-submitter-hiring-manager-required'),
+  branchOrServiceCanadaRegion: v.lazy(() =>
+    v.pipe(
+      stringToIntegerSchema('app:submission-details.errors.branch-or-service-canada-region-required'),
+      v.picklist(
+        allBranchOrServiceCanadaRegions.map(({ id }) => id),
+        'app:submission-details.errors.branch-or-service-canada-region-required',
       ),
     ),
-    directorate: v.lazy(() =>
-      v.pipe(
-        stringToIntegerSchema('app:submission-details.errors.directorate-required'),
-        v.picklist(
-          allDirectorates.map(({ id }) => id),
-          'app:submission-details.errors.directorate-required',
-        ),
+  ),
+  directorate: v.lazy(() =>
+    v.pipe(
+      stringToIntegerSchema('app:submission-details.errors.directorate-required'),
+      v.picklist(
+        allDirectorates.map(({ id }) => id),
+        'app:submission-details.errors.directorate-required',
       ),
     ),
-    languageOfCorrespondenceId: v.lazy(() =>
-      v.pipe(
-        stringToIntegerSchema('app:submission-details.errors.preferred-language-of-correspondence-required'),
-        v.picklist(
-          allLanguagesOfCorrespondence.map(({ id }) => id),
-          'app:submission-details.errors.preferred-language-of-correspondence-required',
-        ),
+  ),
+  languageOfCorrespondenceId: v.lazy(() =>
+    v.pipe(
+      stringToIntegerSchema('app:submission-details.errors.preferred-language-of-correspondence-required'),
+      v.picklist(
+        allLanguagesOfCorrespondence.map(({ id }) => id),
+        'app:submission-details.errors.preferred-language-of-correspondence-required',
       ),
     ),
-    additionalComment: v.optional(
-      v.pipe(
-        v.string('app:submission-details.errors.additional-information-required'),
-        v.trim(),
-        v.maxLength(100, 'app:submission-details.errors.additional-information-max-length'),
-      ),
+  ),
+  additionalComment: v.optional(
+    v.pipe(
+      v.string('app:submission-details.errors.additional-information-required'),
+      v.trim(),
+      v.maxLength(100, 'app:submission-details.errors.additional-information-max-length'),
     ),
-  }),
-);
+  ),
+});
 
 export const processInformationSchema = v.pipe(
   v.intersect([


### PR DESCRIPTION
## Summary

[AB#6895](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6895/)
[AB#6894](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6894/)
Request submission form submitter information
This pr is part of many prs, more form elements will be added in next prs.
This pr deals with showing submitter information on hiring manager and hr advisor route (as the wording is different for both cases).
Next radio button for selecting yes or no will be added in subsequent prs.

## Screenshots (if applicable)

Connect with api running locally, on /hr-advisor dashboard and create a new Request, and then navigate to /submission-details, The selection is unselected for new request:

<img width="987" height="704" alt="image" src="https://github.com/user-attachments/assets/77839a72-7901-43a3-b2fd-61c31558622c" />

while running mocks, navigate to /hr-advisor/request/1/submission-details or /hiring-manager/request/1/submission-details, the mock data have values, so different wording for each route for submitter information:

<img width="509" height="714" alt="image" src="https://github.com/user-attachments/assets/86959672-c419-4f10-a363-e3555b5aa935" />
<img width="541" height="701" alt="image" src="https://github.com/user-attachments/assets/d42f742d-a8f2-43f3-a69d-bd93ce50790a" />

Error message on hiring manager route:

<img width="607" height="737" alt="image" src="https://github.com/user-attachments/assets/9c5d604c-fa4d-4f7f-b8cf-d67dda2b85ba" />

Error message on hiring manager route:

<img width="604" height="851" alt="hr advisor route error message" src="https://github.com/user-attachments/assets/57d6c8c6-a144-41ad-af7c-ea3492bbc205" />