### PR TITLE
refactor(frontend): fix endpoint name

### DIFF
--- a/frontend/app/.server/domain/services/employment-equity-service-default.ts
+++ b/frontend/app/.server/domain/services/employment-equity-service-default.ts
@@ -5,7 +5,7 @@ import { ErrorCodes } from '~/errors/error-codes';
 
 // Create a single instance of the service using shared implementation with standard localization
 const sharedService = createLookupService<EmploymentEquity>(
-  '/codes/employment-equity',
+  '/codes/employment-equities',
   'employment equity',
   ErrorCodes.NO_EMPLOYMENT_EQUITY_FOUND,
 );

--- a/frontend/app/.server/utils/registration-utils.ts
+++ b/frontend/app/.server/utils/registration-utils.ts
@@ -63,7 +63,12 @@ export async function requireRoleRegistration(
 
 // Specific implementations
 export async function checkHiringManagerRouteRegistration(session: AuthenticatedSession, request: Request): Promise<void> {
-  await requireRoleRegistration(session, request, ['admin', 'hiring-manager'], isHiringManagerPath);
+  // TODO: Apply a fix to route to hiring manager dashboard on login
+  // There is no security group in Azure AD for hiring managers, hiring managers are also regular users
+  // To route to the hiring manager dashboard on login, we could check if the user has submitted any hiring requests
+  // Also need to consider that the employee shouldn't be able to navigate to the hiring managers route by typing in the url,
+  // that's why the roles are kept for now even if they are not present in the Azure AD.
+  await requireRoleRegistration(session, request, ['admin', 'hr-advisor', 'hiring-manager'], isHiringManagerPath);
 }
 
 /**

--- a/frontend/tests/.server/utils/registration-utils.test.ts
+++ b/frontend/tests/.server/utils/registration-utils.test.ts
@@ -252,7 +252,7 @@ describe('registration-utils', () => {
       await checkHiringManagerRouteRegistration(session, request);
 
       expect(mockUserService.getCurrentUser).toHaveBeenCalled();
-      expect(mockRequireAnyRole).toHaveBeenCalledWith(session, new URL(request.url), ['admin', 'hiring-manager']);
+      expect(mockRequireAnyRole).toHaveBeenCalledWith(session, new URL(request.url), ['admin', 'hr-advisor', 'hiring-manager']);
     });
 
     it('should return early when not on hiring manager path', async () => {


### PR DESCRIPTION
## Summary

Updated the correct endpoint name
Also added a TODO to fix the registration utils for routing to hiring manager dashboard on login.
Note: run api, and run the frontend connected to the api locally. The run time error is not thrown on the employment equity any more. And the hr-advisor can navigate to the hiring manager route

## Types of changes

What types of changes does this PR introduce?

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] code has been linted and formatted locally

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>
