### PR TITLE
refactor(frontend) date-utils

### DIFF
--- a/frontend/app/routes/hiring-manager/request/process-information.tsx
+++ b/frontend/app/routes/hiring-manager/request/process-information.tsx
@@ -21,8 +21,9 @@ import { HttpStatusCodes } from '~/errors/http-status-codes';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/layout';
 import { ProcessInformationForm } from '~/routes/page-components/requests/process-information/form';
-import { createProcessInformationSchema, toDateString } from '~/routes/page-components/requests/validation.server';
+import { createProcessInformationSchema } from '~/routes/page-components/requests/validation.server';
 import type { ProcessInformationSchema } from '~/routes/page-components/requests/validation.server';
+import { formatISODate } from '~/utils/date-utils';
 import { formString } from '~/utils/string-utils';
 
 export const handle = {
@@ -59,11 +60,11 @@ export async function action({ context, params, request }: Route.ActionArgs) {
       : undefined,
     nonAdvertisedAppointment: formString(formData.get('nonAdvertisedAppointment')),
     employmentTenure: formString(formData.get('employmentTenure')),
-    projectedStartDate: toDateString(projectedStartDateYear, projectedStartDateMonth, projectedStartDateDay),
+    projectedStartDate: formatISODate(`${projectedStartDateYear}-${projectedStartDateMonth}-${projectedStartDateDay}`),
     projectedStartDateYear,
     projectedStartDateMonth,
     projectedStartDateDay,
-    projectedEndDate: toDateString(projectedEndDateYear, projectedEndDateMonth, projectedEndDateDay),
+    projectedEndDate: formatISODate(`${projectedEndDateYear}-${projectedEndDateMonth}-${projectedEndDateDay}`),
     projectedEndDateYear,
     projectedEndDateMonth,
     projectedEndDateDay,

--- a/frontend/app/routes/hr-advisor/request/process-information.tsx
+++ b/frontend/app/routes/hr-advisor/request/process-information.tsx
@@ -21,8 +21,9 @@ import { HttpStatusCodes } from '~/errors/http-status-codes';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/layout';
 import { ProcessInformationForm } from '~/routes/page-components/requests/process-information/form';
-import { createProcessInformationSchema, toDateString } from '~/routes/page-components/requests/validation.server';
+import { createProcessInformationSchema } from '~/routes/page-components/requests/validation.server';
 import type { ProcessInformationSchema } from '~/routes/page-components/requests/validation.server';
+import { formatISODate } from '~/utils/date-utils';
 import { formString } from '~/utils/string-utils';
 
 export const handle = {
@@ -58,11 +59,13 @@ export async function action({ context, params, request }: Route.ActionArgs) {
       : undefined,
     nonAdvertisedAppointment: formString(formData.get('nonAdvertisedAppointment')),
     employmentTenure: formString(formData.get('employmentTenure')),
-    projectedStartDate: toDateString(projectedStartDateYear, projectedStartDateMonth, projectedStartDateDay),
+    projectedStartDate: formatISODate(`${projectedStartDateYear}-${projectedStartDateMonth}-${projectedStartDateDay}`).unwrapOr(
+      '',
+    ),
     projectedStartDateYear,
     projectedStartDateMonth,
     projectedStartDateDay,
-    projectedEndDate: toDateString(projectedEndDateYear, projectedEndDateMonth, projectedEndDateDay),
+    projectedEndDate: formatISODate(`${projectedEndDateYear}-${projectedEndDateMonth}-${projectedEndDateDay}`).unwrapOr(''),
     projectedEndDateYear,
     projectedEndDateMonth,
     projectedEndDateDay,

--- a/frontend/app/routes/page-components/profile/validation.server.ts
+++ b/frontend/app/routes/page-components/profile/validation.server.ts
@@ -13,7 +13,7 @@ import { getWFAStatuses } from '~/.server/domain/services/wfa-status-service';
 import { extractUniqueBranchesFromDirectoratesNonLocalized } from '~/.server/utils/directorate-utils';
 import { stringToIntegerSchema } from '~/.server/validation/string-to-integer-schema';
 import { EMPLOYEE_WFA_STATUS } from '~/domain/constants';
-import { isValidDateString, toISODateString } from '~/utils/date-utils';
+import { formatISODate, isValidDateString } from '~/utils/date-utils';
 import { isValidPhone } from '~/utils/phone-utils';
 import { REGEX_PATTERNS } from '~/utils/regex-utils';
 import { formString } from '~/utils/string-utils';
@@ -364,11 +364,11 @@ export async function parseEmploymentInformation(formData: FormData, hrAdvisors:
     provinceId: formString(formData.get('province')),
     cityId: formString(formData.get('cityId')),
     wfaStatusId: formString(formData.get('wfaStatus')),
-    wfaStartDate: toDateString(wfaStartDateYear, wfaStartDateMonth, wfaStartDateDay),
+    wfaStartDate: formatISODate(`${wfaStartDateYear}-${wfaStartDateMonth}-${wfaStartDateDay}`).unwrapOr(''),
     wfaStartDateYear,
     wfaStartDateMonth,
     wfaStartDateDay,
-    wfaEndDate: toDateString(wfaEndDateYear, wfaEndDateMonth, wfaEndDateDay),
+    wfaEndDate: formatISODate(`${wfaEndDateYear}-${wfaEndDateMonth}-${wfaEndDateDay}`).unwrapOr(''),
     wfaEndDateYear,
     wfaEndDateMonth,
     wfaEndDateDay,
@@ -395,14 +395,6 @@ export async function parseEmploymentInformation(formData: FormData, hrAdvisors:
       hrAdvisorId: formValues.hrAdvisorId,
     },
   };
-}
-
-function toDateString(year?: string, month?: string, day?: string): string {
-  try {
-    return toISODateString(Number(year), Number(month), Number(day));
-  } catch {
-    return '';
-  }
 }
 
 /**

--- a/frontend/app/routes/page-components/requests/validation.server.ts
+++ b/frontend/app/routes/page-components/requests/validation.server.ts
@@ -12,7 +12,7 @@ import { getSelectionProcessTypeService } from '~/.server/domain/services/select
 import { extractUniqueBranchesFromDirectoratesNonLocalized } from '~/.server/utils/directorate-utils';
 import { stringToIntegerSchema } from '~/.server/validation/string-to-integer-schema';
 import { EMPLOYMENT_TENURE, LANGUAGE_REQUIREMENT_CODES, SELECTION_PROCESS_TYPE } from '~/domain/constants';
-import { isValidDateString, toISODateString } from '~/utils/date-utils';
+import { isValidDateString } from '~/utils/date-utils';
 
 export type PositionInformationSchema = Awaited<ReturnType<typeof createPositionInformationSchema>>;
 export type ProcessInformationSchema = Awaited<ReturnType<typeof createProcessInformationSchema>>;
@@ -505,12 +505,4 @@ export async function createProcessInformationSchema() {
       ['projectedEndDate'],
     ),
   );
-}
-
-export function toDateString(year?: string, month?: string, day?: string): string {
-  try {
-    return toISODateString(Number(year), Number(month), Number(day));
-  } catch {
-    return '';
-  }
 }

--- a/frontend/app/utils/date-utils.ts
+++ b/frontend/app/utils/date-utils.ts
@@ -1,5 +1,7 @@
 import { TZDate } from '@date-fns/tz';
 import { format, formatISO, isBefore, isToday, isValid, parseISO, startOfDay } from 'date-fns';
+import { Err, Ok } from 'oxide.ts';
+import type { Result } from 'oxide.ts';
 
 import { padWithZero } from '~/utils/string-utils';
 
@@ -259,21 +261,6 @@ export function getLocalizedMonths(
 /**
  * Formats a date into an ISO8601 date string (YYYY-MM-DD).
  *
- * This function takes the year, month, and day as numerical inputs and
- * returns a string representing the date in the "YYYY-MM-DD" format.
- *
- * @param year - The year (e.g., 2023).
- * @param month - The month (1 for January, 12 for December).
- * @param day - The day of the month.
- * @returns An ISO 8601 date string in the format "YYYY-MM-DD".
- */
-export function toISODateString(year: number, month: number, day: number): string {
-  return formatISODate(`${year}-${month}-${day}`);
-}
-
-/**
- * Formats a date into an ISO8601 date string (YYYY-MM-DD).
- *
  * This function accepts a date as a number (Unix timestamp in milliseconds),
  * a string (parsable by the Date constructor), or a Date object and returns
  * a string representing the date in the "YYYY-MM-DD" format. It leverages
@@ -281,11 +268,14 @@ export function toISODateString(year: number, month: number, day: number): strin
  * with the `representation: 'date'` option.
  *
  * @param date - The date to be formatted. Can be a Unix timestamp (milliseconds), a date string, or a Date object.
- * @returns An ISO 8601 date string in the format "YYYY-MM-DD".
- * @throws {TypeError} If the input `date` is not a valid date representation that can be parsed by `formatISO`.
+ * @returns An a Result of an Ok variant of an ISO 8601 date string in the format "YYYY-MM-DD" if parsing is successful otherwise an Err variant of a TypeError.
  */
-export function formatISODate(date: number | string | Date): string {
-  return formatISO(date, { representation: 'date' });
+export function formatISODate(date: number | string | Date): Result<string, TypeError> {
+  try {
+    return Ok(formatISO(date, { representation: 'date' }));
+  } catch (e) {
+    return Err(new TypeError(String(e)));
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

`date-utils` can be refactored to take advantage of `oxide.ts`.  This removes semi-redundant code used a in a few spots.
