### PR TITLE
feat(frontend): update ProfileQueryParams to include statusId and hrAdvsiorId

### DIFF
--- a/frontend/app/.server/domain/models.ts
+++ b/frontend/app/.server/domain/models.ts
@@ -231,10 +231,11 @@ export type UserQueryParams = {
 };
 
 export type ProfileQueryParams = {
-  'page'?: number;
-  'size'?: number;
-  'active'?: boolean;
-  'hr-advisor'?: string;
+  page?: number;
+  size?: number;
+  active?: boolean;
+  hrAdvisorId?: string;
+  statusIds?: number[];
 };
 
 // Request Status Model

--- a/frontend/app/.server/domain/services/profile-service-default.ts
+++ b/frontend/app/.server/domain/services/profile-service-default.ts
@@ -29,7 +29,16 @@ export function getDefaultProfileService(): ProfileService {
       if (params.page !== undefined) searchParams.append('page', params.page.toString());
       if (params.size !== undefined) searchParams.append('size', params.size.toString());
       if (params.active !== undefined) searchParams.append('active', params.active.toString());
-      if (params['hr-advisor']) searchParams.append('hr-advisor', params['hr-advisor']);
+
+      // New filters: hrAdvisorId and statusIds (appended as repeated statusId)
+      if (params.hrAdvisorId) {
+        searchParams.append('hrAdvisorId', params.hrAdvisorId);
+      }
+      if (params.statusIds?.length) {
+        for (const id of params.statusIds) {
+          searchParams.append('statusId', id.toString());
+        }
+      }
 
       const url = `/profiles${searchParams.toString() ? `?${searchParams.toString()}` : ''}`;
       const result = await apiClient.get<PagedProfileResponse>(url, 'retrieve paginated profiles', accessToken);

--- a/frontend/app/.server/domain/services/profile-service-mock.ts
+++ b/frontend/app/.server/domain/services/profile-service-mock.ts
@@ -58,19 +58,26 @@ export function getMockProfileService(): ProfileService {
         }
       }
 
-      // Apply HR advisor filter
-      if (params['hr-advisor']) {
-        if (params['hr-advisor'] === 'me') {
-          // For mock purposes, filter by hrAdvisorId = 1 when hr-advisor=me
+      // Apply HR advisor filter using hrAdvisorId param
+      if (params.hrAdvisorId) {
+        if (params.hrAdvisorId === 'me') {
+          // For mock purposes, filter by hrAdvisorId = 1 when hrAdvisorId=me
           filteredProfiles = filteredProfiles.filter((p) => p.hrAdvisorId === 1);
           log.debug(`Applied HR advisor filter (me): ${filteredProfiles.length} profiles remaining`);
         } else {
-          const hrAdvisorId = parseInt(params['hr-advisor']);
+          const hrAdvisorId = parseInt(params.hrAdvisorId);
           if (!isNaN(hrAdvisorId)) {
             filteredProfiles = filteredProfiles.filter((p) => p.hrAdvisorId === hrAdvisorId);
             log.debug(`Applied HR advisor filter (${hrAdvisorId}): ${filteredProfiles.length} profiles remaining`);
           }
         }
+      }
+
+      // Apply status filter using statusIds param (array of ids)
+      if (params.statusIds?.length) {
+        const statusIds = params.statusIds.filter((n) => Number.isFinite(n));
+        filteredProfiles = filteredProfiles.filter((p) => (p.profileStatus ? statusIds.includes(p.profileStatus.id) : false));
+        log.debug(`Applied statusId filter (${statusIds.join(',')}): ${filteredProfiles.length} profiles remaining`);
       }
 
       // Apply pagination

--- a/frontend/app/routes/hr-advisor/employees.tsx
+++ b/frontend/app/routes/hr-advisor/employees.tsx
@@ -10,7 +10,7 @@ import * as v from 'valibot';
 
 import type { Route } from './+types/employees';
 
-import type { Profile, ProfileStatus } from '~/.server/domain/models';
+import type { Profile, ProfileQueryParams, ProfileStatus } from '~/.server/domain/models';
 import { getProfileService } from '~/.server/domain/services/profile-service';
 import { getProfileStatusService } from '~/.server/domain/services/profile-status-service';
 import { getUserService } from '~/.server/domain/services/user-service';
@@ -25,7 +25,7 @@ import { InlineLink } from '~/components/links';
 import { LoadingButton } from '~/components/loading-button';
 import { PageTitle } from '~/components/page-title';
 import Pagination from '~/components/pagination';
-import { PROFILE_STATUS_CODE } from '~/domain/constants';
+import { PROFILE_STATUS_APPROVED, PROFILE_STATUS_CODE, PROFILE_STATUS_PENDING } from '~/domain/constants';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
 import { useFetcherState } from '~/hooks/use-fetcher-state';
 import { getTranslation } from '~/i18n-config.server';
@@ -103,12 +103,13 @@ export async function loader({ context, request }: Route.LoaderArgs) {
   // Keep page size modest for wire efficiency, cap to prevent abuse
   const size = Math.min(50, Math.max(1, Number.parseInt(sizeParam ?? '10', 10) || 10));
 
-  const profileParams = {
-    'active': true, // will return In Progress, Pending Approval and Approved
-    'hr-advisor': filter === 'me' ? filter : undefined, // 'me' is used in the API to filter for the current HR advisor
+  const profileParams: ProfileQueryParams = {
+    active: true, // will return In Progress, Pending Approval and Approved
+    hrAdvisorId: filter === 'me' ? filter : undefined, // 'me' is used in the API to filter for the current HR advisor
+    statusIds: [PROFILE_STATUS_APPROVED.id, PROFILE_STATUS_PENDING.id],
     // Backend expects 1-based page index
-    'page': pageOneBased,
-    'size': size,
+    page: pageOneBased,
+    size: size,
   };
 
   const profileService = getProfileService();
@@ -124,17 +125,12 @@ export async function loader({ context, request }: Route.LoaderArgs) {
   }
 
   const profiles = profilesResult.unwrap();
-  const filteredAllProfiles = profiles.content.filter(
-    (profile) =>
-      profile.profileStatus &&
-      [PROFILE_STATUS_CODE.approved, PROFILE_STATUS_CODE.pending].some((id) => id === profile.profileStatus?.code),
-  );
 
   const { serverEnvironment } = await import('~/.server/environment');
 
   return {
     documentTitle: t('app:index.employees'),
-    profiles: filteredAllProfiles,
+    profiles: profiles.content,
     page: profiles.page,
     statuses,
     baseTimeZone: serverEnvironment.BASE_TIMEZONE,

--- a/frontend/tests/.server/domain/services/profile-service-default.test.ts
+++ b/frontend/tests/.server/domain/services/profile-service-default.test.ts
@@ -69,17 +69,17 @@ describe('ProfileServiceDefault', () => {
       mockGet.mockResolvedValue(Ok(mockResponse));
 
       const params = {
-        'page': 2,
-        'size': 20,
-        'active': true,
-        'hr-advisor': '5',
+        page: 2,
+        size: 20,
+        active: true,
+        hrAdvisorId: '5',
       };
       const accessToken = 'valid-token';
 
       await defaultProfileService.getProfiles(params, accessToken);
 
       expect(mockGet).toHaveBeenCalledWith(
-        '/profiles?page=2&size=20&active=true&hr-advisor=5',
+        '/profiles?page=2&size=20&active=true&hrAdvisorId=5',
         'retrieve paginated profiles',
         accessToken,
       );

--- a/frontend/tests/.server/domain/services/profile-service-mock.test.ts
+++ b/frontend/tests/.server/domain/services/profile-service-mock.test.ts
@@ -63,7 +63,7 @@ describe('ProfileServiceMock', () => {
     });
 
     it('should filter by HR advisor when specified', async () => {
-      const params = { 'hr-advisor': '5' };
+      const params = { hrAdvisorId: '5' };
       const accessToken = 'valid-token';
 
       const result = await mockProfileService.getProfiles(params, accessToken);
@@ -78,7 +78,7 @@ describe('ProfileServiceMock', () => {
     });
 
     it('should handle empty results', async () => {
-      const params = { 'hr-advisor': '999' }; // Non-existent HR advisor
+      const params = { hrAdvisorId: '999' }; // Non-existent HR advisor
       const accessToken = 'valid-token';
 
       const result = await mockProfileService.getProfiles(params, accessToken);


### PR DESCRIPTION
This pull request updates the filtering logic for profile queries to support new filter parameters and improves type safety and consistency across the codebase. The main changes include replacing the old `'hr-advisor'` parameter with `hrAdvisorId`, introducing a new `statusIds` filter, and updating related service, route, and test files to use the new parameters and types.

**Profile Query Parameter Improvements**
* Changed the `ProfileQueryParams` type in `models.ts` to use `hrAdvisorId` instead of `'hr-advisor'`, and added a new `statusIds` array for filtering by profile status IDs.

**Service Layer Updates**
* Updated both the default and mock profile services (`profile-service-default.ts` and `profile-service-mock.ts`) to use the new `hrAdvisorId` and `statusIds` parameters for filtering, replacing all uses of `'hr-advisor'`. The mock service now supports filtering profiles by multiple status IDs. [[1]](diffhunk://#diff-ea09278ac6f5784b74517dddd26c9057c808849c0b0ebebc2aa4de2eddc066b1L32-R41) [[2]](diffhunk://#diff-35798cb8db5aba72a6e498702d258c7f1b85e877d6f9d85eaa8ba6547c34c118L61-R82)

**Route and Loader Updates**
* Refactored the HR advisor employees route loader to use the `ProfileQueryParams` type and the new filter parameters, ensuring only relevant profiles are fetched directly from the backend. Removed redundant client-side filtering. [[1]](diffhunk://#diff-c9e3632f5b380d7e64f31440fe26de52f5f8bf52b270c9f42e6ca754206ca755L13-R13) [[2]](diffhunk://#diff-c9e3632f5b380d7e64f31440fe26de52f5f8bf52b270c9f42e6ca754206ca755L106-R112) [[3]](diffhunk://#diff-c9e3632f5b380d7e64f31440fe26de52f5f8bf52b270c9f42e6ca754206ca755L127-R133)

**Test Updates**
* Updated tests for both default and mock profile services to use the new `hrAdvisorId` parameter instead of `'hr-advisor'`, ensuring tests reflect the new filtering logic. [[1]](diffhunk://#diff-0656b61450c877748dc82959d3f81a2886a561cec40fd077f54524e72ed0fb90L72-R82) [[2]](diffhunk://#diff-6e827e259f3d780c3cbd3c56ce30915e35ff5ab46c5c90c123a895d8fb133425L66-R66) [[3]](diffhunk://#diff-6e827e259f3d780c3cbd3c56ce30915e35ff5ab46c5c90c123a895d8fb133425L81-R81)

**Constants Import Update**
* Added imports for `PROFILE_STATUS_APPROVED` and `PROFILE_STATUS_PENDING` to support the new status filtering in the HR advisor employees route.