### PR TITLE
Add the vmsNotRequired status change logic

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/RequestService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/RequestService.java
@@ -399,7 +399,7 @@ public class RequestService {
 		}
 
 		if (!requestStatuses.hrReview().equals(currentStatus)) {
-			throw new ResourceNotFoundException("Request must be in HR_REVIEW status to be marked as VMS not required");
+			throw new ResourceConflictException("Request must be in HR_REVIEW status to be marked as VMS not required");
 		}
 
 		// Set status to PENDING_PSC_NO_VMS

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/RequestService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/RequestService.java
@@ -211,6 +211,8 @@ public class RequestService {
 				handleRequestSubmitted(request, isOwner, currentStatus);
 			case "requestPickedUp" ->
 				handleRequestPickedUp(request, isHrAdvisor, currentStatus, currentUser);
+			case "vmsNotRequired" ->
+				handleVmsNotRequired(request, isHrAdvisor, currentStatus);
 			default ->
 				throw new IllegalArgumentException("Unknown event type: " + eventType);
 		};
@@ -381,6 +383,29 @@ public class RequestService {
 		log.info("Creating matches for request ID: [{}]", request.getId());
 
 		return true;
+	}
+
+	/**
+	 * Handles the vmsNotRequired event.
+	 * 
+	 * @param request The request entity
+	 * @param isHrAdvisor Whether the current user is an HR advisor
+	 * @param currentStatus The current status code of the request
+	 * @return The updated request entity
+	 */
+	private RequestEntity handleVmsNotRequired(RequestEntity request, boolean isHrAdvisor, String currentStatus) {
+		if (!isHrAdvisor) {
+			throw new UnauthorizedException("Only HR advisors can mark a request as VMS not required");
+		}
+
+		if (!requestStatuses.hrReview().equals(currentStatus)) {
+			throw new ResourceNotFoundException("Request must be in HR_REVIEW status to be marked as VMS not required");
+		}
+
+		// Set status to PENDING_PSC_NO_VMS
+		request.setRequestStatus(getRequestStatusByCode(requestStatuses.pendingPscClearanceNoVms()));
+
+		return request;
 	}
 
 }


### PR DESCRIPTION
## Summary

FROM [AB#6642](https://dev.azure.com/DTS-STN/4c33b941-c811-479f-b181-dfd5292182ff/_workitems/edit/6642):

```
If the event  is vmsNotRequired
   Requestor is in "hr-advisor" security group
   Current Status is HR_REVIEW
   If it is,
     then the status is set to PENDING_PSC_NO_VMS
   If not, should return a 404
```

## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [x] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
_(check all that apply by placing an `x` in the relevant boxes)_

- [ ] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes
- [ ] added adequate logging for new or updated functionality
- [ ] ensured metrics and/or tracing are in place for monitoring and debugging
- [ ] documentation has been updated to reflect the changes (if applicable)
- [ ] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
