### PR TITLE
refactor(backend): `ProfileService.createProfile()` now accepts a profile

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/mapper/ProfileEntityMapper.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/mapper/ProfileEntityMapper.java
@@ -1,0 +1,14 @@
+package ca.gov.dtsstn.vacman.api.service.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+import ca.gov.dtsstn.vacman.api.data.entity.ProfileEntity;
+import ca.gov.dtsstn.vacman.api.data.entity.ProfileEntityBuilder;
+
+@Mapper(unmappedTargetPolicy = ReportingPolicy.ERROR)
+public interface ProfileEntityMapper {
+
+	ProfileEntityBuilder toProfileEntityBuilder(ProfileEntity profile);
+
+}

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/ProfilesController.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/ProfilesController.java
@@ -188,7 +188,11 @@ public class ProfilesController {
 		}
 
 		log.debug("Creating profile in database...");
-		final var createdProfile = profileModelMapper.toModel(profileService.createProfile(existingUser));
+
+		final var createdProfile = profileModelMapper.toModel(
+			profileService.createProfile(ProfileEntity.builder()
+				.user(existingUser)
+				.build()));
 
 		log.trace("Successfully created profile user: [{}]", createdProfile);
 


### PR DESCRIPTION
## Summary

In order to facilitate a future change that will allow HR advisors to create profiles for other users, the `ProfileService.createProfile(..)` method needs to be refactored so it doesn't always associate the profile with the currently logged in user.

## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
