### PR TITLE
Removing entries from Employment Tenure and Work Schedule

### DIFF
--- a/backend/src/main/resources/application-local.yaml.example
+++ b/backend/src/main/resources/application-local.yaml.example
@@ -83,7 +83,7 @@ spring:
       '[hibernate.format_sql]': true
     show-sql: true
   liquibase:
-    contexts: mssql, dev
+    contexts: dev
     drop-first: true
 
 ---

--- a/backend/src/main/resources/db/changelog/changes/data/db.data.v1.sql
+++ b/backend/src/main/resources/db/changelog/changes/data/db.data.v1.sql
@@ -797,9 +797,7 @@ SET IDENTITY_INSERT CD_EMPLOYMENT_TENURE ON;
 INSERT INTO [CD_EMPLOYMENT_TENURE] ([ID], [CODE], [NAME_EN], [NAME_FR], [EFFECTIVE_DATE], [USER_CREATED], [DATE_CREATED], [USER_UPDATED], [DATE_UPDATED])
 VALUES
 (0, 'INDETERMINATE', 'Indeterminate', 'Indéterminée', '1970-01-01 00:00:00', 'system', CURRENT_TIMESTAMP, 'system', CURRENT_TIMESTAMP),
-(1, 'TERM', 'Term', 'Durée déterminée', '1970-01-01 00:00:00', 'system', CURRENT_TIMESTAMP, 'system', CURRENT_TIMESTAMP),
-(2, 'CASUAL', 'Casual', 'Occasionnel', '1970-01-01 00:00:00', 'system', CURRENT_TIMESTAMP, 'system', CURRENT_TIMESTAMP),
-(3, 'STUDENT', 'Student', 'Étudiant', '1970-01-01 00:00:00', 'system', CURRENT_TIMESTAMP, 'system', CURRENT_TIMESTAMP);
+(1, 'TERM', 'Term', 'Durée déterminée', '1970-01-01 00:00:00', 'system', CURRENT_TIMESTAMP, 'system', CURRENT_TIMESTAMP);
 
 --changeset system:cd_employment_tenure_off dbms:mssql
 SET IDENTITY_INSERT CD_EMPLOYMENT_TENURE OFF;
@@ -913,9 +911,7 @@ SET IDENTITY_INSERT CD_WORK_SCHEDULE ON;
 INSERT INTO [CD_WORK_SCHEDULE] ([ID], [CODE], [NAME_EN], [NAME_FR], [EFFECTIVE_DATE], [USER_CREATED], [DATE_CREATED], [USER_UPDATED], [DATE_UPDATED])
 VALUES
 (0, 'FULL_TIME', 'Full-time', 'Temps plein', '1970-01-01 00:00:00', 'system', CURRENT_TIMESTAMP, 'system', CURRENT_TIMESTAMP),
-(1, 'PART_TIME', 'Part-time', 'Temps partiel', '1970-01-01 00:00:00', 'system', CURRENT_TIMESTAMP, 'system', CURRENT_TIMESTAMP),
-(2, 'CASUAL', 'Casual', 'Occasionnel', '1970-01-01 00:00:00', 'system', CURRENT_TIMESTAMP, 'system', CURRENT_TIMESTAMP),
-(3, 'TERM', 'Term', 'Durée déterminée', '1970-01-01 00:00:00', 'system', CURRENT_TIMESTAMP, 'system', CURRENT_TIMESTAMP);
+(1, 'PART_TIME', 'Part-time', 'Temps partiel', '1970-01-01 00:00:00', 'system', CURRENT_TIMESTAMP, 'system', CURRENT_TIMESTAMP);
 
 --changeset system:cd_work_schedule_off dbms:mssql
 SET IDENTITY_INSERT CD_WORK_SCHEDULE OFF;


### PR DESCRIPTION
## Summary

Removing entries from Employment Tenure and Work Schedule. Also removed mssql context from the application-local, since dbms makes it kind of redundant.

## Types of changes

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
