### PR TITLE
feat(backend): allow finer-grained filtering when fetching profiles

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/repository/AbstractBaseRepository.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/repository/AbstractBaseRepository.java
@@ -1,5 +1,6 @@
 package ca.gov.dtsstn.vacman.api.data.repository;
 
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.repository.NoRepositoryBean;
@@ -10,4 +11,13 @@ import org.springframework.data.repository.NoRepositoryBean;
  * @param <T> The type of the entity.
  */
 @NoRepositoryBean
-public interface AbstractBaseRepository<T> extends JpaRepository<T, Long>, JpaSpecificationExecutor<T> {}
+public interface AbstractBaseRepository<T> extends JpaRepository<T, Long>, JpaSpecificationExecutor<T> {
+
+	/**
+	 * A conjunction (with zero conjuncts). Always evaluates to true.
+	 */
+	static <T> Specification<T> empty() {
+		return (root, query, cb) -> cb.conjunction();
+	}
+
+}

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/repository/ProfileRepository.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/data/repository/ProfileRepository.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.CollectionUtils;
 
 import ca.gov.dtsstn.vacman.api.data.entity.ProfileEntity;
 
@@ -18,10 +19,27 @@ public interface ProfileRepository extends AbstractBaseRepository<ProfileEntity>
 	}
 
 	/**
+	 * JPA specification to find profiles assigned to specific HR Advisors.
+	 */
+	static Specification<ProfileEntity> hasHrAdvisorIdIn(Collection<Long> hrAdvisorIds) {
+		if (CollectionUtils.isEmpty(hrAdvisorIds)) { return AbstractBaseRepository.empty(); }
+		return (root, query, cb) -> root.get("hrAdvisor").get("id").in(hrAdvisorIds);
+	}
+
+	/**
 	 * JPA specification to find profiles with a status code in the given collection.
 	 */
 	static Specification<ProfileEntity> hasProfileStatusCodeIn(Collection<String> statuses) {
+		if (CollectionUtils.isEmpty(statuses)) { return AbstractBaseRepository.empty(); }
 		return (root, query, cb) -> root.get("profileStatus").get("code").in(statuses);
+	}
+
+	/**
+	 * JPA specification to find profiles with a status code in the given collection.
+	 */
+	static Specification<ProfileEntity> hasProfileStatusIdIn(Collection<Long> statusIds) {
+		if (CollectionUtils.isEmpty(statusIds)) { return AbstractBaseRepository.empty(); }
+		return (root, query, cb) -> root.get("profileStatus").get("id").in(statusIds);
 	}
 
 	/**

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/ProfileService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/ProfileService.java
@@ -41,6 +41,7 @@ import ca.gov.dtsstn.vacman.api.event.ProfileReadEvent;
 import ca.gov.dtsstn.vacman.api.event.ProfileStatusChangeEvent;
 import ca.gov.dtsstn.vacman.api.event.ProfileUpdatedEvent;
 import ca.gov.dtsstn.vacman.api.security.SecurityUtils;
+import ca.gov.dtsstn.vacman.api.service.dto.ProfileQuery;
 import ca.gov.dtsstn.vacman.api.service.mapper.ProfileEntityMapper;
 import ca.gov.dtsstn.vacman.api.web.exception.ResourceNotFoundException;
 import ca.gov.dtsstn.vacman.api.web.model.ProfilePutModel;
@@ -217,6 +218,12 @@ public class ProfileService {
 		eventPublisher.publishEvent(new ProfileCreateEvent(savedProfile));
 
 		return savedProfile;
+	}
+
+	public Page<ProfileEntity> findProfiles(Pageable pageable, ProfileQuery profileQuery) {
+		final var hasHrAdvisorId = ProfileRepository.hasHrAdvisorIdIn(profileQuery.hrAdvisorIds());
+		final var hasStatusId = ProfileRepository.hasProfileStatusIdIn(profileQuery.statusIds());
+		return profileRepository.findAll(hasHrAdvisorId.and(hasStatusId), pageable);
 	}
 
 	/**

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/dto/ProfileQuery.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/dto/ProfileQuery.java
@@ -1,0 +1,11 @@
+package ca.gov.dtsstn.vacman.api.service.dto;
+
+import java.util.Set;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+@RecordBuilder
+public record ProfileQuery(
+	Set<Long> hrAdvisorIds,
+	Set<Long> statusIds
+) {}

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/ProfilesController.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/ProfilesController.java
@@ -7,9 +7,9 @@ import static ca.gov.dtsstn.vacman.api.web.model.CollectionModel.toCollectionMod
 import static java.util.Collections.emptySet;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.lang3.StringUtils;
 import org.mapstruct.factory.Mappers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,14 +35,16 @@ import ca.gov.dtsstn.vacman.api.config.properties.ApplicationProperties;
 import ca.gov.dtsstn.vacman.api.config.properties.EntraIdProperties.RolesProperties;
 import ca.gov.dtsstn.vacman.api.config.properties.LookupCodes;
 import ca.gov.dtsstn.vacman.api.config.properties.LookupCodes.ProfileStatuses;
+import ca.gov.dtsstn.vacman.api.data.entity.AbstractBaseEntity;
 import ca.gov.dtsstn.vacman.api.data.entity.ProfileEntity;
-import ca.gov.dtsstn.vacman.api.data.entity.UserEntity;
 import ca.gov.dtsstn.vacman.api.security.SecurityUtils;
 import ca.gov.dtsstn.vacman.api.service.ProfileService;
 import ca.gov.dtsstn.vacman.api.service.UserService;
 import ca.gov.dtsstn.vacman.api.web.exception.ResourceConflictException;
 import ca.gov.dtsstn.vacman.api.web.model.CollectionModel;
 import ca.gov.dtsstn.vacman.api.web.model.ProfilePutModel;
+import ca.gov.dtsstn.vacman.api.web.model.ProfileReadFilterModel;
+import ca.gov.dtsstn.vacman.api.web.model.ProfileReadFilterModelBuilder;
 import ca.gov.dtsstn.vacman.api.web.model.ProfileReadModel;
 import ca.gov.dtsstn.vacman.api.web.model.ProfileStatusUpdateModel;
 import ca.gov.dtsstn.vacman.api.web.model.mapper.ProfileModelMapper;
@@ -92,37 +94,15 @@ public class ProfilesController {
 	@ApiResponses.AuthenticationError
 	@PreAuthorize("hasAuthority('hr-advisor')")
 	@Operation(summary = "Retrieve a list of profiles with optional filters on active profiles, inactive profiles, and HR advisor assocation.")
-	public ResponseEntity<PagedModel<ProfileReadModel>> getProfiles(
-			@ParameterObject
-			Pageable pageable,
+	public ResponseEntity<PagedModel<ProfileReadModel>> getProfiles(@ParameterObject Pageable pageable, @ParameterObject ProfileReadFilterModel filter) {
+		final var profileQuery = profileModelMapper.toProfileQuery(
+			ProfileReadFilterModelBuilder.builder(filter)
+				// ?hrAdvisorId=me is a valid filter, so we must replace any instance
+				// of 'me' with the current user's id before fetching the data
+				.hrAdvisorId(resolveMeKeyword(filter.hrAdvisorId()))
+				.build());
 
-			@RequestParam(name = "active", required = false)
-			@Parameter(name = "active", description = "Return only active or inactive profiles")
-			Boolean isActive,
-
-			@RequestParam(name = "hr-advisor", required = false)
-			@Parameter(name = "hr-advisor", description = "Return only the profiles that are associated with the HR advisor")
-			String hrAdvisor) {
-		// Determine the advisor ID based on the advisor param (or lack thereof).
-		Long hrAdvisorId;
-
-		if (StringUtils.isBlank(hrAdvisor)) {
-			hrAdvisorId = null;
-		}
-		else if (hrAdvisor.equalsIgnoreCase("me")) {
-			final var entraId = SecurityUtils.getCurrentUserEntraId()
-				.orElseThrow(asEntraIdUnauthorizedException());
-
-			hrAdvisorId = userService.getUserByMicrosoftEntraId(entraId)
-				.map(UserEntity::getId)
-				.orElseThrow(asUserResourceNotFoundException("microsoftEntraId", entraId));
-		}
-		else {
-			hrAdvisorId = Long.valueOf(hrAdvisor);
-		}
-
-		// Determine the mapping function to use.
-		final var profiles = profileService.getProfilesByStatusAndHrId(pageable, isActive, hrAdvisorId)
+		final var profiles = profileService.findProfiles(pageable, profileQuery)
 			.map(profileModelMapper::toModel);
 
 		return ResponseEntity.ok(new PagedModel<>(profiles));
@@ -284,6 +264,24 @@ public class ProfilesController {
 			.orElse(emptySet());
 
 		return userAuthorities.contains(roles.hrAdvisor());
+	}
+
+	/**
+	 * Replaces the "me" keyword in a list of IDs with the current authenticated user's ID.
+	 */
+	private List<String> resolveMeKeyword(Collection<String> hrAdvisorIds) {
+		// if the "me" keyword isn't used, we don't need to do anything.
+		if (!hrAdvisorIds.contains("me")) { return List.copyOf(hrAdvisorIds); }
+
+		final var currentUserId = SecurityUtils.getCurrentUserEntraId()
+			.flatMap(userService::getUserByMicrosoftEntraId)
+			.map(AbstractBaseEntity::getId)
+			.orElseThrow(asEntraIdUnauthorizedException());
+
+		// replace all occurrences of "me" with the actual userid
+		return hrAdvisorIds.stream()
+			.map(id -> "me".equals(id) ? currentUserId.toString() : id)
+			.toList();
 	}
 
 	private void updateStatusToTarget(ProfileEntity profile, String targetStatus, Collection<String> validPreTransitionStates) {

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/model/ProfileReadFilterModel.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/model/ProfileReadFilterModel.java
@@ -1,0 +1,33 @@
+package ca.gov.dtsstn.vacman.api.web.model;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Set;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@RecordBuilder
+public record ProfileReadFilterModel(
+	// Note: this field is intentionally /singular/ so that it will map
+	// to the correct endpoint querystring param (ie: ?hrAdvisorId=1&hrAdvisorId=2)
+	// TODO ::: GjB :: is there a way to achieve this without needing a singular-form name here?
+	@Schema(description = "Filter by HR advisor IDs")
+	Collection<String> hrAdvisorId,
+
+	// Note: this field is intentionally /singular/ so that it will map
+	// to the correct endpoint querystring param (ie: ?statusId=1&statusId=2)
+	// TODO ::: GjB :: is there a way to achieve this without needing a singular-form name here?
+	@Schema(description = "Filter by status IDs")
+	Collection<String> statusId
+) {
+
+	/**
+	 * Constructor to prevent null collections being returned
+	 */
+	public ProfileReadFilterModel(Collection<String> hrAdvisorId, Collection<String> statusId) {
+		this.hrAdvisorId = Objects.requireNonNullElse(hrAdvisorId, Set.of());
+		this.statusId = Objects.requireNonNullElse(statusId, Set.of());
+	}
+
+}

--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/model/mapper/ProfileModelMapper.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/web/model/mapper/ProfileModelMapper.java
@@ -8,10 +8,12 @@ import ca.gov.dtsstn.vacman.api.data.entity.ProfileCityEntity;
 import ca.gov.dtsstn.vacman.api.data.entity.ProfileEmploymentOpportunityEntity;
 import ca.gov.dtsstn.vacman.api.data.entity.ProfileEntity;
 import ca.gov.dtsstn.vacman.api.data.entity.ProfileLanguageReferralTypeEntity;
+import ca.gov.dtsstn.vacman.api.service.dto.ProfileQuery;
 import ca.gov.dtsstn.vacman.api.web.model.CityReadModel;
 import ca.gov.dtsstn.vacman.api.web.model.ClassificationReadModel;
 import ca.gov.dtsstn.vacman.api.web.model.EmploymentOpportunityReadModel;
 import ca.gov.dtsstn.vacman.api.web.model.LanguageReferralTypeReadModel;
+import ca.gov.dtsstn.vacman.api.web.model.ProfileReadFilterModel;
 import ca.gov.dtsstn.vacman.api.web.model.ProfileReadModel;
 
 @Mapper(uses = { CodeModelMapper.class })
@@ -32,5 +34,9 @@ public interface ProfileModelMapper {
 
 	@Mapping(source = "languageReferralType", target = ".")
 	LanguageReferralTypeReadModel toLanguageReferralTypeReadModel(ProfileLanguageReferralTypeEntity entity);
+
+	@Mapping(source = "statusId", target = "statusIds")
+	@Mapping(source = "hrAdvisorId", target = "hrAdvisorIds")
+	ProfileQuery toProfileQuery(ProfileReadFilterModel filter);
 
 }


### PR DESCRIPTION
## Summary

This PR allows for finer-grained filtering when fetching profiles. It isn't an exhaustive filtering solution, but it can easily be extended to be.

An example of how to filter:

```shell
GET /api/v1/profiles?hrAdvisorId=840&hrAdvisorId=841&statusId=1&statusId=2
```

Notice how multiple values can be passed.
