### PR TITLE
fix(frontend) add margin bottom to input-multiselect legend

### DIFF
--- a/frontend/app/components/input-multiselect.tsx
+++ b/frontend/app/components/input-multiselect.tsx
@@ -124,7 +124,7 @@ export function InputMultiSelect(props: InputMultiSelectProps) {
   return (
     <div className="relative" ref={wrapperRef} {...restDivProps}>
       <fieldset id={inputWrapperId} aria-describedby={ariaDescribedbyId}>
-        <InputLegend id={inputLegendId} required={required}>
+        <InputLegend id={inputLegendId} required={required} className="mb-2">
           {legend}
         </InputLegend>
         {errorMessage && (

--- a/frontend/tests/components/__snapshots__/input-multiselect.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/input-multiselect.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`InputMultiSelect > should match the initial snapshot 1`] = `
       id="input-framework"
     >
       <legend
-        class="block"
+        class="block mb-2"
         id="input-framework-legend"
       >
         <span


### PR DESCRIPTION
## Summary

I noticed there was 0 margin on the legend of the input-multiselect component.  This PR adds a consistent `mb-2` which aligns with the other input components.

