### PR TITLE
refactor(frontend) consolidate actionData errors

### DIFF
--- a/frontend/app/routes/employee/profile/employment-information.tsx
+++ b/frontend/app/routes/employee/profile/employment-information.tsx
@@ -136,7 +136,6 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 
 export default function EmploymentInformation({ loaderData, actionData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespace);
-  const errors = actionData?.errors;
 
   return (
     <>
@@ -147,7 +146,7 @@ export default function EmploymentInformation({ loaderData, actionData, params }
         <EmploymentInformationForm
           cancelLink="routes/employee/profile/index.tsx"
           formValues={loaderData.defaultValues}
-          formErrors={errors}
+          formErrors={actionData?.errors}
           substantivePositions={loaderData.substantivePositions}
           branchOrServiceCanadaRegions={loaderData.branchOrServiceCanadaRegions}
           directorates={loaderData.directorates}

--- a/frontend/app/routes/employee/profile/personal-information.tsx
+++ b/frontend/app/routes/employee/profile/personal-information.tsx
@@ -155,7 +155,6 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 
 export default function PersonalInformation({ loaderData, actionData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespace);
-  const errors = actionData?.errors;
 
   return (
     <>
@@ -165,7 +164,7 @@ export default function PersonalInformation({ loaderData, actionData, params }: 
       <div className="max-w-prose">
         <PersonalInformationForm
           cancelLink="routes/employee/profile/index.tsx"
-          formErrors={errors}
+          formErrors={actionData?.errors}
           formValues={loaderData.defaultValues}
           isReadOnly={false}
           languagesOfCorrespondence={loaderData.languagesOfCorrespondence}

--- a/frontend/app/routes/employee/profile/referral-preferences.tsx
+++ b/frontend/app/routes/employee/profile/referral-preferences.tsx
@@ -144,7 +144,6 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 
 export default function PersonalDetails({ loaderData, actionData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespace);
-  const errors = actionData?.errors;
 
   return (
     <>
@@ -156,7 +155,7 @@ export default function PersonalDetails({ loaderData, actionData, params }: Rout
           cancelLink="routes/employee/profile/index.tsx"
           formValues={loaderData.defaultValues}
           preferredProvince={loaderData.defaultValues.preferredProvince}
-          formErrors={errors}
+          formErrors={actionData?.errors}
           languageReferralTypes={loaderData.languageReferralTypes}
           classifications={loaderData.classifications}
           provinces={loaderData.provinces}

--- a/frontend/app/routes/hiring-manager/request/position-information.tsx
+++ b/frontend/app/routes/hiring-manager/request/position-information.tsx
@@ -141,7 +141,6 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 
 export default function HiringManagerRequestPositionInformation({ loaderData, actionData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespace);
-  const errors = actionData?.errors;
 
   return (
     <>
@@ -156,7 +155,7 @@ export default function HiringManagerRequestPositionInformation({ loaderData, ac
       <div className="max-w-prose">
         <PositionInformationForm
           cancelLink="routes/hiring-manager/request/index.tsx"
-          formErrors={errors}
+          formErrors={actionData?.errors}
           formValues={loaderData.defaultValues}
           languageRequirements={loaderData.languageRequirements}
           classifications={loaderData.classifications}

--- a/frontend/app/routes/hiring-manager/request/somc-conditions.tsx
+++ b/frontend/app/routes/hiring-manager/request/somc-conditions.tsx
@@ -76,7 +76,6 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
 
 export default function HiringManagerRequestSomcConditions({ loaderData, actionData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespace);
-  const errors = actionData?.errors;
 
   return (
     <>
@@ -91,7 +90,7 @@ export default function HiringManagerRequestSomcConditions({ loaderData, actionD
       <div className="max-w-prose">
         <SomcConditionsForm
           cancelLink="routes/hiring-manager/request/index.tsx"
-          formErrors={errors}
+          formErrors={actionData?.errors}
           formValues={loaderData.defaultValues}
           params={params}
         />

--- a/frontend/app/routes/hiring-manager/request/submission-details.tsx
+++ b/frontend/app/routes/hiring-manager/request/submission-details.tsx
@@ -104,7 +104,6 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
 
 export default function HiringManagerRequestSubmissionDetails({ loaderData, actionData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespace);
-  const errors = actionData?.errors;
 
   return (
     <>
@@ -119,7 +118,7 @@ export default function HiringManagerRequestSubmissionDetails({ loaderData, acti
       <div className="max-w-prose">
         <SubmissionDetailsForm
           cancelLink="routes/hiring-manager/request/index.tsx"
-          formErrors={errors}
+          formErrors={actionData?.errors}
           formValues={loaderData.defaultValues}
           branchOrServiceCanadaRegions={loaderData.branchOrServiceCanadaRegions}
           directorates={loaderData.directorates}

--- a/frontend/app/routes/hr-advisor/employee-profile/employment-information.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/employment-information.tsx
@@ -127,7 +127,6 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 
 export default function EmploymentInformation({ loaderData, actionData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespace);
-  const errors = actionData?.errors;
 
   return (
     <>
@@ -138,7 +137,7 @@ export default function EmploymentInformation({ loaderData, actionData, params }
         <EmploymentInformationForm
           cancelLink="routes/hr-advisor/employee-profile/index.tsx"
           formValues={loaderData.defaultValues}
-          formErrors={errors}
+          formErrors={actionData?.errors}
           substantivePositions={loaderData.substantivePositions}
           branchOrServiceCanadaRegions={loaderData.branchOrServiceCanadaRegions}
           directorates={loaderData.directorates}

--- a/frontend/app/routes/hr-advisor/employee-profile/personal-information.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/personal-information.tsx
@@ -158,7 +158,6 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 
 export default function PersonalInformation({ loaderData, actionData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespace);
-  const errors = actionData?.errors;
 
   return (
     <>
@@ -169,7 +168,7 @@ export default function PersonalInformation({ loaderData, actionData, params }: 
         <PersonalInformationForm
           cancelLink="routes/hr-advisor/employee-profile/index.tsx"
           formValues={loaderData.defaultValues}
-          formErrors={errors}
+          formErrors={actionData?.errors}
           isReadOnly={true}
           languagesOfCorrespondence={loaderData.languagesOfCorrespondence}
           params={params}

--- a/frontend/app/routes/hr-advisor/employee-profile/referral-preferences.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/referral-preferences.tsx
@@ -134,7 +134,6 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 
 export default function PersonalDetails({ loaderData, actionData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespace);
-  const errors = actionData?.errors;
 
   return (
     <>
@@ -146,7 +145,7 @@ export default function PersonalDetails({ loaderData, actionData, params }: Rout
           cancelLink="routes/hr-advisor/employee-profile/index.tsx"
           formValues={loaderData.defaultValues}
           preferredProvince={loaderData.defaultValues.preferredProvince}
-          formErrors={errors}
+          formErrors={actionData?.errors}
           languageReferralTypes={loaderData.languageReferralTypes}
           classifications={loaderData.classifications}
           provinces={loaderData.provinces}

--- a/frontend/app/routes/hr-advisor/request/position-information.tsx
+++ b/frontend/app/routes/hr-advisor/request/position-information.tsx
@@ -146,7 +146,6 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 
 export default function HiringManagerRequestPositionInformation({ loaderData, actionData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespace);
-  const errors = actionData?.errors;
 
   return (
     <>
@@ -161,7 +160,7 @@ export default function HiringManagerRequestPositionInformation({ loaderData, ac
       <div className="max-w-prose">
         <PositionInformationForm
           cancelLink="routes/hr-advisor/request/index.tsx"
-          formErrors={errors}
+          formErrors={actionData?.errors}
           formValues={loaderData.defaultValues}
           languageRequirements={loaderData.languageRequirements}
           classifications={loaderData.classifications}

--- a/frontend/app/routes/hr-advisor/request/somc-conditions.tsx
+++ b/frontend/app/routes/hr-advisor/request/somc-conditions.tsx
@@ -76,7 +76,6 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
 
 export default function HiringManagerRequestSomcConditions({ loaderData, actionData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespace);
-  const errors = actionData?.errors;
 
   return (
     <>
@@ -91,7 +90,7 @@ export default function HiringManagerRequestSomcConditions({ loaderData, actionD
       <div className="max-w-prose">
         <SomcConditionsForm
           cancelLink="routes/hr-advisor/request/index.tsx"
-          formErrors={errors}
+          formErrors={actionData?.errors}
           formValues={loaderData.defaultValues}
           params={params}
         />

--- a/frontend/app/routes/hr-advisor/request/submission-details.tsx
+++ b/frontend/app/routes/hr-advisor/request/submission-details.tsx
@@ -108,7 +108,6 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
 
 export default function HiringManagerRequestSubmissionDetails({ loaderData, actionData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespace);
-  const errors = actionData?.errors;
 
   return (
     <>
@@ -123,7 +122,7 @@ export default function HiringManagerRequestSubmissionDetails({ loaderData, acti
       <div className="max-w-prose">
         <SubmissionDetailsForm
           cancelLink="routes/hr-advisor/request/index.tsx"
-          formErrors={errors}
+          formErrors={actionData?.errors}
           formValues={loaderData.defaultValues}
           branchOrServiceCanadaRegions={loaderData.branchOrServiceCanadaRegions}
           directorates={loaderData.directorates}


### PR DESCRIPTION
## Summary

There's no sense in assigning `actionData.errors` to a variable only to pass it into a component.  Just pass it directly into the component without assignment.
