### PR TITLE
feat(frontend): add a splash page

### DIFF
--- a/frontend/app/i18n-routes.ts
+++ b/frontend/app/i18n-routes.ts
@@ -162,7 +162,7 @@ export const i18nRoutes = [
         file: 'routes/hr-advisor/index.tsx',
         paths: {
           en: '/en/hr-advisor',
-          fr: '/fr/hr-advisor',
+          fr: '/fr/conseiller-rh',
         },
       },
       {
@@ -170,7 +170,7 @@ export const i18nRoutes = [
         file: 'routes/hr-advisor/employees.tsx',
         paths: {
           en: '/en/hr-advisor/employees',
-          fr: '/fr/hr-advisor/employes',
+          fr: '/fr/conseiller-rh/employes',
         },
       },
       {
@@ -178,7 +178,7 @@ export const i18nRoutes = [
         file: 'routes/hr-advisor/employee-profile/index.tsx',
         paths: {
           en: '/en/hr-advisor/employee-profile/:profileId',
-          fr: '/fr/hr-advisor/employe-profil/:profileId',
+          fr: '/fr/conseiller-rh/employe-profil/:profileId',
         },
       },
       {
@@ -186,7 +186,7 @@ export const i18nRoutes = [
         file: 'routes/hr-advisor/employee-profile/personal-information.tsx',
         paths: {
           en: '/en/hr-advisor/employee-profile/personal-information/:profileId',
-          fr: '/fr/hr-advisor/employe-profil/informations-personnelles/:profileId',
+          fr: '/fr/conseiller-rh/employe-profil/informations-personnelles/:profileId',
         },
       },
       {
@@ -194,7 +194,7 @@ export const i18nRoutes = [
         file: 'routes/hr-advisor/employee-profile/employment-information.tsx',
         paths: {
           en: '/en/hr-advisor/employee-profile/employment-information/:profileId',
-          fr: '/fr/hr-advisor/employe-profil/informations-sur-lemploi/:profileId',
+          fr: '/fr/conseiller-rh/employe-profil/informations-sur-lemploi/:profileId',
         },
       },
       {
@@ -202,7 +202,7 @@ export const i18nRoutes = [
         file: 'routes/hr-advisor/employee-profile/referral-preferences.tsx',
         paths: {
           en: '/en/hr-advisor/employee-profile/referral-preferences/:profileId',
-          fr: '/fr/hr-advisor/employe-profil/preferences-de-presentation-de-canditure/:profileId',
+          fr: '/fr/conseiller-rh/employe-profil/preferences-de-presentation-de-canditure/:profileId',
         },
       },
       {

--- a/frontend/app/routes/index.tsx
+++ b/frontend/app/routes/index.tsx
@@ -1,19 +1,99 @@
+import type { RouteHandle } from 'react-router';
+
+import { useTranslation } from 'react-i18next';
+
 import type { Route } from './+types/index';
 
 import { requireAuthentication } from '~/.server/utils/auth-utils';
-import { i18nRedirect } from '~/.server/utils/route-utils';
+import { ButtonLink } from '~/components/button-link';
+import { AppLink } from '~/components/links';
+import { getFixedT } from '~/i18n-config.server';
 
-export function loader({ context, request }: Route.LoaderArgs) {
+export const handle = {
+  i18nNamespace: ['gcweb'],
+} as const satisfies RouteHandle;
+
+export async function loader({ context, request }: Route.LoaderArgs) {
   // First ensure the user is authenticated
   requireAuthentication(context.session, request);
+  const en = await getFixedT('en', handle.i18nNamespace);
+  const fr = await getFixedT('fr', handle.i18nNamespace);
+  return { documentTitle: `${en('header.govt-of-canada.text')} / ${fr('header.govt-of-canada.text')}` };
+}
 
-  // Get user roles from the access token claims
-  const userRoles = context.session.authState.accessTokenClaims.roles;
+export function meta({ loaderData }: Route.MetaArgs) {
+  return [{ title: loaderData.documentTitle }];
+}
 
-  // Redirect based on roles
-  if (userRoles?.includes('hr-advisor')) {
-    return i18nRedirect('routes/hr-advisor/index.tsx', request);
-  } else {
-    return i18nRedirect('routes/employee/index.tsx', request);
-  }
+export default function Index() {
+  const { i18n } = useTranslation(handle.i18nNamespace);
+  const en = i18n.getFixedT('en');
+  const fr = i18n.getFixedT('fr');
+
+  return (
+    <main role="main" className="bg-splash-page flex h-svh bg-cover bg-center">
+      <div className="m-auto w-[300px] bg-white md:w-[400px] lg:w-[500px]">
+        <div className="p-8">
+          <h1 className="sr-only">
+            <span lang="en">{en('gcweb:header.language-selection')}</span>
+            <span lang="fr">{fr('gcweb:header.language-selection')}</span>
+          </h1>
+          <div className="w-11/12 lg:w-8/12">
+            <AppLink to="https://www.canada.ca/en.html">
+              <img
+                className="h-8 w-auto"
+                src="https://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-en.svg"
+                alt={`${en('gcweb:footer.gc-symbol')} / ${fr('gcweb:footer.gc-symbol')}`}
+                width="300"
+                height="28"
+                decoding="async"
+              />
+            </AppLink>
+          </div>
+          <div className="mt-9 mb-2 grid grid-cols-2 gap-8 md:mx-4 lg:mx-8">
+            <section lang="en" className="text-center">
+              <h2 className="sr-only">{en('gcweb:header.govt-of-canada.text')}</h2>
+              <ButtonLink file="routes/employee/index.tsx" lang="en" variant="primary" size="lg" className="w-full">
+                {en('gcweb:language')}
+              </ButtonLink>
+            </section>
+            <section lang="fr" className="text-center">
+              <h2 className="sr-only">{fr('gcweb:header.govt-of-canada.text')}</h2>
+              <ButtonLink file="routes/employee/index.tsx" lang="fr" variant="primary" size="lg" className="w-full">
+                {fr('gcweb:language')}
+              </ButtonLink>
+            </section>
+          </div>
+        </div>
+        <div className="flex items-center justify-between gap-6 bg-gray-200 p-8">
+          <div className="w-7/12 md:w-8/12">
+            <AppLink
+              className="text-slate-700 hover:text-blue-700 hover:underline focus:text-blue-700"
+              to={en('gcweb:footer.terms-conditions.href')}
+              lang="en"
+            >
+              {en('gcweb:footer.terms-conditions.text')}
+            </AppLink>
+            <span className="text-gray-400"> • </span>
+            <AppLink
+              className="text-slate-700 hover:text-blue-700 hover:underline focus:text-blue-700"
+              to={fr('gcweb:footer.terms-conditions.href')}
+              lang="fr"
+            >
+              {fr('gcweb:footer.terms-conditions.text')}
+            </AppLink>
+          </div>
+          <div className="w-5/12 md:w-4/12">
+            <img
+              src="https://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg"
+              alt={`${en('gcweb:footer.gc-symbol')} / ${fr('gcweb:footer.gc-symbol')}`}
+              width={300}
+              height={71}
+              className="h-10 w-auto"
+            />
+          </div>
+        </div>
+      </div>
+    </main>
+  );
 }

--- a/frontend/e2e/index.spec.ts
+++ b/frontend/e2e/index.spec.ts
@@ -1,7 +1,23 @@
 import { expect, test } from '@playwright/test';
 
-test('Navigating to / routes to /en by default', async ({ page }) => {
-  await page.goto('/');
-  // The app should route to /en by default
-  await expect(page).toHaveURL(/\/en/);
+test.describe('Splash Page Language Selection', () => {
+  test('Navigating to / shows splash page and allows selection of English or Français', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.locator('h1.sr-only')).toContainText('Language selectionSélection de la langue');
+
+    // Click the English button
+    await page.locator('section[lang="en"] a:has-text("English")').click();
+
+    await expect(page).toHaveURL(/\/en/);
+  });
+
+  test('Navigating to / shows splash page and allows selection of French', async ({ page }) => {
+    await page.goto('/');
+
+    // Click the French button
+    await page.locator('section[lang="fr"] a:has-text("Français")').click();
+
+    await expect(page).toHaveURL(/\/fr/);
+  });
 });


### PR DESCRIPTION
## Summary

[AB#6971](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6971)
- add a splash page, that redirect English to /en/employee and Français to /fr/employe
- removed auto redirect for hr-advisor
- update the hr advisor route for French
- update the tests and e2e tests

## Types of changes

What types of changes does this PR introduce?

- [x] ✨ **new feature** -- non-breaking change that adds functionality

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
<img width="862" height="598" alt="image" src="https://github.com/user-attachments/assets/68aabf6a-35b8-48ba-aedb-bbbf8a0082f7" />
<img width="832" height="488" alt="image" src="https://github.com/user-attachments/assets/c6d688f7-4704-4432-8c43-74af2a7cc6d1" />

