### PR TITLE
refactor(frontend): update radio buttons to select drop down

### DIFF
--- a/frontend/app/routes/page-components/employees/employment-information/form.tsx
+++ b/frontend/app/routes/page-components/employees/employment-information/form.tsx
@@ -21,8 +21,6 @@ import { ButtonLink } from '~/components/button-link';
 import { DatePickerField } from '~/components/date-picker-field';
 import { FormErrorSummary } from '~/components/error-summary';
 import { InputLegend } from '~/components/input-legend';
-import type { InputRadiosProps } from '~/components/input-radios';
-import { InputRadios } from '~/components/input-radios';
 import { InputSelect } from '~/components/input-select';
 import { PageTitle } from '~/components/page-title';
 import { EMPLOYEE_WFA_STATUS } from '~/domain/constants';
@@ -105,7 +103,12 @@ export function EmploymentInformationForm({
     children: id === 'select-option' ? t('form.select-option') : name,
   }));
 
-  const handleWFAStatusChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const wfaStatusOptions = [{ id: 'select-option', name: '' }, ...wfaStatuses].map(({ id, name }) => ({
+    value: id === 'select-option' ? '' : String(id),
+    children: id === 'select-option' ? t('form.select-option') : name,
+  }));
+
+  const handleWFAStatusChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedValue = event.target.value;
     const selectedStatus = wfaStatuses.find((c) => c.id === Number(selectedValue))?.code;
     setWfaStatusCode(selectedStatus);
@@ -125,13 +128,6 @@ export function EmploymentInformationForm({
       setDirectorate(undefined);
     }
   };
-
-  const wfaStatusOptions: InputRadiosProps['options'] = wfaStatuses.map(({ id, name }) => ({
-    value: String(id),
-    children: name,
-    onChange: handleWFAStatusChange,
-    defaultChecked: formValues?.wfaStatus?.id === id,
-  }));
 
   const hrAdvisorOptions = [{ id: 'select-option', firstName: '', lastName: '' }, ...hrAdvisors].map(
     ({ id, firstName, lastName }) => ({
@@ -217,14 +213,16 @@ export function EmploymentInformationForm({
                 {t('employment-information.wfa-detils')}
               </InputLegend>
               <div className="w-full sm:w-1/2">
-                <InputRadios
+                <InputSelect
                   ariaDescribedbyId="wfaDetilsLegend"
                   id="wfaStatus"
                   name="wfaStatus"
                   errorMessage={t(extractValidationKey(formErrors?.wfaStatusId))}
                   required
                   options={wfaStatusOptions}
-                  legend={t('employment-information.wfa-status')}
+                  label={t('employment-information.wfa-status')}
+                  defaultValue={formValues?.wfaStatus !== undefined ? String(formValues.wfaStatus.id) : ''}
+                  onChange={handleWFAStatusChange}
                 />
               </div>
               <DatePickerField


### PR DESCRIPTION
## Summary

update radio buttons to select drop down
we have radio buttons for the wfa status: 
<img width="567" height="588" alt="image" src="https://github.com/user-attachments/assets/265e73f2-91f9-40cc-b19b-93ee26cd14e3" />
which are changed to the drop down in [figma](https://www.figma.com/design/R75ntV67ucgc6UXWbEwhdN/VacMan-Main?node-id=181-5173&t=uUMegxxIxdNcOBBe-0), so changed the control...
<img width="643" height="763" alt="image" src="https://github.com/user-attachments/assets/57e75693-5ed0-4455-9376-a819a7842329" />


## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [ ] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

