### PR TITLE
feat(frontend): update request submission detail for hiring manager

### DIFF
--- a/frontend/app/.server/domain/services/request-service-mock.ts
+++ b/frontend/app/.server/domain/services/request-service-mock.ts
@@ -12,14 +12,17 @@ import type {
 } from '~/.server/domain/models';
 import { getCityService } from '~/.server/domain/services/city-service';
 import { getClassificationService } from '~/.server/domain/services/classification-service';
+import { getDirectorateService } from '~/.server/domain/services/directorate-service';
 import { getEmploymentEquityService } from '~/.server/domain/services/employment-equity-service';
 import { getEmploymentTenureService } from '~/.server/domain/services/employment-tenure-service';
+import { getLanguageForCorrespondenceService } from '~/.server/domain/services/language-for-correspondence-service';
 import { getLanguageRequirementService } from '~/.server/domain/services/language-requirement-service';
 import { createMockRequest, mockRequests } from '~/.server/domain/services/mock-data';
 import { getNonAdvertisedAppointmentService } from '~/.server/domain/services/non-advertised-appointment-service';
 import type { RequestService } from '~/.server/domain/services/request-service';
 import { getSecurityClearanceService } from '~/.server/domain/services/security-clearance-service';
 import { getSelectionProcessTypeService } from '~/.server/domain/services/selection-process-type-service';
+import { getUserService } from '~/.server/domain/services/user-service';
 import { getWorkScheduleService } from '~/.server/domain/services/work-schedule-service';
 import { LogFactory } from '~/.server/logging';
 import { AppError } from '~/errors/app-error';
@@ -185,6 +188,33 @@ export function getMockRequestService(): RequestService {
           ? (await getNonAdvertisedAppointmentService().getById(requestUpdate.appointmentNonAdvertisedId)).into()
           : existingRequest.appointmentNonAdvertised;
 
+      const submitter =
+        requestUpdate.submitterId !== undefined
+          ? (await getUserService().getUserById(requestUpdate.submitterId, accessToken)).into()
+          : existingRequest.submitter;
+
+      const hiringManager =
+        requestUpdate.hiringManagerId !== undefined
+          ? (await getUserService().getUserById(requestUpdate.hiringManagerId, accessToken)).into()
+          : existingRequest.hiringManager;
+
+      const subDelegatedManager =
+        requestUpdate.subDelegatedManagerId !== undefined
+          ? (await getUserService().getUserById(requestUpdate.subDelegatedManagerId, accessToken)).into()
+          : existingRequest.subDelegatedManager;
+
+      const workUnit =
+        requestUpdate.workUnitId !== undefined
+          ? (await Promise.all([getDirectorateService().getById(requestUpdate.workUnitId)]))
+              .filter((result) => result.isOk())
+              .map((result) => result.unwrap())[0]
+          : existingRequest.workUnit;
+
+      const languageOfCorrespondence =
+        requestUpdate.languageOfCorrespondenceId !== undefined
+          ? (await getLanguageForCorrespondenceService().getById(requestUpdate.languageOfCorrespondenceId)).into()
+          : existingRequest.languageOfCorrespondence;
+
       // Merge updates with existing request
       const updatedRequest: RequestReadModel = {
         ...existingRequest,
@@ -201,6 +231,11 @@ export function getMockRequestService(): RequestService {
         selectionProcessType,
         employmentTenure,
         workSchedule,
+        submitter,
+        hiringManager,
+        subDelegatedManager,
+        workUnit,
+        languageOfCorrespondence,
         employmentEquities,
         appointmentNonAdvertised,
         hasPerformedSameDuties: requestUpdate.hasPerformedSameDuties,

--- a/frontend/app/routes/hiring-manager/request/index.tsx
+++ b/frontend/app/routes/hiring-manager/request/index.tsx
@@ -8,7 +8,6 @@ import { useTranslation } from 'react-i18next';
 import type { Route } from './+types/index';
 
 import { getCityService } from '~/.server/domain/services/city-service';
-import { getClassificationService } from '~/.server/domain/services/classification-service';
 import { getDirectorateService } from '~/.server/domain/services/directorate-service';
 import { getEmploymentEquityService } from '~/.server/domain/services/employment-equity-service';
 import { getEmploymentTenureService } from '~/.server/domain/services/employment-tenure-service';
@@ -163,7 +162,6 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
     allLocalizedTenures,
     allLocalizedWorkSchedules,
     allLocalizedEmploymentEquities,
-    allLocalizedClassifications,
     allLocalizedDirectorates,
     allLocalizedPreferredLanguage,
   ] = await Promise.all([
@@ -173,7 +171,6 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
     getEmploymentTenureService().listAllLocalized(lang),
     getWorkScheduleService().listAllLocalized(lang),
     getEmploymentEquityService().listAllLocalized(lang),
-    getClassificationService().listAllLocalized(lang),
     getDirectorateService().listAllLocalized(lang),
     getLanguageForCorrespondenceService().listAllLocalized(lang),
   ]);
@@ -354,8 +351,7 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
     submitter: currentRequest?.submitter,
     hiringManager: currentRequest?.hiringManager,
     subDelegatedManager: currentRequest?.subDelegatedManager,
-    workUnit: allLocalizedClassifications.find((c) => c.code === currentRequest?.workUnit?.parent?.code),
-    directorate: allLocalizedDirectorates.find((d) => d.code === currentRequest?.workUnit?.code),
+    directorate: allLocalizedDirectorates.find((c) => c.code === currentRequest?.workUnit?.code),
     languageOfCorrespondence: allLocalizedPreferredLanguage.find(
       (p) => p.code === currentRequest?.languageOfCorrespondence?.code,
     ),
@@ -706,14 +702,12 @@ export default function EditRequest({ loaderData, params }: Route.ComponentProps
                   </DescriptionListItem>
 
                   <DescriptionListItem term={t('app:submission-details.branch-or-service-canada-region')}>
-                    {loaderData.workUnit?.name ?? t('app:hiring-manager-referral-requests.not-provided')}
+                    {loaderData.directorate?.parent?.name ?? t('app:hiring-manager-referral-requests.not-provided')}
                   </DescriptionListItem>
 
-                  {loaderData.workUnit && (
-                    <DescriptionListItem term={t('app:submission-details.directorate')}>
-                      {loaderData.directorate?.name ?? t('app:hiring-manager-referral-requests.not-provided')}
-                    </DescriptionListItem>
-                  )}
+                  <DescriptionListItem term={t('app:submission-details.directorate')}>
+                    {loaderData.directorate?.name ?? t('app:hiring-manager-referral-requests.not-provided')}
+                  </DescriptionListItem>
 
                   <DescriptionListItem term={t('app:submission-details.preferred-language-of-correspondence')}>
                     {loaderData.languageOfCorrespondence?.name ?? t('app:hiring-manager-referral-requests.not-provided')}


### PR DESCRIPTION
## Summary

[AB#6894](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6894/)
updated mocks to save/update the request submission details for the hiring manager. Also updated the request index screen to correctly display the saved data.

Next steps: 
update the hr-advisor request submission detail to update request
update French translations when available

## Types of changes

What types of changes does this PR introduce?

- [x] ✨ **new feature** -- non-breaking change that adds functionality

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.

- [x] code has been linted and formatted locally

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)
<img width="543" height="914" alt="image" src="https://github.com/user-attachments/assets/94df1b28-3bac-4a92-9091-c6dff23a96a1" />


<img width="453" height="551" alt="image" src="https://github.com/user-attachments/assets/35ffdf61-6e61-49fd-ab57-5cb7c09df265" />


