### PR TITLE
feat(frontend): submission details on hr-advisor route

### DIFF
--- a/frontend/app/routes/hiring-manager/request/submission-details.tsx
+++ b/frontend/app/routes/hiring-manager/request/submission-details.tsx
@@ -71,7 +71,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
       { email: parseResult.output.hiringManagerEmailAddress },
       context.session.authState.accessToken,
     );
-    const hiringManager = hiringManagerResult.into()?.content[0];
+    const hiringManager = hiringManagerResult.into()?.content[0]; // TODO: add the error handling if content[0] is undefined
     hiringManagerId = hiringManager?.id;
   }
 
@@ -82,7 +82,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
       context.session.authState.accessToken,
     );
 
-    const subDelegatedManager = subDelegatedManagerResult.into()?.content[0];
+    const subDelegatedManager = subDelegatedManagerResult.into()?.content[0]; // TODO: add the error handling if content[0] is undefined
     subDelegatedManagerId = subDelegatedManager?.id;
   }
 


### PR DESCRIPTION
## Summary

update the request on submission details on hr-advisor route (while running mocks):
/hr-advisor/request/1/submission-details

Added a TODO for the error handling if content[0] is undefined, In case the API return an empty collection resource if the user does not exists in Azure AD, the value will be undefined while saving the form even if the user typed an email address (might be a typo in the email)

## Types of changes

What types of changes does this PR introduce?

- [x] ✨ **new feature** -- non-breaking change that adds functionality

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.

- [x] code has been linted and formatted locally

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Mocks always create a new user if the email address ends in @canada.ca
<img width="522" height="868" alt="image" src="https://github.com/user-attachments/assets/227705eb-b50c-47fd-b1c4-86047e6e5800" />

