### PR TITLE
refactor(fronend) i18nRedirect params in request pages

### DIFF
--- a/frontend/app/routes/hiring-manager/request/position-information.tsx
+++ b/frontend/app/routes/hiring-manager/request/position-information.tsx
@@ -96,9 +96,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     throw updateResult.unwrapErr();
   }
 
-  return i18nRedirect('routes/hiring-manager/request/index.tsx', request, {
-    params: { requestId: requestData.id.toString() },
-  });
+  return i18nRedirect('routes/hiring-manager/request/index.tsx', request, { params });
 }
 
 export async function loader({ context, request, params }: Route.LoaderArgs) {

--- a/frontend/app/routes/hiring-manager/request/process-information.tsx
+++ b/frontend/app/routes/hiring-manager/request/process-information.tsx
@@ -79,9 +79,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     throw updateResult.unwrapErr();
   }
 
-  return i18nRedirect('routes/hiring-manager/request/index.tsx', request, {
-    params: { requestId: requestData.id.toString() },
-  });
+  return i18nRedirect('routes/hiring-manager/request/index.tsx', request, { params });
 }
 
 export async function loader({ context, request, params }: Route.LoaderArgs) {

--- a/frontend/app/routes/hr-advisor/request/position-information.tsx
+++ b/frontend/app/routes/hr-advisor/request/position-information.tsx
@@ -96,9 +96,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     throw updateResult.unwrapErr();
   }
 
-  return i18nRedirect('routes/hr-advisor/request/index.tsx', request, {
-    params: { requestId: requestData.id.toString() },
-  });
+  return i18nRedirect('routes/hr-advisor/request/index.tsx', request, { params });
 }
 
 export async function loader({ context, request, params }: Route.LoaderArgs) {

--- a/frontend/app/routes/hr-advisor/request/process-information.tsx
+++ b/frontend/app/routes/hr-advisor/request/process-information.tsx
@@ -79,9 +79,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     throw updateResult.unwrapErr();
   }
 
-  return i18nRedirect('routes/hr-advisor/request/index.tsx', request, {
-    params: { requestId: requestData.id.toString() },
-  });
+  return i18nRedirect('routes/hr-advisor/request/index.tsx', request, { params });
 }
 
 export async function loader({ context, request, params }: Route.LoaderArgs) {


### PR DESCRIPTION
## Summary

We can get away with just returning `params` for the redirect to work as expected