### PR TITLE
bug fix(frontend): fix hr advisor redirect from employee dashboard

### DIFF
--- a/frontend/app/routes/employee/index.tsx
+++ b/frontend/app/routes/employee/index.tsx
@@ -31,14 +31,14 @@ export async function loader({ context, request }: Route.LoaderArgs) {
   if (currentUser.isNone()) {
     const language = await getLanguageForCorrespondenceService().findById(LANGUAGE_ID[getLanguage(request) ?? 'en']);
     await getUserService().registerCurrentUser({ languageId: language.unwrap().id }, context.session.authState.accessToken);
-
-    // create a profile if and only if there are no active profiles found for the current user
-    const profileService = getProfileService();
-    const profileResult = await profileService.getCurrentUserProfiles({ active: true }, context.session.authState.accessToken);
-    if (profileResult.into()?.content.length === 0) {
-      await profileService.registerProfile(context.session.authState.accessToken);
-    }
   }
+  // create a profile if and only if there are no active profiles found for the current user
+  const profileService = getProfileService();
+  const profileResult = await profileService.getCurrentUserProfiles({ active: true }, context.session.authState.accessToken);
+  if (profileResult.into()?.content.length === 0) {
+    await profileService.registerProfile(context.session.authState.accessToken);
+  }
+
   const { t } = await getTranslation(request, handle.i18nNamespace);
   return {
     documentTitle: t('app:employee-dashboard.page-title'),


### PR DESCRIPTION
## Summary

run the frontend connected with the api locally,
Issue fixed:  you are navigated to the hr-advisor dashboard because of your role. Navigate to the /employees route, clicking on 'View my profile' would redirect you to the hr-advisor screen instead of showing the "Privacy statement" screen. 
The problem was that when you first time login, the user was created, but profile wasn't created for you as you navigated to the hr-advisor screen first. 

## Types of changes

What types of changes does this PR introduce?

- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
