### PR TITLE
fix(frontend): fix canada watermark on static error pages

### DIFF
--- a/frontend/app/.server/express/assets/403.html
+++ b/frontend/app/.server/express/assets/403.html
@@ -12,6 +12,11 @@
     />
     <link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/css/theme.min.css" />
     <link href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico" rel="icon" type="image/x-icon" />
+    <style>
+      #wb-info img {
+        height: 40px;
+      }
+    </style>
   </head>
   <body>
     <header>
@@ -67,7 +72,7 @@
         </div>
       </div>
     </main>
-    <footer role="contentinfo">
+    <footer role="contentinfo" id="wb-info">
       <div class="brand">
         <div class="container">
           <div class="row">

--- a/frontend/app/.server/express/assets/500.html
+++ b/frontend/app/.server/express/assets/500.html
@@ -12,6 +12,11 @@
     />
     <link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/css/theme.min.css" />
     <link href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico" rel="icon" type="image/x-icon" />
+    <style>
+      #wb-info img {
+        height: 40px;
+      }
+    </style>
   </head>
   <body>
     <header>
@@ -75,7 +80,7 @@
         </div>
       </div>
     </main>
-    <footer role="contentinfo">
+    <footer role="contentinfo" id="wb-info">
       <div class="brand">
         <div class="container">
           <div class="row">


### PR DESCRIPTION
## Summary

[AB#6914](https://dev.azure.com/DTS-STN/4c33b941-c811-479f-b181-dfd5292182ff/_workitems/edit/6914) -- fix 500 error page

Fix the rendering of the canada watermark in static error pages.

**Fun fact:** this error also occurs on <https://www.canada.ca/errors/500.html> 🎉 

## Screenshots

before:
<img width="1198" height="744" alt="image" src="https://github.com/user-attachments/assets/ae4415b2-fc78-4cb4-883c-6a653608a9d9" />

after:
<img width="1163" height="495" alt="image" src="https://github.com/user-attachments/assets/a64f022e-78bd-42e4-903f-029fc29bde87" />
