### PR TITLE
refactor(frontend) cleanup profile/validation.server

### DIFF
--- a/frontend/app/routes/page-components/profile/validation.server.ts
+++ b/frontend/app/routes/page-components/profile/validation.server.ts
@@ -1,5 +1,4 @@
 import { parsePhoneNumberWithError } from 'libphonenumber-js';
-import type { BaseIssue, BaseSchema } from 'valibot';
 import * as v from 'valibot';
 
 import type { User } from '~/.server/domain/models';
@@ -17,6 +16,7 @@ import { formatISODate, isValidDateString } from '~/utils/date-utils';
 import { isValidPhone } from '~/utils/phone-utils';
 import { REGEX_PATTERNS } from '~/utils/regex-utils';
 import { formString } from '~/utils/string-utils';
+import { optionalString } from '~/utils/validation-utils';
 
 export type EmploymentInformationSchema = Awaited<ReturnType<typeof createEmploymentInformationSchema>>;
 export type PersonalInformationSchema = Awaited<ReturnType<typeof createPersonalInformationSchema>>;
@@ -395,17 +395,4 @@ export async function parseEmploymentInformation(formData: FormData, hrAdvisors:
       hrAdvisorId: formValues.hrAdvisorId,
     },
   };
-}
-
-/**
- * A custom schema that transforms an empty string to `undefined` before
- * passing it to another schema. This makes `v.optional` work correctly
- * with empty form fields.
- */
-function optionalString<TOutput>(schema: BaseSchema<string | undefined, TOutput, BaseIssue<unknown>>) {
-  return v.pipe(
-    v.string(),
-    v.transform((input) => (input.trim() === '' ? undefined : input)),
-    schema,
-  );
 }

--- a/frontend/app/utils/validation-utils.ts
+++ b/frontend/app/utils/validation-utils.ts
@@ -1,4 +1,6 @@
 import type { ResourceKey } from 'i18next';
+import type { BaseIssue, BaseSchema } from 'valibot';
+import * as v from 'valibot';
 
 /**
  * Normalizes validation error messages into a single i18next `ResourceKey`.
@@ -38,4 +40,17 @@ export function preprocess<K extends string | number | symbol, T>(data: Record<K
     .map(([key, val]) => [key, val === '' ? undefined : val]);
 
   return Object.fromEntries(processedEntries);
+}
+
+/**
+ * A custom schema that transforms an empty string to `undefined` before
+ * passing it to another schema. This makes `v.optional` work correctly
+ * with empty form fields.
+ */
+export function optionalString<TOutput>(schema: BaseSchema<string | undefined, TOutput, BaseIssue<unknown>>) {
+  return v.pipe(
+    v.string(),
+    v.transform((input) => (input.trim() === '' ? undefined : input)),
+    schema,
+  );
 }


### PR DESCRIPTION
## Summary

moving `optionalString` to `validation-utils` for better™ organization
