### PR TITLE
refactor(frontend) Complete request page position information card

### DIFF
--- a/frontend/app/routes/hiring-manager/request/index.tsx
+++ b/frontend/app/routes/hiring-manager/request/index.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 
 import type { Route } from './+types/index';
 
+import { getCityService } from '~/.server/domain/services/city-service';
 //import { getCityService } from '~/.server/domain/services/city-service';
 //import { getClassificationService } from '~/.server/domain/services/classification-service';
 import { getRequestService } from '~/.server/domain/services/request-service';
@@ -23,6 +24,7 @@ import { PageTitle } from '~/components/page-title';
 import { ProfileCard } from '~/components/profile-card';
 import { Progress } from '~/components/progress';
 import { StatusTag } from '~/components/status-tag';
+import { LANGUAGE_REQUIREMENT_CODES } from '~/domain/constants';
 //import { PROFILE_STATUS_CODE, EMPLOYEE_WFA_STATUS } from '~/domain/constants';
 import { useFetcherState } from '~/hooks/use-fetcher-state';
 import { getTranslation } from '~/i18n-config.server';
@@ -155,6 +157,8 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
   const url = new URL(request.url);
   const hasRequestChanged = url.searchParams.get('edited') === 'true';
 
+  const allLocalizedCities = await getCityService().listAllLocalized(lang);
+
   //
   // TODO review next section remove what is not needed
 
@@ -235,7 +239,25 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
     securityClearance: currentRequest?.securityClearance,
   };
 
-  const requiredPositionInformation = positionInformationData;
+  const languageProficiencyRequired =
+    currentRequest?.languageRequirement?.code === LANGUAGE_REQUIREMENT_CODES.bilingualImperative ||
+    currentRequest?.languageRequirement?.code === LANGUAGE_REQUIREMENT_CODES.bilingualNonImperative;
+
+  const requiredPositionInformation = {
+    positionNumber: positionInformationData.positionNumber,
+    classification: positionInformationData.classification,
+    englishTitle: positionInformationData.englishTitle,
+    frenchTitle: positionInformationData.frenchTitle,
+    cities: positionInformationData.cities,
+    languageRequirement: positionInformationData.languageRequirement,
+    securityClearance: positionInformationData.securityClearance,
+    ...(languageProficiencyRequired
+      ? {
+          englishLanguageProfile: positionInformationData.englishLanguageProfile,
+          frenchLanguageProfile: positionInformationData.frenchLanguageProfile,
+        }
+      : {}),
+  };
   const positionInformationCompleted = countCompletedItems(requiredPositionInformation);
   const positionInformationTotalFields = Object.keys(requiredPositionInformation).length;
 
@@ -291,6 +313,7 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
     statementOfMeritCriteriaInformationTotalFields +
     submissionInformationTotalFields;
   const amountCompleted = (profileCompleted / profileTotalFields) * 100;
+  const cities = currentRequest?.cities?.map((city) => allLocalizedCities.find((c) => c.id === city.id)).filter(Boolean);
 
   return {
     documentTitle: t('app:hiring-manager-referral-requests.page-title'),
@@ -327,7 +350,7 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
     classification: currentRequest?.classification,
     englishTitle: currentRequest?.englishTitle,
     frenchTitle: currentRequest?.frenchTitle,
-    cities: currentRequest?.cities,
+    cities: cities?.map((city) => city?.provinceTerritory.name + ' - ' + city?.name),
     languageRequirement: currentRequest?.languageRequirement,
     englishLanguageProfile: currentRequest?.englishLanguageProfile,
     frenchLanguageProfile: currentRequest?.frenchLanguageProfile,
@@ -579,22 +602,28 @@ export default function EditRequest({ loaderData, params }: Route.ComponentProps
                     {loaderData.frenchTitle ?? t('app:hiring-manager-referral-requests.not-provided')}
                   </DescriptionListItem>
 
-                  {/* TODO review  formatting and contents */}
-                  {/* <DescriptionListItem term={t('app:position-information.location-city')}>
-                    {loaderData.cities ?? t('app:hiring-manager-referral-requests.not-provided')}
-                  </DescriptionListItem> */}
+                  <DescriptionListItem term={t('app:position-information.locations')}>
+                    {loaderData.cities === undefined
+                      ? t('app:hiring-manager-referral-requests.not-provided')
+                      : loaderData.cities.length > 0 && loaderData.cities.join(', ')}
+                  </DescriptionListItem>
 
                   <DescriptionListItem term={t('app:position-information.language-profile')}>
                     {loaderData.languageRequirement?.code ?? t('app:hiring-manager-referral-requests.not-provided')}
                   </DescriptionListItem>
 
-                  <DescriptionListItem term={t('app:position-information.english')}>
-                    {loaderData.englishLanguageProfile ?? t('app:hiring-manager-referral-requests.not-provided')}
-                  </DescriptionListItem>
+                  {loaderData.languageRequirement?.code === LANGUAGE_REQUIREMENT_CODES.bilingualImperative ||
+                    (loaderData.languageRequirement?.code === LANGUAGE_REQUIREMENT_CODES.bilingualNonImperative && (
+                      <>
+                        <DescriptionListItem term={t('app:position-information.english')}>
+                          {loaderData.englishLanguageProfile ?? t('app:hiring-manager-referral-requests.not-provided')}
+                        </DescriptionListItem>
 
-                  <DescriptionListItem term={t('app:position-information.french')}>
-                    {loaderData.frenchLanguageProfile ?? t('app:hiring-manager-referral-requests.not-provided')}
-                  </DescriptionListItem>
+                        <DescriptionListItem term={t('app:position-information.french')}>
+                          {loaderData.frenchLanguageProfile ?? t('app:hiring-manager-referral-requests.not-provided')}
+                        </DescriptionListItem>
+                      </>
+                    ))}
 
                   <DescriptionListItem term={t('app:position-information.security-requirement')}>
                     {loaderData.securityClearance?.code ?? t('app:hiring-manager-referral-requests.not-provided')}

--- a/frontend/app/routes/hiring-manager/request/index.tsx
+++ b/frontend/app/routes/hiring-manager/request/index.tsx
@@ -8,7 +8,6 @@ import { useTranslation } from 'react-i18next';
 import type { Route } from './+types/index';
 
 import { getCityService } from '~/.server/domain/services/city-service';
-// import { getClassificationService } from '~/.server/domain/services/classification-service';
 import { getRequestService } from '~/.server/domain/services/request-service';
 // TODO review
 
@@ -611,18 +610,18 @@ export default function EditRequest({ loaderData, params }: Route.ComponentProps
                     {loaderData.languageRequirement?.code ?? t('app:hiring-manager-referral-requests.not-provided')}
                   </DescriptionListItem>
 
-                  {loaderData.languageRequirement?.code === LANGUAGE_REQUIREMENT_CODES.bilingualImperative ||
-                    (loaderData.languageRequirement?.code === LANGUAGE_REQUIREMENT_CODES.bilingualNonImperative && (
-                      <>
-                        <DescriptionListItem term={t('app:position-information.english')}>
-                          {loaderData.englishLanguageProfile ?? t('app:hiring-manager-referral-requests.not-provided')}
-                        </DescriptionListItem>
+                  {(loaderData.languageRequirement?.code === LANGUAGE_REQUIREMENT_CODES.bilingualImperative ||
+                    loaderData.languageRequirement?.code === LANGUAGE_REQUIREMENT_CODES.bilingualNonImperative) && (
+                    <>
+                      <DescriptionListItem term={t('app:position-information.english')}>
+                        {loaderData.englishLanguageProfile ?? t('app:hiring-manager-referral-requests.not-provided')}
+                      </DescriptionListItem>
 
-                        <DescriptionListItem term={t('app:position-information.french')}>
-                          {loaderData.frenchLanguageProfile ?? t('app:hiring-manager-referral-requests.not-provided')}
-                        </DescriptionListItem>
-                      </>
-                    ))}
+                      <DescriptionListItem term={t('app:position-information.french')}>
+                        {loaderData.frenchLanguageProfile ?? t('app:hiring-manager-referral-requests.not-provided')}
+                      </DescriptionListItem>
+                    </>
+                  )}
 
                   <DescriptionListItem term={t('app:position-information.security-requirement')}>
                     {loaderData.securityClearance?.code ?? t('app:hiring-manager-referral-requests.not-provided')}

--- a/frontend/app/routes/hiring-manager/request/index.tsx
+++ b/frontend/app/routes/hiring-manager/request/index.tsx
@@ -8,8 +8,7 @@ import { useTranslation } from 'react-i18next';
 import type { Route } from './+types/index';
 
 import { getCityService } from '~/.server/domain/services/city-service';
-//import { getCityService } from '~/.server/domain/services/city-service';
-//import { getClassificationService } from '~/.server/domain/services/classification-service';
+// import { getClassificationService } from '~/.server/domain/services/classification-service';
 import { getRequestService } from '~/.server/domain/services/request-service';
 // TODO review
 


### PR DESCRIPTION
## Summary

[AB#6837](https://dev.azure.com/DTS-STN/4c33b941-c811-479f-b181-dfd5292182ff/_workitems/edit/6837)
Show all fields in the position information card on hiring-manager request page. added logic to handle the language profile fields.

## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
_(check all that apply by placing an `x` in the relevant boxes)_

- [ ] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
