### PR TITLE
refactor(frontend) removew hidden view input

### DIFF
--- a/frontend/app/routes/hiring-manager/request/submission-details.tsx
+++ b/frontend/app/routes/hiring-manager/request/submission-details.tsx
@@ -35,10 +35,8 @@ export async function action({ context, params, request }: Route.ActionArgs) {
   requireAuthentication(context.session, request);
 
   const formData = await request.formData();
-  const view = formString(formData.get('view')) as 'hr-advisor' | 'hiring-manager' | undefined;
 
-  const parseResult = v.safeParse(await createSubmissionDetailSchema(view), {
-    view: view,
+  const parseResult = v.safeParse(await createSubmissionDetailSchema('hiring-manager'), {
     isSubmiterHiringManager: formData.get('isSubmiterHiringManager')
       ? formData.get('isSubmiterHiringManager') === REQUIRE_OPTIONS.yes
       : undefined,

--- a/frontend/app/routes/hr-advisor/request/submission-details.tsx
+++ b/frontend/app/routes/hr-advisor/request/submission-details.tsx
@@ -35,10 +35,8 @@ export async function action({ context, params, request }: Route.ActionArgs) {
   requireAuthentication(context.session, request);
 
   const formData = await request.formData();
-  const view = formString(formData.get('view')) as 'hr-advisor' | 'hiring-manager' | undefined;
 
-  const parseResult = v.safeParse(await createSubmissionDetailSchema(view), {
-    view: view,
+  const parseResult = v.safeParse(await createSubmissionDetailSchema('hr-advisor'), {
     isSubmiterHiringManager: formData.get('isSubmiterHiringManager')
       ? formData.get('isSubmiterHiringManager') === REQUIRE_OPTIONS.yes
       : undefined,

--- a/frontend/app/routes/page-components/requests/submission-detail/form.tsx
+++ b/frontend/app/routes/page-components/requests/submission-detail/form.tsx
@@ -174,7 +174,6 @@ export function SubmissionDetailsForm({
         <Form method="post" noValidate>
           <div className="space-y-6">
             <div className="rounded-2xl border bg-gray-100 px-3 py-0.5 text-sm font-semibold text-black">
-              <input type="hidden" name="view" value={view} />
               {view === 'hiring-manager'
                 ? tApp('submission-details.hiring-manager.submitter', {
                     name: submitterName,

--- a/frontend/app/routes/page-components/requests/validation.server.ts
+++ b/frontend/app/routes/page-components/requests/validation.server.ts
@@ -157,28 +157,25 @@ export const somcConditionsSchema = v.pipe(
   }),
 );
 
-export async function createSubmissionDetailSchema(view: 'hr-advisor' | 'hiring-manager' | undefined) {
+export async function createSubmissionDetailSchema(view: 'hr-advisor' | 'hiring-manager') {
   const allDirectorates = await getDirectorateService().listAll();
   const allBranchOrServiceCanadaRegions = extractUniqueBranchesFromDirectoratesNonLocalized(allDirectorates);
   const allLanguagesOfCorrespondence = await getLanguageForCorrespondenceService().listAll();
 
-  const getIsSubmiterHiringManagerErrorMessage = (view: 'hr-advisor' | 'hiring-manager' | undefined) => {
+  const getIsSubmiterHiringManagerErrorMessage = (view: 'hr-advisor' | 'hiring-manager') => {
     if (view === 'hiring-manager') {
       return 'app:submission-details.errors.are-you-hiring-manager-for-request-required';
     }
-    // Default for 'hr-advisor' or if view is not provided/unexpected
     return 'app:submission-details.errors.is-submitter-hiring-manager-required';
   };
-  const getIsSubmiterSubdelegateErrorMessage = (view: 'hr-advisor' | 'hiring-manager' | undefined) => {
+  const getIsSubmiterSubdelegateErrorMessage = (view: 'hr-advisor' | 'hiring-manager') => {
     if (view === 'hiring-manager') {
       return 'app:submission-details.errors.are-you-a-subdelegate-required';
     }
-    // Default for 'hr-advisor' or if view is not provided/unexpected
     return 'app:submission-details.errors.is-submitter-a-sub-delegate-required';
   };
 
   const submissionDetail = {
-    viewSchema: v.optional(v.string()),
     hiringManagerEmailAddressSchema: v.pipe(
       v.string('app:submission-details.errors.hiring-manager-email-required'),
       v.trim(),
@@ -229,7 +226,6 @@ export async function createSubmissionDetailSchema(view: 'hr-advisor' | 'hiring-
 
   const baseCombinedSchema = v.intersect([
     v.object({
-      view: submissionDetail.viewSchema,
       branchOrServiceCanadaRegion: submissionDetail.branchOrServiceCanadaRegionSchema,
       directorate: submissionDetail.directorateSchema,
       languageOfCorrespondenceId: submissionDetail.languageOfCorrespondenceIdSchema,


### PR DESCRIPTION
## Summary

I could be wrong, but I don't think we need the hidden `view` input in /submission-details.  The view is delegated by the page, so we don't need to infer it from the form in a round-trip kind of way.  We can just supply it as an argument to the validation since we know what route we're on in the action.