### PR TITLE
feat(frontend): allow controlled selection for hr-advisor/employees table Status column

### DIFF
--- a/frontend/app/components/data-table.tsx
+++ b/frontend/app/components/data-table.tsx
@@ -178,22 +178,20 @@ export function DataTableColumnHeaderWithOptions<TData, TValue>({
   selected: controlledSelected,
   onSelectionChange,
 }: DataTableColumnHeaderWithOptionsProps<TData, TValue>) {
-  // Prefer controlled selection when provided; fall back to column filter state
-  const selected = controlledSelected ?? column.getFilterValue();
+  // Source of truth: controlled 'selected' if provided, else column filter state
+  const selectedValues: string[] = controlledSelected ?? (column.getFilterValue() as string[] | undefined) ?? [];
 
-  const toggleOption = (value: string) => {
-    let next: string[];
-
-    if (selected?.includes(value)) {
-      next = selected.filter((v) => v !== value);
-    } else {
-      next = [...(selected ?? []), value];
-    }
-
+  const setSelectedValues = (next: string[]) => {
     // Update internal column filter for local filtering/sorting UX
     column.setFilterValue(next.length ? next : undefined);
     // Notify parent when controlled handling is desired
     onSelectionChange?.(next);
+  };
+
+  const toggleOption = (value: string) => {
+    const has = selectedValues.includes(value);
+    const next = has ? selectedValues.filter((v) => v !== value) : [...selectedValues, value];
+    setSelectedValues(next);
   };
 
   return (
@@ -218,7 +216,7 @@ export function DataTableColumnHeaderWithOptions<TData, TValue>({
               <label className="flex w-full cursor-pointer items-center gap-2 px-2 py-1.5">
                 <input
                   type="checkbox"
-                  checked={selected?.includes(option) ?? false}
+                  checked={selectedValues.includes(option)}
                   onChange={() => toggleOption(option)}
                   className="h-4 w-4"
                 />

--- a/frontend/app/components/data-table.tsx
+++ b/frontend/app/components/data-table.tsx
@@ -179,7 +179,7 @@ export function DataTableColumnHeaderWithOptions<TData, TValue>({
   onSelectionChange,
 }: DataTableColumnHeaderWithOptionsProps<TData, TValue>) {
   // Prefer controlled selection when provided; fall back to column filter state
-  const selected = (controlledSelected ?? (column.getFilterValue() as string[] | undefined)) as string[] | undefined;
+  const selected = controlledSelected ?? column.getFilterValue();
 
   const toggleOption = (value: string) => {
     let next: string[];

--- a/frontend/app/components/data-table.tsx
+++ b/frontend/app/components/data-table.tsx
@@ -164,6 +164,10 @@ interface DataTableColumnHeaderWithOptionsProps<TData, TValue> {
   title: string;
   options: string[];
   className?: string;
+  // Optional controlled selection of option values (e.g., status codes)
+  selected?: string[];
+  // Optional change notifier when selection updates
+  onSelectionChange?: (selected: string[]) => void;
 }
 
 export function DataTableColumnHeaderWithOptions<TData, TValue>({
@@ -171,8 +175,11 @@ export function DataTableColumnHeaderWithOptions<TData, TValue>({
   title,
   options,
   className,
+  selected: controlledSelected,
+  onSelectionChange,
 }: DataTableColumnHeaderWithOptionsProps<TData, TValue>) {
-  const selected = column.getFilterValue() as string[] | undefined;
+  // Prefer controlled selection when provided; fall back to column filter state
+  const selected = (controlledSelected ?? (column.getFilterValue() as string[] | undefined)) as string[] | undefined;
 
   const toggleOption = (value: string) => {
     let next: string[];
@@ -183,7 +190,10 @@ export function DataTableColumnHeaderWithOptions<TData, TValue>({
       next = [...(selected ?? []), value];
     }
 
+    // Update internal column filter for local filtering/sorting UX
     column.setFilterValue(next.length ? next : undefined);
+    // Notify parent when controlled handling is desired
+    onSelectionChange?.(next);
   };
 
   return (

--- a/frontend/app/routes/hr-advisor/employees.tsx
+++ b/frontend/app/routes/hr-advisor/employees.tsx
@@ -108,7 +108,7 @@ export async function loader({ context, request }: Route.LoaderArgs) {
   // Shared default selection for statuses (kept in sync with client UI)
   const DEFAULT_STATUS_IDS = [PROFILE_STATUS_APPROVED.id, PROFILE_STATUS_PENDING.id] as const;
   // Compute desired statusIds, defaulting to Approved + Pending Approval
-  const defaultStatusIds = DEFAULT_STATUS_IDS as unknown as number[];
+  const defaultStatusIds = [...DEFAULT_STATUS_IDS];
   const statusIdsFromQuery = (statusIdsParam ?? '')
     .split(',')
     .map((s) => Number.parseInt(s.trim(), 10))

--- a/frontend/app/routes/hr-advisor/employees.tsx
+++ b/frontend/app/routes/hr-advisor/employees.tsx
@@ -213,7 +213,9 @@ export default function EmployeeDashboard({ loaderData, params }: Route.Componen
 
   // Selected status codes for the DataTable header control
   const selectedStatusCodes = useMemo(
-    () => selectedStatusIds.map((id: number) => statusCodeById.get(id)).filter(Boolean) as string[],
+    () => selectedStatusIds
+      .map((id: number) => statusCodeById.get(id))
+      .filter((code): code is string => code !== undefined),
     [selectedStatusIds, statusCodeById],
   );
 

--- a/frontend/app/routes/hr-advisor/employees.tsx
+++ b/frontend/app/routes/hr-advisor/employees.tsx
@@ -213,9 +213,7 @@ export default function EmployeeDashboard({ loaderData, params }: Route.Componen
 
   // Selected status codes for the DataTable header control
   const selectedStatusCodes = useMemo(
-    () => selectedStatusIds
-      .map((id: number) => statusCodeById.get(id))
-      .filter((code): code is string => code !== undefined),
+    () => selectedStatusIds.map((id: number) => statusCodeById.get(id)).filter((code): code is string => code !== undefined),
     [selectedStatusIds, statusCodeById],
   );
 

--- a/frontend/app/routes/hr-advisor/employees.tsx
+++ b/frontend/app/routes/hr-advisor/employees.tsx
@@ -35,6 +35,9 @@ import { getCurrentPage, getPageItems, makePageClickHandler, nextPage, prevPage 
 import { formString } from '~/utils/string-utils';
 import { extractValidationKey } from '~/utils/validation-utils';
 
+// Shared default selection for statuses (kept in sync between loader and client UI)
+const DEFAULT_STATUS_IDS = [PROFILE_STATUS_APPROVED.id, PROFILE_STATUS_PENDING.id] as const;
+
 export const handle = {
   i18nNamespace: [...parentHandle.i18nNamespace],
 } as const satisfies RouteHandle;
@@ -105,8 +108,6 @@ export async function loader({ context, request }: Route.LoaderArgs) {
   // Keep page size modest for wire efficiency, cap to prevent abuse
   const size = Math.min(50, Math.max(1, Number.parseInt(sizeParam ?? '10', 10) || 10));
 
-  // Shared default selection for statuses (kept in sync with client UI)
-  const DEFAULT_STATUS_IDS = [PROFILE_STATUS_APPROVED.id, PROFILE_STATUS_PENDING.id] as const;
   // Compute desired statusIds, defaulting to Approved + Pending Approval
   const defaultStatusIds = [...DEFAULT_STATUS_IDS];
   const rawStatusValues = statusIdsParams;
@@ -150,8 +151,6 @@ export async function loader({ context, request }: Route.LoaderArgs) {
 }
 
 export default function EmployeeDashboard({ loaderData, params }: Route.ComponentProps) {
-  // Keep loader and client UI defaults in sync; memoize to keep stable reference for deps
-  const DEFAULT_STATUS_IDS = useMemo(() => [PROFILE_STATUS_APPROVED.id, PROFILE_STATUS_PENDING.id] as const, []);
   const { t } = useTranslation(handle.i18nNamespace);
   const fetcher = useFetcher<typeof action>();
   const fetcherState = useFetcherState(fetcher);
@@ -208,7 +207,7 @@ export default function EmployeeDashboard({ loaderData, params }: Route.Componen
     return Array.from(new Set(parts.map((s) => Number.parseInt(s.trim(), 10)).filter((n) => Number.isFinite(n)))).sort(
       (a, b) => a - b,
     );
-  }, [searchParams, DEFAULT_STATUS_IDS]);
+  }, [searchParams]);
 
   // Selected status codes for the DataTable header control
   const selectedStatusCodes = useMemo(


### PR DESCRIPTION
This pull request enhances the hr-advisors/employees table filtering functionality by introducing a controlled selection for status codes and ensuring consistent synchronization between the client UI and backend queries. The changes improve both usability and accessibility, allowing users to filter employees by status more intuitively and ensuring that filter selections persist across navigation and updates.

**Filtering and selection improvements:**

* Added controlled selection support to the `DataTableColumnHeaderWithOptions` component via new `selected` and `onSelectionChange` props, enabling parent components to manage the selected status codes and react to changes.
* Updated the employee dashboard to map between status codes and IDs, allowing the UI to display status codes while the backend receives corresponding IDs for filtering. This includes memoized mappings and logic to keep selected status codes and IDs synchronized with URL parameters.

**Backend query and default synchronization:**

* Modified the loader in `hr-advisor/employees.tsx` to parse `statusIds` from the URL and default to "Approved" and "Pending Approval" statuses when not specified, ensuring consistent filter defaults between the frontend and backend.
* Synced default status ID selection between loader and client UI using a shared constant, ensuring that both sides use the same initial filter values.

**Navigation and accessibility enhancements:**

* Updated filter change handlers to preserve selected status IDs when switching filters or paginating, and added screen reader announcements for filter updates to improve accessibility. [[1]](diffhunk://#diff-c9e3632f5b380d7e64f31440fe26de52f5f8bf52b270c9f42e6ca754206ca755L292-R350) [[2]](diffhunk://#diff-c9e3632f5b380d7e64f31440fe26de52f5f8bf52b270c9f42e6ca754206ca755R263-R274)