### PR TITLE
feat(frontend): adding server-side pagination to hr-advisor/employees

### DIFF
--- a/frontend/app/.server/locales/gcweb-en.ts
+++ b/frontend/app/.server/locales/gcweb-en.ts
@@ -93,7 +93,6 @@ export default {
       'info_other': 'Showing {{start}} to {{end}} of {{count}} entries',
       'page-size': 'Entries per page',
       'page-info': 'Page {{index}} of {{count}}',
-      'page-status': 'Page {{index}} of {{count}}',
       'page-button-current': 'Current page, page {{index}}',
       'page-button-go-to': 'Go to page {{index}}',
       'first-page': 'Go to first page',

--- a/frontend/app/.server/locales/gcweb-en.ts
+++ b/frontend/app/.server/locales/gcweb-en.ts
@@ -99,7 +99,7 @@ export default {
       'previous-page': 'Previous',
       'next-page': 'Next',
       'last-page': 'Go to last page',
-  'more-pages': 'More pages',
+      'more-pages': 'More pages',
     },
     'sorting': {
       'sorted-ascending': '{{column}}, sorted ascending. Click to sort descending.',

--- a/frontend/app/.server/locales/gcweb-en.ts
+++ b/frontend/app/.server/locales/gcweb-en.ts
@@ -87,11 +87,15 @@ export default {
   'data-table': {
     'zero-records': 'No matching records found',
     'pagination': {
+      'label': 'Pagination',
       'info_zero': 'Showing 0 to 0 of 0 entries',
       'info_one': 'Showing {{start}} to {{end}} of {{count}} entru',
       'info_other': 'Showing {{start}} to {{end}} of {{count}} entries',
       'page-size': 'Entries per page',
       'page-info': 'Page {{index}} of {{count}}',
+      'page-status': 'Page {{index}} of {{count}}',
+      'page-button-current': 'Current page, page {{index}}',
+      'page-button-go-to': 'Go to page {{index}}',
       'first-page': 'Go to first page',
       'previous-page': 'Go to previous page',
       'next-page': 'Go to next page',

--- a/frontend/app/.server/locales/gcweb-en.ts
+++ b/frontend/app/.server/locales/gcweb-en.ts
@@ -89,7 +89,7 @@ export default {
     'pagination': {
       'label': 'Pagination',
       'info_zero': 'Showing 0 to 0 of 0 entries',
-      'info_one': 'Showing {{start}} to {{end}} of {{count}} entru',
+      'info_one': 'Showing {{start}} to {{end}} of {{count}} entry',
       'info_other': 'Showing {{start}} to {{end}} of {{count}} entries',
       'page-size': 'Entries per page',
       'page-info': 'Page {{index}} of {{count}}',

--- a/frontend/app/.server/locales/gcweb-en.ts
+++ b/frontend/app/.server/locales/gcweb-en.ts
@@ -96,8 +96,8 @@ export default {
       'page-button-current': 'Current page, page {{index}}',
       'page-button-go-to': 'Go to page {{index}}',
       'first-page': 'Go to first page',
-      'previous-page': 'Go to previous page',
-      'next-page': 'Go to next page',
+      'previous-page': 'Previous',
+      'next-page': 'Next',
       'last-page': 'Go to last page',
     },
     'sorting': {

--- a/frontend/app/.server/locales/gcweb-en.ts
+++ b/frontend/app/.server/locales/gcweb-en.ts
@@ -99,6 +99,7 @@ export default {
       'previous-page': 'Previous',
       'next-page': 'Next',
       'last-page': 'Go to last page',
+  'more-pages': 'More pages',
     },
     'sorting': {
       'sorted-ascending': '{{column}}, sorted ascending. Click to sort descending.',

--- a/frontend/app/.server/locales/gcweb-fr.ts
+++ b/frontend/app/.server/locales/gcweb-fr.ts
@@ -89,11 +89,15 @@ export default {
   'data-table': {
     'zero-records': 'Aucune entrée correspondante trouvée',
     'pagination': {
+      'label': 'Pagination',
       'info_zero': 'Affichage de 0 à 0 sur 0 entrées',
       'info_one': 'Affichage de {{start}} à {{end}} sur {{count}} entré',
       'info_other': 'Affichage de {{start}} à {{end}} sur {{count}} entrées',
       'page-size': 'Entrées par page',
       'page-info': 'Page {{index}} de {{count}}',
+      'page-status': 'Page {{index}} sur {{count}}',
+      'page-button-current': 'Page actuelle, page {{index}}',
+      'page-button-go-to': 'Aller à la page {{index}}',
       'first-page': 'Aller à la première page',
       'previous-page': 'Aller à la page précédente',
       'next-page': 'Aller à la page suivante',

--- a/frontend/app/.server/locales/gcweb-fr.ts
+++ b/frontend/app/.server/locales/gcweb-fr.ts
@@ -98,8 +98,8 @@ export default {
       'page-button-current': 'Page actuelle, page {{index}}',
       'page-button-go-to': 'Aller à la page {{index}}',
       'first-page': 'Aller à la première page',
-      'previous-page': 'Aller à la page précédente',
-      'next-page': 'Aller à la page suivante',
+      'previous-page': 'Précédent',
+      'next-page': 'Suivant',
       'last-page': 'Aller à la dernière page',
     },
     'sorting': {

--- a/frontend/app/.server/locales/gcweb-fr.ts
+++ b/frontend/app/.server/locales/gcweb-fr.ts
@@ -95,7 +95,6 @@ export default {
       'info_other': 'Affichage de {{start}} à {{end}} sur {{count}} entrées',
       'page-size': 'Entrées par page',
       'page-info': 'Page {{index}} de {{count}}',
-      'page-status': 'Page {{index}} sur {{count}}',
       'page-button-current': 'Page actuelle, page {{index}}',
       'page-button-go-to': 'Aller à la page {{index}}',
       'first-page': 'Aller à la première page',

--- a/frontend/app/.server/locales/gcweb-fr.ts
+++ b/frontend/app/.server/locales/gcweb-fr.ts
@@ -101,6 +101,7 @@ export default {
       'previous-page': 'Précédent',
       'next-page': 'Suivant',
       'last-page': 'Aller à la dernière page',
+  'more-pages': 'Plus de pages',
     },
     'sorting': {
       'sorted-ascending': '{{column}}, trié en ordre croissant. Cliquez pour trier en ordre décroissant.',

--- a/frontend/app/.server/locales/gcweb-fr.ts
+++ b/frontend/app/.server/locales/gcweb-fr.ts
@@ -101,7 +101,7 @@ export default {
       'previous-page': 'Précédent',
       'next-page': 'Suivant',
       'last-page': 'Aller à la dernière page',
-  'more-pages': 'Plus de pages',
+      'more-pages': 'Plus de pages',
     },
     'sorting': {
       'sorted-ascending': '{{column}}, trié en ordre croissant. Cliquez pour trier en ordre décroissant.',

--- a/frontend/app/components/data-table.tsx
+++ b/frontend/app/components/data-table.tsx
@@ -2,15 +2,7 @@ import { useState } from 'react';
 
 import { faSortUp, faSortDown } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import type {
-  ColumnDef,
-  SortingState,
-  Column,
-  Table as ReactTable,
-  ColumnFiltersState,
-  PaginationState,
-  Updater,
-} from '@tanstack/react-table';
+import type { ColumnDef, SortingState, Column, Table as ReactTable, ColumnFiltersState } from '@tanstack/react-table';
 import {
   flexRender,
   getCoreRowModel,
@@ -26,61 +18,33 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '~/components/table';
 import { cn } from '~/utils/tailwind-utils';
 
-interface DataTableServerPagination {
-  pageIndex: number;
-  pageCount: number;
-  onPageChange: (nextIndex: number) => void;
-}
-
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
-  // Optional: when provided, pagination is controlled by the parent (e.g., server-side pagination)
-  serverPagination?: DataTableServerPagination;
+  // Whether to render the built-in pagination UI. If false, caller should render their own.
+  showPagination?: boolean;
 }
 
-export function DataTable<TData, TValue>({ columns, data, serverPagination }: DataTableProps<TData, TValue>) {
+export function DataTable<TData, TValue>({ columns, data, showPagination = true }: DataTableProps<TData, TValue>) {
   const { t } = useTranslation(['gcweb']);
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
-
-  const manualPagination = Boolean(serverPagination);
-  const paginationState: PaginationState | undefined = manualPagination
-    ? { pageIndex: serverPagination?.pageIndex ?? 0, pageSize: data.length || 10 }
-    : undefined;
-  const handlePaginationChange: ((updater: Updater<PaginationState>) => void) | undefined = manualPagination
-    ? (updater: Updater<PaginationState>) => {
-        const prev: PaginationState = { pageIndex: serverPagination?.pageIndex ?? 0, pageSize: data.length || 10 };
-        const nextState =
-          typeof updater === 'function'
-            ? (updater as (old: PaginationState) => PaginationState)(prev)
-            : (updater as PaginationState);
-        if (typeof nextState.pageIndex === 'number' && serverPagination?.onPageChange) {
-          serverPagination.onPageChange(nextState.pageIndex);
-        }
-      }
-    : undefined;
 
   const table = useReactTable({
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
-    // In manual/server-controlled pagination mode, don't slice rows locally to avoid flicker
-    ...(manualPagination ? {} : { getPaginationRowModel: getPaginationRowModel() }),
-    // Prevent bouncing back to page 0 when data changes under server-controlled pagination
-    autoResetPageIndex: !manualPagination,
+    // Only enable local pagination when the pagination UI is shown.
+    ...(showPagination ? { getPaginationRowModel: getPaginationRowModel() } : {}),
+    autoResetPageIndex: true,
     onSortingChange: setSorting,
     getSortedRowModel: getSortedRowModel(),
     onColumnFiltersChange: setColumnFilters,
     getFilteredRowModel: getFilteredRowModel(),
-    manualPagination,
-    pageCount: manualPagination ? serverPagination?.pageCount : undefined,
     state: {
       sorting,
       columnFilters,
-      ...(manualPagination && paginationState ? { pagination: paginationState } : {}),
     },
-    onPaginationChange: handlePaginationChange,
   });
 
   return (
@@ -139,9 +103,11 @@ export function DataTable<TData, TValue>({ columns, data, serverPagination }: Da
           )}
         </TableBody>
       </Table>
-      <div className="my-4">
-        <DataTablePagination table={table} />
-      </div>
+      {showPagination && (
+        <div className="my-4">
+          <DataTablePagination table={table} />
+        </div>
+      )}
     </>
   );
 }

--- a/frontend/app/components/pagination.tsx
+++ b/frontend/app/components/pagination.tsx
@@ -43,11 +43,12 @@ function PaginationLink({ className, isActive, children, ...props }: PaginationL
 
 // Previous page button (uses FontAwesome left chevron)
 function PaginationPrevious({ className, children, ...props }: ComponentProps<typeof Button>) {
+  const { t } = useTranslation(['gcweb']);
   return (
     <Button
       type="button"
+      aria-label={t('gcweb:data-table.pagination.previous-page', { defaultValue: 'Go to previous page' })}
       variant="ghost"
-      aria-label="Go to previous page"
       className={cn('h-8 border-hidden px-2 text-sm font-medium underline transition-colors duration-200', className)}
       {...props}
     >

--- a/frontend/app/components/pagination.tsx
+++ b/frontend/app/components/pagination.tsx
@@ -35,7 +35,6 @@ export function Pagination({ pageIndex, pageCount, onPageChange, className }: Pa
               onClick={() => onPageChange(i)}
               aria-current={pageIndex === i ? 'page' : undefined}
             >
-              <span className="sr-only">{t('gcweb:data-table.pagination.first-page')}</span>
               {i + 1}
             </Button>
           ))}

--- a/frontend/app/components/pagination.tsx
+++ b/frontend/app/components/pagination.tsx
@@ -23,34 +23,44 @@ export function Pagination({ pageIndex, pageCount, onPageChange, className }: Pa
   if (pageCount <= 1) return null;
 
   return (
-    <div className={cn('flex items-center justify-between px-2', className)}>
-      <div className="flex items-center space-x-6 lg:space-x-8">
-        <div className="flex items-center space-x-2">
-          {Array.from({ length: pageCount }, (_, i) => (
-            <Button
-              key={i}
-              type="button"
-              variant="outline"
-              className={cn('h-8 w-8 p-0 text-sm', pageIndex === i ? 'bg-slate-700 text-white' : 'border-hidden underline')}
-              onClick={() => onPageChange(i)}
-              aria-current={pageIndex === i ? 'page' : undefined}
-            >
-              {i + 1}
-            </Button>
-          ))}
+    <nav aria-label={t('gcweb:data-table.pagination.label', { defaultValue: 'Pagination' })} className={cn('px-2', className)}>
+      {/* Current page and total for screen readers */}
+      <p className="sr-only">{t('gcweb:data-table.pagination.page-status', { index: pageIndex + 1, count: pageCount })}</p>
+      <ul className="flex items-center gap-2">
+        {Array.from({ length: pageCount }, (_, i) => {
+          const isCurrent = pageIndex === i;
+          const label = isCurrent
+            ? t('gcweb:data-table.pagination.page-button-current', { index: i + 1 })
+            : t('gcweb:data-table.pagination.page-button-go-to', { index: i + 1 });
+          return (
+            <li key={i}>
+              <Button
+                type="button"
+                variant="outline"
+                className={cn('h-8 w-8 p-0 text-sm', isCurrent ? 'bg-slate-700 text-white' : 'border-hidden underline')}
+                onClick={() => onPageChange(i)}
+                aria-current={isCurrent ? 'page' : undefined}
+                aria-label={label}
+              >
+                {i + 1}
+              </Button>
+            </li>
+          );
+        })}
+        <li>
           <Button
             type="button"
             variant="ghost"
             onClick={() => onPageChange(Math.min(pageIndex + 1, pageCount - 1))}
             disabled={pageIndex >= pageCount - 1}
+            aria-label={t('gcweb:data-table.pagination.next-page', { defaultValue: 'Next page' })}
             className={cn('h-8 border-hidden px-2 text-sm font-medium underline transition-colors duration-200')}
           >
-            <span className="sr-only">{t('gcweb:data-table.pagination.next-page')}</span>
             {t('app:hr-advisor-employees-table.next-page')}
           </Button>
-        </div>
-      </div>
-    </div>
+        </li>
+      </ul>
+    </nav>
   );
 }
 

--- a/frontend/app/components/pagination.tsx
+++ b/frontend/app/components/pagination.tsx
@@ -1,67 +1,183 @@
+import type React from 'react';
+import type { ComponentProps, PropsWithChildren } from 'react';
+import { createContext, useContext, useMemo } from 'react';
+
+import { useSearchParams } from 'react-router';
+
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '~/components/button';
+import { clamp } from '~/utils/math-utils';
 import { cn } from '~/utils/tailwind-utils';
 
-export interface PaginationProps {
-  // 0-based current page index
-  pageIndex: number;
-  // total number of pages
+type ButtonProps = ComponentProps<typeof Button>;
+
+type PaginationContextValue = {
+  // 1-based current page from URL
+  currentPage: number;
+  // total page count from props
   pageCount: number;
-  // callback with next 0-based index
-  onPageChange: (nextIndex: number) => void;
-  className?: string;
+  // query string key to use (default: 'page')
+  paramName: string;
+  // navigate to a specific 1-based page, clamped to [1, pageCount]
+  goTo: (pageOneBased: number) => void;
+};
+
+const PaginationContext = createContext<PaginationContextValue | null>(null);
+
+function usePaginationContext(): PaginationContextValue {
+  const ctx = useContext(PaginationContext);
+  if (!ctx) throw new Error('Pagination subcomponents must be used within <Pagination>');
+  return ctx;
 }
 
-/**
- * Presentation-only pagination control. This component renders page buttons and
- * next navigation, and delegates page changes to the caller.
- */
-export function Pagination({ pageIndex, pageCount, onPageChange, className }: PaginationProps) {
+export interface PaginationRootProps extends PropsWithChildren {
+  pageCount: number;
+  className?: string;
+  paramName?: string; // default 'page'
+}
+
+function getCurrentPage(searchParams: URLSearchParams, paramName: string, pageCount: number) {
+  const n = Number.parseInt(searchParams.get(paramName) ?? '1', 10) || 1;
+  return clamp(n, 1, Math.max(1, pageCount));
+}
+
+function Root({ children, pageCount, className, paramName = 'page' }: PaginationRootProps) {
   const { t } = useTranslation(['gcweb', 'app']);
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const currentPage = useMemo(() => getCurrentPage(searchParams, paramName, pageCount), [searchParams, paramName, pageCount]);
+
+  const ctx = useMemo<PaginationContextValue>(
+    () => ({
+      currentPage,
+      pageCount,
+      paramName,
+      goTo: (pageOneBased) => {
+        const next = new URLSearchParams(searchParams);
+        next.set(paramName, String(clamp(pageOneBased, 1, Math.max(1, pageCount))));
+        setSearchParams(next);
+      },
+    }),
+    [currentPage, pageCount, paramName, searchParams, setSearchParams],
+  );
 
   if (pageCount <= 1) return null;
 
   return (
-    <nav aria-label={t('gcweb:data-table.pagination.label', { defaultValue: 'Pagination' })} className={cn('px-2', className)}>
-      {/* Current page and total for screen readers */}
-      <p className="sr-only">{t('gcweb:data-table.pagination.page-info', { index: pageIndex + 1, count: pageCount })}</p>
-      <ul className="flex items-center gap-2">
-        {Array.from({ length: pageCount }, (_, i) => {
-          const isCurrent = pageIndex === i;
-          const label = isCurrent
-            ? t('gcweb:data-table.pagination.page-button-current', { index: i + 1 })
-            : t('gcweb:data-table.pagination.page-button-go-to', { index: i + 1 });
-          return (
-            <li key={i}>
-              <Button
-                type="button"
-                variant="outline"
-                className={cn('h-8 w-8 p-0 text-sm', isCurrent ? 'bg-slate-700 text-white' : 'border-hidden underline')}
-                onClick={() => onPageChange(i)}
-                aria-current={isCurrent ? 'page' : undefined}
-                aria-label={label}
-              >
-                {i + 1}
-              </Button>
-            </li>
-          );
-        })}
-        <li>
-          <Button
-            type="button"
-            variant="ghost"
-            onClick={() => onPageChange(Math.min(pageIndex + 1, pageCount - 1))}
-            disabled={pageIndex >= pageCount - 1}
-            aria-label={t('gcweb:data-table.pagination.next-page', { defaultValue: 'Next page' })}
-            className={cn('h-8 border-hidden px-2 text-sm font-medium underline transition-colors duration-200')}
-          >
-            {t('app:hr-advisor-employees-table.next-page')}
-          </Button>
-        </li>
-      </ul>
-    </nav>
+    <PaginationContext.Provider value={ctx}>
+      <nav
+        aria-label={t('gcweb:data-table.pagination.label', { defaultValue: 'Pagination' })}
+        className={cn('px-2', className)}
+      >
+        <p className="sr-only">{t('gcweb:data-table.pagination.page-info', { index: currentPage, count: pageCount })}</p>
+        <ul className="flex items-center gap-2">{children}</ul>
+      </nav>
+    </PaginationContext.Provider>
   );
 }
+
+function Pages() {
+  const { pageCount } = usePaginationContext();
+  return (
+    <>
+      {Array.from({ length: pageCount }, (_, i) => (
+        <Link key={i} page={i + 1} />
+      ))}
+    </>
+  );
+}
+
+interface LinkProps extends Omit<ButtonProps, 'onClick'> {
+  page: number; // 1-based target page
+  onClick?: (page: number, event: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+function Link({ page, className, onClick, children, ...rest }: LinkProps) {
+  const { currentPage, pageCount, goTo } = usePaginationContext();
+  const { t } = useTranslation(['gcweb']);
+  const clamped = clamp(page, 1, Math.max(1, pageCount));
+  const isCurrent = currentPage === clamped;
+  const label = isCurrent
+    ? t('gcweb:data-table.pagination.page-button-current', { index: clamped })
+    : t('gcweb:data-table.pagination.page-button-go-to', { index: clamped });
+
+  return (
+    <li>
+      <Button
+        type="button"
+        variant="outline"
+        className={cn('h-8 w-8 p-0 text-sm', isCurrent ? 'bg-slate-700 text-white' : 'border-hidden underline', className)}
+        aria-current={isCurrent ? 'page' : undefined}
+        aria-label={label}
+        onClick={(e) => {
+          onClick?.(clamped, e);
+          if (!e.defaultPrevented) goTo(clamped);
+        }}
+        {...rest}
+      >
+        {children ?? clamped}
+      </Button>
+    </li>
+  );
+}
+
+type NavButtonProps = Omit<ButtonProps, 'onClick'> & {
+  onClick?: (nextPage: number, event: React.MouseEvent<HTMLButtonElement>) => void;
+};
+
+function Previous({ className, children, onClick, ...rest }: NavButtonProps) {
+  const { currentPage, goTo } = usePaginationContext();
+  const { t } = useTranslation(['gcweb', 'app']);
+  const target = clamp(currentPage - 1, 1, Infinity);
+  const disabled = currentPage <= 1;
+  return (
+    <li>
+      <Button
+        type="button"
+        variant="ghost"
+        disabled={disabled}
+        aria-label={t('gcweb:data-table.pagination.previous-page', { defaultValue: 'Previous page' })}
+        className={cn('h-8 border-hidden px-2 text-sm font-medium underline transition-colors duration-200', className)}
+        onClick={(e) => {
+          if (disabled) return;
+          onClick?.(target, e);
+          if (!e.defaultPrevented) goTo(target);
+        }}
+        {...rest}
+      >
+        {children ?? t('gcweb:data-table.pagination.previous-page', { defaultValue: 'Previous' })}
+      </Button>
+    </li>
+  );
+}
+
+function Next({ className, children, onClick, ...rest }: NavButtonProps) {
+  const { currentPage, pageCount, goTo } = usePaginationContext();
+  const { t } = useTranslation(['gcweb', 'app']);
+  const target = clamp(currentPage + 1, 1, pageCount);
+  const disabled = currentPage >= pageCount;
+  return (
+    <li>
+      <Button
+        type="button"
+        variant="ghost"
+        disabled={disabled}
+        aria-label={t('gcweb:data-table.pagination.next-page', { defaultValue: 'Next page' })}
+        className={cn('h-8 border-hidden px-2 text-sm font-medium underline transition-colors duration-200', className)}
+        onClick={(e) => {
+          if (disabled) return;
+          onClick?.(target, e);
+          if (!e.defaultPrevented) goTo(target);
+        }}
+        {...rest}
+      >
+        {children ?? t('gcweb:data-table.pagination.next-page', { defaultValue: 'Next' })}
+      </Button>
+    </li>
+  );
+}
+
+export const Pagination = Object.assign(Root, { Pages, Link, Previous, Next });
 
 export default Pagination;

--- a/frontend/app/components/pagination.tsx
+++ b/frontend/app/components/pagination.tsx
@@ -1,0 +1,58 @@
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '~/components/button';
+import { cn } from '~/utils/tailwind-utils';
+
+export interface PaginationProps {
+  // 0-based current page index
+  pageIndex: number;
+  // total number of pages
+  pageCount: number;
+  // callback with next 0-based index
+  onPageChange: (nextIndex: number) => void;
+  className?: string;
+}
+
+/**
+ * Presentation-only pagination control. This component renders page buttons and
+ * next navigation, and delegates page changes to the caller.
+ */
+export function Pagination({ pageIndex, pageCount, onPageChange, className }: PaginationProps) {
+  const { t } = useTranslation(['gcweb', 'app']);
+
+  if (pageCount <= 1) return null;
+
+  return (
+    <div className={cn('flex items-center justify-between px-2', className)}>
+      <div className="flex items-center space-x-6 lg:space-x-8">
+        <div className="flex items-center space-x-2">
+          {Array.from({ length: pageCount }, (_, i) => (
+            <Button
+              key={i}
+              type="button"
+              variant="outline"
+              className={cn('h-8 w-8 p-0 text-sm', pageIndex === i ? 'bg-slate-700 text-white' : 'border-hidden underline')}
+              onClick={() => onPageChange(i)}
+              aria-current={pageIndex === i ? 'page' : undefined}
+            >
+              <span className="sr-only">{t('gcweb:data-table.pagination.first-page')}</span>
+              {i + 1}
+            </Button>
+          ))}
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => onPageChange(Math.min(pageIndex + 1, pageCount - 1))}
+            disabled={pageIndex >= pageCount - 1}
+            className={cn('h-8 border-hidden px-2 text-sm font-medium underline transition-colors duration-200')}
+          >
+            <span className="sr-only">{t('gcweb:data-table.pagination.next-page')}</span>
+            {t('app:hr-advisor-employees-table.next-page')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Pagination;

--- a/frontend/app/components/pagination.tsx
+++ b/frontend/app/components/pagination.tsx
@@ -2,6 +2,7 @@ import type { ComponentProps } from 'react';
 
 import { faEllipsis } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useTranslation } from 'react-i18next';
 
 import { Button } from '~/components/button';
 import { cn } from '~/utils/tailwind-utils';
@@ -72,6 +73,7 @@ function PaginationNext({ className, children, ...props }: ComponentProps<typeof
 
 // Ellipsis indicator
 function PaginationEllipsis({ className, ...props }: ComponentProps<'span'>) {
+  const { t } = useTranslation(['gcweb']);
   return (
     <span
       aria-hidden
@@ -80,7 +82,7 @@ function PaginationEllipsis({ className, ...props }: ComponentProps<'span'>) {
       {...props}
     >
       <FontAwesomeIcon icon={faEllipsis} className="h-4 w-4" />
-      <span className="sr-only">More pages</span>
+      <span className="sr-only">{t('gcweb:data-table.pagination.more-pages', { defaultValue: 'More pages' })}</span>
     </span>
   );
 }

--- a/frontend/app/components/pagination.tsx
+++ b/frontend/app/components/pagination.tsx
@@ -59,11 +59,12 @@ function PaginationPrevious({ className, children, ...props }: ComponentProps<ty
 
 // Next page button (uses FontAwesome right chevron)
 function PaginationNext({ className, children, ...props }: ComponentProps<typeof Button>) {
+  const { t } = useTranslation(['gcweb']);
   return (
     <Button
       type="button"
+      aria-label={t('gcweb:data-table.pagination.next-page', { defaultValue: 'Go to next page' })}
       variant="ghost"
-      aria-label="Go to next page"
       className={cn('h-8 border-hidden px-2 text-sm font-medium underline transition-colors duration-200', className)}
       {...props}
     >

--- a/frontend/app/components/pagination.tsx
+++ b/frontend/app/components/pagination.tsx
@@ -25,7 +25,7 @@ export function Pagination({ pageIndex, pageCount, onPageChange, className }: Pa
   return (
     <nav aria-label={t('gcweb:data-table.pagination.label', { defaultValue: 'Pagination' })} className={cn('px-2', className)}>
       {/* Current page and total for screen readers */}
-      <p className="sr-only">{t('gcweb:data-table.pagination.page-status', { index: pageIndex + 1, count: pageCount })}</p>
+      <p className="sr-only">{t('gcweb:data-table.pagination.page-info', { index: pageIndex + 1, count: pageCount })}</p>
       <ul className="flex items-center gap-2">
         {Array.from({ length: pageCount }, (_, i) => {
           const isCurrent = pageIndex === i;

--- a/frontend/app/routes/hr-advisor/employees.tsx
+++ b/frontend/app/routes/hr-advisor/employees.tsx
@@ -31,6 +31,7 @@ import { useFetcherState } from '~/hooks/use-fetcher-state';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/layout';
 import { formatDateTimeInZone } from '~/utils/date-utils';
+import { clampPageIndex } from '~/utils/math-utils';
 import { formString } from '~/utils/string-utils';
 import { extractValidationKey } from '~/utils/validation-utils';
 
@@ -294,16 +295,13 @@ export default function EmployeeDashboard({ loaderData, params }: Route.Componen
       <DataTable columns={columns} data={loaderData.profiles} showPagination={false} />
 
       <Pagination
-        pageIndex={Math.min(
-          Math.max(0, loaderData.page.totalPages - 1),
-          Math.max(0, (Number.parseInt(searchParams.get('page') ?? '1', 10) || 1) - 1),
-        )}
+        pageIndex={clampPageIndex((Number.parseInt(searchParams.get('page') ?? '1', 10) || 1) - 1, loaderData.page.totalPages)}
         pageCount={loaderData.page.totalPages}
         onPageChange={(nextIndex) => {
           const filter = searchParams.get('filter') ?? 'all';
           const size = searchParams.get('size') ?? '10';
-          const clamped = Math.min(Math.max(0, nextIndex), Math.max(0, loaderData.page.totalPages - 1));
-          setSearchParams({ filter, page: String(clamped + 1), size });
+          const clampedIndex = clampPageIndex(nextIndex, loaderData.page.totalPages);
+          setSearchParams({ filter, page: String(clampedIndex + 1), size });
         }}
         className="my-4"
       />

--- a/frontend/app/routes/hr-advisor/employees.tsx
+++ b/frontend/app/routes/hr-advisor/employees.tsx
@@ -31,7 +31,7 @@ import { useFetcherState } from '~/hooks/use-fetcher-state';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/layout';
 import { formatDateTimeInZone } from '~/utils/date-utils';
-import { getCurrentPage, getPageItems } from '~/utils/pagination-utils';
+import { getCurrentPage, getPageItems, makePageClickHandler, nextPage, prevPage } from '~/utils/pagination-utils';
 import { formString } from '~/utils/string-utils';
 import { extractValidationKey } from '~/utils/validation-utils';
 
@@ -166,6 +166,9 @@ export default function EmployeeDashboard({ loaderData, params }: Route.Componen
   const totalPages = loaderData.page.totalPages;
   const currentPage = getCurrentPage(searchParams, 'page', totalPages);
   const pageItems = getPageItems(totalPages, currentPage, { threshold: 9, delta: 2 });
+
+  // Navigation helpers
+  const handlePageClick = (target: number) => makePageClickHandler(searchParams, setSearchParams, target);
 
   const columns: ColumnDef<Profile>[] = [
     {
@@ -310,16 +313,7 @@ export default function EmployeeDashboard({ loaderData, params }: Route.Componen
           <Pagination.Content>
             {/* Previous */}
             <Pagination.Item>
-              <Pagination.Previous
-                disabled={currentPage <= 1}
-                onClick={(e) => {
-                  e.preventDefault();
-                  const target = Math.max(1, currentPage - 1);
-                  const next = new URLSearchParams(searchParams);
-                  next.set('page', String(target));
-                  setSearchParams(next);
-                }}
-              />
+              <Pagination.Previous disabled={currentPage <= 1} onClick={handlePageClick(prevPage(currentPage))} />
             </Pagination.Item>
 
             {/* Page numbers */}
@@ -342,12 +336,7 @@ export default function EmployeeDashboard({ loaderData, params }: Route.Componen
                         ? t('gcweb:data-table.pagination.page-button-current', { index: p })
                         : t('gcweb:data-table.pagination.page-button-go-to', { index: p })
                     }
-                    onClick={(e) => {
-                      e.preventDefault();
-                      const next = new URLSearchParams(searchParams);
-                      next.set('page', String(p));
-                      setSearchParams(next);
-                    }}
+                    onClick={handlePageClick(p)}
                   >
                     {p}
                   </Pagination.Link>
@@ -359,13 +348,7 @@ export default function EmployeeDashboard({ loaderData, params }: Route.Componen
             <Pagination.Item>
               <Pagination.Next
                 disabled={currentPage >= totalPages}
-                onClick={(e) => {
-                  e.preventDefault();
-                  const target = Math.min(totalPages, currentPage + 1);
-                  const next = new URLSearchParams(searchParams);
-                  next.set('page', String(target));
-                  setSearchParams(next);
-                }}
+                onClick={handlePageClick(nextPage(currentPage, totalPages))}
               />
             </Pagination.Item>
           </Pagination.Content>

--- a/frontend/app/routes/hr-advisor/employees.tsx
+++ b/frontend/app/routes/hr-advisor/employees.tsx
@@ -295,6 +295,7 @@ export default function EmployeeDashboard({ loaderData, params }: Route.Componen
         data={loaderData.profiles}
         serverPagination={{
           // Derive 0-based index from URL 'page' (1-based in URL/backend) and clamp to range
+          // React Table requires pageIndex to be 0-based
           pageIndex: Math.min(
             Math.max(0, loaderData.page.totalPages - 1),
             Math.max(0, (Number.parseInt(searchParams.get('page') ?? '1', 10) || 1) - 1),

--- a/frontend/app/routes/hr-advisor/employees.tsx
+++ b/frontend/app/routes/hr-advisor/employees.tsx
@@ -24,6 +24,7 @@ import { InputSelect } from '~/components/input-select';
 import { InlineLink } from '~/components/links';
 import { LoadingButton } from '~/components/loading-button';
 import { PageTitle } from '~/components/page-title';
+import { Pagination } from '~/components/pagination';
 import { PROFILE_STATUS_CODE } from '~/domain/constants';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
 import { useFetcherState } from '~/hooks/use-fetcher-state';
@@ -290,25 +291,21 @@ export default function EmployeeDashboard({ loaderData, params }: Route.Componen
         {srAnnouncement}
       </div>
 
-      <DataTable
-        columns={columns}
-        data={loaderData.profiles}
-        serverPagination={{
-          // Derive 0-based index from URL 'page' (1-based in URL/backend) and clamp to range
-          // React Table requires pageIndex to be 0-based
-          pageIndex: Math.min(
-            Math.max(0, loaderData.page.totalPages - 1),
-            Math.max(0, (Number.parseInt(searchParams.get('page') ?? '1', 10) || 1) - 1),
-          ),
-          pageCount: loaderData.page.totalPages,
-          onPageChange: (nextIndex) => {
-            const filter = searchParams.get('filter') ?? 'all';
-            const size = searchParams.get('size') ?? '10';
-            const clamped = Math.min(Math.max(0, nextIndex), Math.max(0, loaderData.page.totalPages - 1));
-            // Write 1-based page to URL
-            setSearchParams({ filter, page: String(clamped + 1), size });
-          },
+      <DataTable columns={columns} data={loaderData.profiles} showPagination={false} />
+
+      <Pagination
+        pageIndex={Math.min(
+          Math.max(0, loaderData.page.totalPages - 1),
+          Math.max(0, (Number.parseInt(searchParams.get('page') ?? '1', 10) || 1) - 1),
+        )}
+        pageCount={loaderData.page.totalPages}
+        onPageChange={(nextIndex) => {
+          const filter = searchParams.get('filter') ?? 'all';
+          const size = searchParams.get('size') ?? '10';
+          const clamped = Math.min(Math.max(0, nextIndex), Math.max(0, loaderData.page.totalPages - 1));
+          setSearchParams({ filter, page: String(clamped + 1), size });
         }}
+        className="my-4"
       />
     </div>
   );

--- a/frontend/app/routes/hr-advisor/employees.tsx
+++ b/frontend/app/routes/hr-advisor/employees.tsx
@@ -31,7 +31,6 @@ import { useFetcherState } from '~/hooks/use-fetcher-state';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/layout';
 import { formatDateTimeInZone } from '~/utils/date-utils';
-import { clampPageIndex } from '~/utils/math-utils';
 import { formString } from '~/utils/string-utils';
 import { extractValidationKey } from '~/utils/validation-utils';
 
@@ -294,17 +293,11 @@ export default function EmployeeDashboard({ loaderData, params }: Route.Componen
 
       <DataTable columns={columns} data={loaderData.profiles} showPagination={false} />
 
-      <Pagination
-        pageIndex={clampPageIndex((Number.parseInt(searchParams.get('page') ?? '1', 10) || 1) - 1, loaderData.page.totalPages)}
-        pageCount={loaderData.page.totalPages}
-        onPageChange={(nextIndex) => {
-          const filter = searchParams.get('filter') ?? 'all';
-          const size = searchParams.get('size') ?? '10';
-          const clampedIndex = clampPageIndex(nextIndex, loaderData.page.totalPages);
-          setSearchParams({ filter, page: String(clampedIndex + 1), size });
-        }}
-        className="my-4"
-      />
+      <Pagination pageCount={loaderData.page.totalPages} className="my-4">
+        <Pagination.Previous />
+        <Pagination.Pages />
+        <Pagination.Next />
+      </Pagination>
     </div>
   );
 }

--- a/frontend/app/utils/math-utils.ts
+++ b/frontend/app/utils/math-utils.ts
@@ -1,0 +1,13 @@
+/** Clamp a number between min and max. If value is NaN, returns min. */
+export function clamp(value: number, min: number, max: number): number {
+  if (Number.isNaN(value)) return min;
+  const lower = Math.min(min, max);
+  const upper = Math.max(min, max);
+  return Math.min(Math.max(value, lower), upper);
+}
+
+/** Clamp a 0-based page index to a valid range given totalPages. */
+export function clampPageIndex(indexZeroBased: number, totalPages: number): number {
+  const maxIndex = Math.max(0, totalPages - 1);
+  return clamp(indexZeroBased, 0, maxIndex);
+}

--- a/frontend/app/utils/math-utils.ts
+++ b/frontend/app/utils/math-utils.ts
@@ -5,9 +5,3 @@ export function clamp(value: number, min: number, max: number): number {
   const upper = Math.max(min, max);
   return Math.min(Math.max(value, lower), upper);
 }
-
-/** Clamp a 0-based page index to a valid range given totalPages. */
-export function clampPageIndex(indexZeroBased: number, totalPages: number): number {
-  const maxIndex = Math.max(0, totalPages - 1);
-  return clamp(indexZeroBased, 0, maxIndex);
-}

--- a/frontend/app/utils/pagination-utils.ts
+++ b/frontend/app/utils/pagination-utils.ts
@@ -1,3 +1,7 @@
+import type React from 'react';
+
+import { clamp } from '~/utils/math-utils';
+
 /**
  * Returns a 1-based current page number clamped to [1, totalPages].
  */
@@ -43,4 +47,49 @@ export function getPageItems(
 
   items.push(last);
   return items;
+}
+
+/**
+ * Returns a new URLSearchParams with the page parameter set to the provided target (no clamping).
+ */
+export function getNextSearchParamsForPage(
+  searchParams: URLSearchParams,
+  targetPage: number,
+  paramName = 'page',
+): URLSearchParams {
+  const next = new URLSearchParams(searchParams);
+  next.set(paramName, String(targetPage));
+  return next;
+}
+
+/**
+ * Factory for a click handler that updates the page query string parameter.
+ * Captures the provided searchParams at creation time similar to inline handlers.
+ */
+export function makePageClickHandler(
+  searchParams: URLSearchParams,
+  setSearchParams: (nextInit: URLSearchParams) => void,
+  targetPage: number,
+  paramName = 'page',
+) {
+  return (e: React.MouseEvent) => {
+    e.preventDefault();
+    const next = getNextSearchParamsForPage(searchParams, targetPage, paramName);
+    setSearchParams(next);
+  };
+}
+
+/** Clamp a page to the inclusive range [1, totalPages]. */
+export function clampPage(page: number, totalPages: number): number {
+  return clamp(page, 1, Math.max(1, totalPages));
+}
+
+/** Previous page, clamped to 1. */
+export function prevPage(currentPage: number): number {
+  return Math.max(1, currentPage - 1);
+}
+
+/** Next page, clamped to totalPages. */
+export function nextPage(currentPage: number, totalPages: number): number {
+  return clampPage(currentPage + 1, totalPages);
 }

--- a/frontend/app/utils/pagination-utils.ts
+++ b/frontend/app/utils/pagination-utils.ts
@@ -1,0 +1,46 @@
+/**
+ * Returns a 1-based current page number clamped to [1, totalPages].
+ */
+export function getCurrentPage(
+  searchParams: URLSearchParams,
+  paramName = 'page',
+  totalPages = Number.POSITIVE_INFINITY,
+): number {
+  const raw = searchParams.get(paramName);
+  const n = Math.max(1, Number.parseInt(raw ?? '1', 10) || 1);
+  const upper = Math.max(1, Number.isFinite(totalPages) ? totalPages : Number.MAX_SAFE_INTEGER);
+  return Math.min(n, upper);
+}
+
+/**
+ * Build a compact pagination item list with optional ellipses.
+ * When totalPages <= threshold, returns [1..totalPages].
+ * When totalPages > threshold, returns: [1, ..., window..., ..., totalPages].
+ *
+ * @returns array containing page numbers and the string 'ellipsis'
+ */
+export function getPageItems(
+  totalPages: number,
+  currentPage: number,
+  options?: { delta?: number; threshold?: number },
+): (number | 'ellipsis')[] {
+  const threshold = options?.threshold ?? 9;
+  const delta = options?.delta ?? 2; // pages around current
+
+  if (totalPages <= 1) return [1];
+  if (totalPages <= threshold) return Array.from({ length: totalPages }, (_, i) => i + 1);
+
+  const first = 1;
+  const last = totalPages;
+  const items: (number | 'ellipsis')[] = [first];
+
+  const left = Math.max(first + 1, currentPage - delta);
+  const right = Math.min(last - 1, currentPage + delta);
+
+  if (left > first + 1) items.push('ellipsis');
+  for (let i = left; i <= right; i++) items.push(i);
+  if (right < last - 1) items.push('ellipsis');
+
+  items.push(last);
+  return items;
+}


### PR DESCRIPTION
Addresses [BUG 6837](https://dev.azure.com/DTS-STN/VacMan/_boards/board/t/VacMan%20Team/Stories?System.IterationPath=VacMan%5CCurrent%20Work%2CVacMan%5CMVP%20-%20GET%20IT%20DONE%2CVacMan%5CMVP%20Iteration%202&workitem=6837)

This pull request introduces a reusable, accessible pagination component and integrates server-side pagination into the HR Advisor Employees dashboard. It also improves locale support for pagination labels and adds utility functions for pagination logic. The changes enhance the user experience for large datasets and provide better accessibility and internationalization.

**Pagination component and utilities**

* Added a new reusable `Pagination` component (`frontend/app/components/pagination.tsx`) with accessible markup, customizable subcomponents, and screen reader support for navigation and ellipsis.
* Created pagination utility functions (`frontend/app/utils/pagination-utils.ts`) for page calculation, navigation, and compact page item display with ellipses.
* Added a general-purpose `clamp` function to `math-utils.ts` for safely bounding numeric values.

**HR Advisor Employees dashboard integration**

* Refactored the HR Advisor Employees dashboard (`frontend/app/routes/hr-advisor/employees.tsx`) to use server-side pagination, updating loader logic, URL search params, and rendering the new pagination UI below the table. [[1]](diffhunk://#diff-c9e3632f5b380d7e64f31440fe26de52f5f8bf52b270c9f42e6ca754206ca755R86-R99) [[2]](diffhunk://#diff-c9e3632f5b380d7e64f31440fe26de52f5f8bf52b270c9f42e6ca754206ca755R126) [[3]](diffhunk://#diff-c9e3632f5b380d7e64f31440fe26de52f5f8bf52b270c9f42e6ca754206ca755L126-R140) [[4]](diffhunk://#diff-c9e3632f5b380d7e64f31440fe26de52f5f8bf52b270c9f42e6ca754206ca755R165-R172) [[5]](diffhunk://#diff-c9e3632f5b380d7e64f31440fe26de52f5f8bf52b270c9f42e6ca754206ca755L259-R285) [[6]](diffhunk://#diff-c9e3632f5b380d7e64f31440fe26de52f5f8bf52b270c9f42e6ca754206ca755L279-R356)
* Modified the `DataTable` component to allow disabling its built-in pagination UI, enabling external pagination control. [[1]](diffhunk://#diff-a1c20a4ce08812c4dd92eb3949001cc7dac02afe22ce55b43fb246fa7fe78beaR24-R28) [[2]](diffhunk://#diff-a1c20a4ce08812c4dd92eb3949001cc7dac02afe22ce55b43fb246fa7fe78beaL35-R39) [[3]](diffhunk://#diff-a1c20a4ce08812c4dd92eb3949001cc7dac02afe22ce55b43fb246fa7fe78beaR106-R110)

**Localization improvements**

* Updated English and French locale files (`gcweb-en.ts`, `gcweb-fr.ts`) with new and revised pagination labels for improved accessibility and clarity. [[1]](diffhunk://#diff-3ff5c497124df65a907bf39e75c074666731ce4420420b5554b66cd8e86833bdR90-R102) [[2]](diffhunk://#diff-6abebf11f63fb7b28cb0190ede327b75e2edb81ed23000243c0f23ec9c8cb38bR92-R104)