### PR TITLE
refactor(frontend): remove search button from request submission details

### DIFF
--- a/frontend/app/.server/domain/services/mock-data.ts
+++ b/frontend/app/.server/domain/services/mock-data.ts
@@ -432,7 +432,7 @@ export const mockRequests: RequestReadModel[] = [
     },
     workUnit: undefined,
     submitter: mockUsers[0], // John Doe
-    hiringManager: mockUsers[0], // John Doe
+    hiringManager: mockUsers[3], // Bob Johnson
     subDelegatedManager: mockUsers[0], // John Doe
     hrAdvisor: mockUsers[3], // Bob Johnson
     languageOfCorrespondence: undefined,

--- a/frontend/app/.server/locales/app-en.ts
+++ b/frontend/app/.server/locales/app-en.ts
@@ -396,7 +396,6 @@ export default {
     'directorate': 'Directorate',
     'preferred-language-of-correspondence': 'Preferred language for correspondence',
     'additional-comments': 'Additional comments',
-    'search': 'Search',
     // TODO: error messages need to be updated when available
     'errors': {
       'is-submitter-hiring-manager-required': 'Is submitter the hiring manager for this request field is required.',

--- a/frontend/app/.server/locales/app-fr.ts
+++ b/frontend/app/.server/locales/app-fr.ts
@@ -400,7 +400,6 @@ export default {
     'directorate': 'Direction',
     'preferred-language-of-correspondence': 'Langue de préférene pour la correspondance',
     'additional-comments': 'Commentaires additionnels',
-    'search': 'Rechercher',
     // TODO: error messages need to be updated when available
     'errors': {
       'is-submitter-hiring-manager-required': 'Is submitter the hiring manager for this request field is required.',

--- a/frontend/app/routes/hiring-manager/request/submission-details.tsx
+++ b/frontend/app/routes/hiring-manager/request/submission-details.tsx
@@ -36,99 +36,34 @@ export async function action({ context, params, request }: Route.ActionArgs) {
 
   const formData = await request.formData();
 
-  const action = formData.get('action');
+  const parseResult = v.safeParse(await createSubmissionDetailSchema('hiring-manager'), {
+    isSubmiterHiringManager: formData.get('isSubmiterHiringManager')
+      ? formData.get('isSubmiterHiringManager') === REQUIRE_OPTIONS.yes
+      : undefined,
+    isSubmiterSubdelegate: formData.get('isSubmiterSubdelegate')
+      ? formData.get('isSubmiterSubdelegate') === REQUIRE_OPTIONS.yes
+      : undefined,
+    isHiringManagerASubDelegate: formData.get('isHiringManagerASubDelegate')
+      ? formData.get('isHiringManagerASubDelegate') === REQUIRE_OPTIONS.yes
+      : undefined,
+    hiringManagerEmailAddress: formString(formData.get('hiringManagerEmailAddress')),
+    subDelegatedManagerEmailAddress: formString(formData.get('subDelegatedManagerEmailAddress')),
+    branchOrServiceCanadaRegion: formString(formData.get('branchOrServiceCanadaRegion')),
+    directorate: formString(formData.get('directorate')),
+    languageOfCorrespondenceId: formString(formData.get('languageOfCorrespondenceId')),
+    additionalComment: formString(formData.get('additionalComment')),
+  });
 
-  if (action === 'searchHiringManagerEmailAddress') {
-    const parseResult = v.safeParse(
-      v.object({
-        hiringManagerEmailAddress: v.pipe(
-          v.string('app:submission-details.errors.hiring-manager-email-required'),
-          v.trim(),
-          v.nonEmpty('app:submission-details.errors.hiring-manager-email-required'),
-          v.email('app:submission-details.errors.hiring-manager-email-invalid'),
-        ),
-      }),
-      {
-        hiringManagerEmailAddress: formString(formData.get('hiringManagerEmailAddress')),
-      },
+  if (!parseResult.success) {
+    return data(
+      { errors: v.flatten<SubmissionDetailSchema>(parseResult.issues).nested },
+      { status: HttpStatusCodes.BAD_REQUEST },
     );
-
-    if (!parseResult.success) {
-      return {
-        errors: v.flatten(parseResult.issues).nested,
-      };
-    }
-
-    const userResult = await getUserService().getUsers(
-      { email: parseResult.output.hiringManagerEmailAddress },
-      context.session.authState.accessToken,
-    );
-    const hiringManager = userResult.into()?.content[0];
-    const hiringManagerName = `${hiringManager?.firstName ?? ''} ${hiringManager?.lastName ?? ''}`.trim();
-    return { hiringManagerName };
   }
 
-  if (action === 'searchSubDelegatedManagerEmailAddress') {
-    const parseResult = v.safeParse(
-      v.object({
-        subDelegatedManagerEmailAddress: v.pipe(
-          v.string('app:submission-details.errors.sub-delegate-email-required'),
-          v.trim(),
-          v.nonEmpty('app:submission-details.errors.sub-delegate-email-required'),
-          v.email('app:submission-details.errors.sub-delegate-email-invalid'),
-        ),
-      }),
-      {
-        subDelegatedManagerEmailAddress: formString(formData.get('subDelegatedManagerEmailAddress')),
-      },
-    );
+  //TODO: call request service to update data
 
-    if (!parseResult.success) {
-      return {
-        errors: v.flatten(parseResult.issues).nested,
-      };
-    }
-
-    const userResult = await getUserService().getUsers(
-      { email: parseResult.output.subDelegatedManagerEmailAddress },
-      context.session.authState.accessToken,
-    );
-
-    const subDelegatedManager = userResult.into()?.content[0];
-    const subDelegatedManagerName = `${subDelegatedManager?.firstName ?? ''} ${subDelegatedManager?.lastName ?? ''}`.trim();
-    return { subDelegatedManagerName };
-  }
-
-  if (action === 'submit') {
-    const parseResult = v.safeParse(await createSubmissionDetailSchema('hiring-manager'), {
-      isSubmiterHiringManager: formData.get('isSubmiterHiringManager')
-        ? formData.get('isSubmiterHiringManager') === REQUIRE_OPTIONS.yes
-        : undefined,
-      isSubmiterSubdelegate: formData.get('isSubmiterSubdelegate')
-        ? formData.get('isSubmiterSubdelegate') === REQUIRE_OPTIONS.yes
-        : undefined,
-      isHiringManagerASubDelegate: formData.get('isHiringManagerASubDelegate')
-        ? formData.get('isHiringManagerASubDelegate') === REQUIRE_OPTIONS.yes
-        : undefined,
-      hiringManagerEmailAddress: formString(formData.get('hiringManagerEmailAddress')),
-      subDelegatedManagerEmailAddress: formString(formData.get('subDelegatedManagerEmailAddress')),
-      branchOrServiceCanadaRegion: formString(formData.get('branchOrServiceCanadaRegion')),
-      directorate: formString(formData.get('directorate')),
-      languageOfCorrespondenceId: formString(formData.get('languageOfCorrespondenceId')),
-      additionalComment: formString(formData.get('additionalComment')),
-    });
-
-    if (!parseResult.success) {
-      return data(
-        { errors: v.flatten<SubmissionDetailSchema>(parseResult.issues).nested },
-        { status: HttpStatusCodes.BAD_REQUEST },
-      );
-    }
-
-    //TODO: call request service to update data
-
-    return i18nRedirect('routes/hiring-manager/request/index.tsx', request, { params });
-  }
+  return i18nRedirect('routes/hiring-manager/request/index.tsx', request, { params });
 }
 
 export async function loader({ context, params, request }: Route.LoaderArgs) {
@@ -169,6 +104,7 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
 
 export default function HiringManagerRequestSubmissionDetails({ loaderData, actionData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespace);
+  const errors = actionData?.errors;
 
   return (
     <>
@@ -183,6 +119,7 @@ export default function HiringManagerRequestSubmissionDetails({ loaderData, acti
       <div className="max-w-prose">
         <SubmissionDetailsForm
           cancelLink="routes/hiring-manager/request/index.tsx"
+          formErrors={errors}
           formValues={loaderData.defaultValues}
           branchOrServiceCanadaRegions={loaderData.branchOrServiceCanadaRegions}
           directorates={loaderData.directorates}

--- a/frontend/app/routes/hr-advisor/request/submission-details.tsx
+++ b/frontend/app/routes/hr-advisor/request/submission-details.tsx
@@ -10,7 +10,6 @@ import type { RequestReadModel } from '~/.server/domain/models';
 import { getDirectorateService } from '~/.server/domain/services/directorate-service';
 import { getLanguageForCorrespondenceService } from '~/.server/domain/services/language-for-correspondence-service';
 import { getRequestService } from '~/.server/domain/services/request-service';
-import { getUserService } from '~/.server/domain/services/user-service';
 import { requireAuthentication } from '~/.server/utils/auth-utils';
 import { extractUniqueBranchesFromDirectorates } from '~/.server/utils/directorate-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
@@ -37,99 +36,34 @@ export async function action({ context, params, request }: Route.ActionArgs) {
 
   const formData = await request.formData();
 
-  const action = formData.get('action');
+  const parseResult = v.safeParse(await createSubmissionDetailSchema('hr-advisor'), {
+    isSubmiterHiringManager: formData.get('isSubmiterHiringManager')
+      ? formData.get('isSubmiterHiringManager') === REQUIRE_OPTIONS.yes
+      : undefined,
+    isSubmiterSubdelegate: formData.get('isSubmiterSubdelegate')
+      ? formData.get('isSubmiterSubdelegate') === REQUIRE_OPTIONS.yes
+      : undefined,
+    isHiringManagerASubDelegate: formData.get('isHiringManagerASubDelegate')
+      ? formData.get('isHiringManagerASubDelegate') === REQUIRE_OPTIONS.yes
+      : undefined,
+    hiringManagerEmailAddress: formString(formData.get('hiringManagerEmailAddress')),
+    subDelegatedManagerEmailAddress: formString(formData.get('subDelegatedManagerEmailAddress')),
+    branchOrServiceCanadaRegion: formString(formData.get('branchOrServiceCanadaRegion')),
+    directorate: formString(formData.get('directorate')),
+    languageOfCorrespondenceId: formString(formData.get('languageOfCorrespondenceId')),
+    additionalComment: formString(formData.get('additionalComment')),
+  });
 
-  if (action === 'searchHiringManagerEmailAddress') {
-    const parseResult = v.safeParse(
-      v.object({
-        hiringManagerEmailAddress: v.pipe(
-          v.string('app:submission-details.errors.hiring-manager-email-required'),
-          v.trim(),
-          v.nonEmpty('app:submission-details.errors.hiring-manager-email-required'),
-          v.email('app:submission-details.errors.hiring-manager-email-invalid'),
-        ),
-      }),
-      {
-        hiringManagerEmailAddress: formString(formData.get('hiringManagerEmailAddress')),
-      },
+  if (!parseResult.success) {
+    return data(
+      { errors: v.flatten<SubmissionDetailSchema>(parseResult.issues).nested },
+      { status: HttpStatusCodes.BAD_REQUEST },
     );
-
-    if (!parseResult.success) {
-      return {
-        errors: v.flatten(parseResult.issues).nested,
-      };
-    }
-
-    const userResult = await getUserService().getUsers(
-      { email: parseResult.output.hiringManagerEmailAddress },
-      context.session.authState.accessToken,
-    );
-    const hiringManager = userResult.into()?.content[0];
-    const hiringManagerName = `${hiringManager?.firstName ?? ''} ${hiringManager?.lastName ?? ''}`.trim();
-    return { hiringManagerName };
   }
 
-  if (action === 'searchSubDelegatedManagerEmailAddress') {
-    const parseResult = v.safeParse(
-      v.object({
-        subDelegatedManagerEmailAddress: v.pipe(
-          v.string('app:submission-details.errors.sub-delegate-email-required'),
-          v.trim(),
-          v.nonEmpty('app:submission-details.errors.sub-delegate-email-required'),
-          v.email('app:submission-details.errors.sub-delegate-email-invalid'),
-        ),
-      }),
-      {
-        subDelegatedManagerEmailAddress: formString(formData.get('subDelegatedManagerEmailAddress')),
-      },
-    );
+  //TODO: call request service to update data
 
-    if (!parseResult.success) {
-      return {
-        errors: v.flatten(parseResult.issues).nested,
-      };
-    }
-
-    const userResult = await getUserService().getUsers(
-      { email: parseResult.output.subDelegatedManagerEmailAddress },
-      context.session.authState.accessToken,
-    );
-
-    const subDelegatedManager = userResult.into()?.content[0];
-    const subDelegatedManagerName = `${subDelegatedManager?.firstName ?? ''} ${subDelegatedManager?.lastName ?? ''}`.trim();
-    return { subDelegatedManagerName };
-  }
-
-  if (action === 'submit') {
-    const parseResult = v.safeParse(await createSubmissionDetailSchema('hr-advisor'), {
-      isSubmiterHiringManager: formData.get('isSubmiterHiringManager')
-        ? formData.get('isSubmiterHiringManager') === REQUIRE_OPTIONS.yes
-        : undefined,
-      isSubmiterSubdelegate: formData.get('isSubmiterSubdelegate')
-        ? formData.get('isSubmiterSubdelegate') === REQUIRE_OPTIONS.yes
-        : undefined,
-      isHiringManagerASubDelegate: formData.get('isHiringManagerASubDelegate')
-        ? formData.get('isHiringManagerASubDelegate') === REQUIRE_OPTIONS.yes
-        : undefined,
-      hiringManagerEmailAddress: formString(formData.get('hiringManagerEmailAddress')),
-      subDelegatedManagerEmailAddress: formString(formData.get('subDelegatedManagerEmailAddress')),
-      branchOrServiceCanadaRegion: formString(formData.get('branchOrServiceCanadaRegion')),
-      directorate: formString(formData.get('directorate')),
-      languageOfCorrespondenceId: formString(formData.get('languageOfCorrespondenceId')),
-      additionalComment: formString(formData.get('additionalComment')),
-    });
-
-    if (!parseResult.success) {
-      return data(
-        { errors: v.flatten<SubmissionDetailSchema>(parseResult.issues).nested },
-        { status: HttpStatusCodes.BAD_REQUEST },
-      );
-    }
-
-    //TODO: call request service to update data
-
-    return i18nRedirect('routes/hr-advisor/request/index.tsx', request, { params });
-  }
+  return i18nRedirect('routes/hr-advisor/request/index.tsx', request, { params });
 }
 
 export async function loader({ context, params, request }: Route.LoaderArgs) {
@@ -174,6 +108,7 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
 
 export default function HiringManagerRequestSubmissionDetails({ loaderData, actionData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespace);
+  const errors = actionData?.errors;
 
   return (
     <>
@@ -188,6 +123,7 @@ export default function HiringManagerRequestSubmissionDetails({ loaderData, acti
       <div className="max-w-prose">
         <SubmissionDetailsForm
           cancelLink="routes/hr-advisor/request/index.tsx"
+          formErrors={errors}
           formValues={loaderData.defaultValues}
           branchOrServiceCanadaRegions={loaderData.branchOrServiceCanadaRegions}
           directorates={loaderData.directorates}


### PR DESCRIPTION
## Summary

[AB#6894](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6894/)
After discussion with the team, decided to removed search button from request submission details, so reverting those changes.
Keeping the name tags for submitter and hiring manager, which will be removed if the email is changed, see attached screen capture for the effect.

## Types of changes

What types of changes does this PR introduce?

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.

[Submission detail name tags.webm](https://github.com/user-attachments/assets/9f042ee2-fab3-4b1e-b7cd-68ff77579e7c)


