### PR TITLE
refactor(frontend): remove text box from personal information route

### DIFF
--- a/frontend/app/.server/domain/models.ts
+++ b/frontend/app/.server/domain/models.ts
@@ -149,7 +149,6 @@ export type PageMetadata = Readonly<{
 // Profile Models - Based on OpenAPI ProfileReadModel schema
 export type Profile = Readonly<{
   id: number;
-  additionalComment?: string;
   hasConsentedToPrivacyTerms?: boolean;
   hrAdvisorId?: number;
   isAvailableForReferral?: boolean;
@@ -178,7 +177,6 @@ export type Profile = Readonly<{
 // Profile PUT Model - Based on OpenAPI ProfilePutModel schema
 // Used for updating profiles via PUT /api/v1/profiles/{id}
 export type ProfilePutModel = Readonly<{
-  additionalComment?: string;
   cityId?: number;
   classificationId?: number;
   hasConsentedToPrivacyTerms?: boolean;

--- a/frontend/app/.server/domain/services/mockData.ts
+++ b/frontend/app/.server/domain/services/mockData.ts
@@ -202,7 +202,6 @@ export function buildProfilesFromTemplates(): Profile[] {
       profileId: 1,
       userId: 1,
       data: {
-        additionalComment: 'Looking for opportunities in software development.',
         hasConsentedToPrivacyTerms: false,
         hrAdvisorId: undefined,
         isAvailableForReferral: undefined,
@@ -221,7 +220,6 @@ export function buildProfilesFromTemplates(): Profile[] {
       profileId: 2,
       userId: 2,
       data: {
-        additionalComment: undefined,
         hasConsentedToPrivacyTerms: false,
         hrAdvisorId: undefined,
         isAvailableForReferral: undefined,
@@ -240,7 +238,6 @@ export function buildProfilesFromTemplates(): Profile[] {
       profileId: 3,
       userId: 3,
       data: {
-        additionalComment: 'Interested in remote work.',
         hasConsentedToPrivacyTerms: true,
         hrAdvisorId: 1,
         isAvailableForReferral: false,
@@ -259,7 +256,6 @@ export function buildProfilesFromTemplates(): Profile[] {
       profileId: 4,
       userId: 4,
       data: {
-        additionalComment: 'Fluent in French and English.',
         hasConsentedToPrivacyTerms: true,
         hrAdvisorId: 1,
         isAvailableForReferral: true,
@@ -278,7 +274,6 @@ export function buildProfilesFromTemplates(): Profile[] {
       profileId: 5,
       userId: 5,
       data: {
-        additionalComment: 'Open to contract roles.',
         hasConsentedToPrivacyTerms: true,
         hrAdvisorId: 5,
         isAvailableForReferral: true,
@@ -345,7 +340,6 @@ export function createAndLinkNewMockProfile(accessToken: string): Profile {
   const newProfile: Profile = {
     id: newProfileId,
     profileStatus: PROFILE_STATUS_INCOMPLETE,
-    additionalComment: 'Looking for opportunities in software development.',
     hasConsentedToPrivacyTerms: false,
     personalEmailAddress: 'personal.email@example.com',
     personalPhoneNumber: '613-938-0001',

--- a/frontend/app/.server/domain/services/profile-service-mock.ts
+++ b/frontend/app/.server/domain/services/profile-service-mock.ts
@@ -331,7 +331,6 @@ export function getMockProfileService(): ProfileService {
       const updatedProfile: Profile = {
         ...existingProfile,
         // Map ProfilePutModel properties to Profile properties
-        additionalComment: profile.additionalComment ?? existingProfile.additionalComment,
         hasConsentedToPrivacyTerms: profile.hasConsentedToPrivacyTerms ?? existingProfile.hasConsentedToPrivacyTerms,
         isAvailableForReferral: profile.isAvailableForReferral ?? existingProfile.isAvailableForReferral,
         isInterestedInAlternation: profile.isInterestedInAlternation ?? existingProfile.isInterestedInAlternation,

--- a/frontend/app/.server/locales/app-en.ts
+++ b/frontend/app/.server/locales/app-en.ts
@@ -83,8 +83,8 @@ export default {
     'personal-phone': 'Personal phone number',
     'personal-phone-help-message-primary': 'Cell, home, or other. For example <noWrap>123 456 7890</noWrap>',
     'work-phone-help-message-primary': 'For example: <noWrap>123 456 7890</noWrap>',
-    'additional-information': 'Additional information',
-    'additional-info-help-message': 'Briefly note absences or other key information.',
+    'additional-information':
+      'For any additional information regarding your personal information (for example, changes to your contact details or leave of absence) please contact the HR advisor indicated on your workforce adjustment status letter.',
     'errors': {
       'surname-required': 'Surname is required',
       'givenName-required': 'Given name is required',
@@ -99,8 +99,6 @@ export default {
       'work-phone-invalid': 'Invalid work phone number.',
       'personal-phone-required': 'Personal phone number is required.',
       'personal-phone-invalid': 'Invalid personal phone number.',
-      'additional-information-required': 'Additional information is required.',
-      'additional-information-max-length': 'Additional information must be less than 100 characters.',
     },
   },
   'employment-information': {

--- a/frontend/app/.server/locales/app-fr.ts
+++ b/frontend/app/.server/locales/app-fr.ts
@@ -86,8 +86,8 @@ export default {
     'personal-phone': 'Numéro du téléphone personnel',
     'personal-phone-help-message-primary': 'Cellulaire, domicile ou autre. Par exemple\u00A0: <noWrap>123 456 7890</noWrap>',
     'work-phone-help-message-primary': 'Par exemple\u00A0: <noWrap>123 456 7890</noWrap>',
-    'additional-information': 'Renseignements supplémentaires',
-    'additional-info-help-message': 'Veuillez noter brièvement les absences ou autres informations clés.',
+    'additional-information':
+      'Pour toute information additionnelle concernant vos informations personnelles (par exemple, changement à vos coordonnées ou congé) veuillez communiquer avec le conseiller en RH indiqué sur votre lettre de statut sous le réaménagement des effectifs.',
     'errors': {
       'surname-required': 'Le nom de famille est requis',
       'givenName-required': 'Le prénom est requis',
@@ -102,8 +102,6 @@ export default {
       'work-phone-invalid': "Le numéro du téléphone au travail n'est pas valide.",
       'personal-phone-required': 'Le numéro du téléphone personnel est requis.',
       'personal-phone-invalid': "Le numéro du téléphone personnel n'est pas valide.",
-      'additional-information-required': 'Renseignements supplémentaires est requis.',
-      'additional-information-max-length': "L'information supplémentaire doit contenir moins de 100 caractères.",
     },
   },
   'employment-information': {

--- a/frontend/app/.server/utils/profile-utils.ts
+++ b/frontend/app/.server/utils/profile-utils.ts
@@ -150,7 +150,6 @@ export async function getHrAdvisors(accessToken: string): Promise<User[]> {
  */
 export function mapProfileToPutModel(profile: Profile): ProfilePutModel {
   return {
-    additionalComment: profile.additionalComment,
     cityId: profile.substantiveCity?.id,
     classificationId: profile.substantiveClassification?.id,
     hasConsentedToPrivacyTerms: profile.hasConsentedToPrivacyTerms,

--- a/frontend/app/routes/employee/profile/index.tsx
+++ b/frontend/app/routes/employee/profile/index.tsx
@@ -290,7 +290,6 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
       personalEmail: profileData.personalEmailAddress,
       workPhone: currentUser.businessPhoneNumber,
       personalPhone: profileData.personalPhoneNumber,
-      additionalInformation: profileData.additionalComment,
     },
     employmentInformation: {
       isComplete: isCompleteEmploymentInformation,
@@ -499,9 +498,6 @@ export default function EditProfile({ loaderData, params }: Route.ComponentProps
               </DescriptionListItem>
               <DescriptionListItem term={t('app:personal-information.personal-phone')}>
                 {loaderData.personalInformation.personalPhone ?? t('app:profile.not-provided')}
-              </DescriptionListItem>
-              <DescriptionListItem term={t('app:personal-information.additional-information')}>
-                {loaderData.personalInformation.additionalInformation ?? t('app:profile.not-provided')}
               </DescriptionListItem>
             </DescriptionList>
           )}

--- a/frontend/app/routes/employee/profile/personal-information.tsx
+++ b/frontend/app/routes/employee/profile/personal-information.tsx
@@ -45,7 +45,6 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     personalEmailAddress: formString(formData.get('personalEmailAddress')),
     businessPhoneNumber: formString(formData.get('businessPhoneNumber')),
     personalPhoneNumber: formString(formData.get('personalPhoneNumber')),
-    additionalComment: formString(formData.get('additionalComment')),
   });
 
   if (!parseResult.success) {
@@ -105,7 +104,6 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     languageOfCorrespondenceId: personalInformationForProfile.languageOfCorrespondenceId,
     personalEmailAddress: personalInformationForProfile.personalEmailAddress,
     personalPhoneNumber: personalInformationForProfile.personalPhoneNumber,
-    additionalComment: personalInformationForProfile.additionalComment,
   });
 
   const updateResult = await profileService.updateProfileById(
@@ -147,7 +145,6 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
       personalEmailAddress: profileData.personalEmailAddress,
       businessPhoneNumber: toE164(currentUser.businessPhoneNumber),
       personalPhoneNumber: toE164(profileData.personalPhoneNumber),
-      additionalComment: profileData.additionalComment,
     },
     languagesOfCorrespondence: localizedLanguagesOfCorrespondenceResult,
   };

--- a/frontend/app/routes/hr-advisor/employee-profile/index.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/index.tsx
@@ -202,7 +202,6 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
       personalEmail: profileData.personalEmailAddress,
       workPhone: profileUser?.businessPhoneNumber ?? profileData.profileUser.businessPhoneNumber,
       personalPhone: profileData.personalPhoneNumber,
-      additionalInformation: profileData.additionalComment,
     },
     employmentInformation: {
       substantivePosition: substantivePosition,
@@ -333,9 +332,6 @@ export default function EditProfile({ loaderData, params }: Route.ComponentProps
             </DescriptionListItem>
             <DescriptionListItem term={t('app:personal-information.personal-phone')}>
               {loaderData.personalInformation.personalPhone ?? t('app:profile.not-provided')}
-            </DescriptionListItem>
-            <DescriptionListItem term={t('app:personal-information.additional-information')}>
-              {loaderData.personalInformation.additionalInformation ?? t('app:profile.not-provided')}
             </DescriptionListItem>
           </DescriptionList>
         </ProfileCard>

--- a/frontend/app/routes/hr-advisor/employee-profile/personal-information.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/personal-information.tsx
@@ -53,7 +53,6 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     personalEmailAddress: formString(formData.get('personalEmailAddress')),
     businessPhoneNumber: formString(formData.get('businessPhoneNumber')),
     personalPhoneNumber: formString(formData.get('personalPhoneNumber')),
-    additionalComment: formString(formData.get('additionalComment')),
   });
 
   if (!parseResult.success) {
@@ -107,7 +106,6 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     languageOfCorrespondenceId: personalInformationForProfile.languageOfCorrespondenceId,
     personalEmailAddress: personalInformationForProfile.personalEmailAddress,
     personalPhoneNumber: personalInformationForProfile.personalPhoneNumber,
-    additionalComment: personalInformationForProfile.additionalComment,
   });
 
   const updateProfileResult = await profileService.updateProfileById(
@@ -150,7 +148,6 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
       personalEmailAddress: profileData.personalEmailAddress,
       businessPhoneNumber: toE164(profileData.profileUser.businessPhoneNumber),
       personalPhoneNumber: toE164(profileData.personalPhoneNumber),
-      additionalComment: profileData.additionalComment,
     },
     languagesOfCorrespondence: localizedLanguagesOfCorrespondenceResult,
   };

--- a/frontend/app/routes/page-components/employees/personal-information/form.tsx
+++ b/frontend/app/routes/page-components/employees/personal-information/form.tsx
@@ -12,7 +12,6 @@ import { FormErrorSummary } from '~/components/error-summary';
 import { InputField } from '~/components/input-field';
 import { InputPhoneField } from '~/components/input-phone-field';
 import { InputRadios } from '~/components/input-radios';
-import { InputTextarea } from '~/components/input-textarea';
 import { PageTitle } from '~/components/page-title';
 import type { I18nRouteFile } from '~/i18n-routes';
 import type { Errors } from '~/routes/page-components/employees/validation.server';
@@ -27,7 +26,6 @@ export type UserPersonalInformation = {
   personalEmailAddress?: string;
   businessPhoneNumber?: string;
   personalPhoneNumber?: string;
-  additionalComment?: string;
 };
 
 interface PersonalInformationFormProps {
@@ -137,16 +135,7 @@ export function PersonalInformationForm({
               }
               required
             />
-            <InputTextarea
-              id="additional-comment"
-              className="w-full"
-              label={t('personal-information.additional-information')}
-              name="additionalComment"
-              defaultValue={formValues?.additionalComment}
-              errorMessage={t(extractValidationKey(formErrors?.additionalComment))}
-              helpMessage={t('personal-information.additional-info-help-message')}
-              maxLength={100}
-            />
+            <p className="block max-w-prose text-gray-500">{t('personal-information.additional-information')}</p>
             <div className="mt-8 flex flex-wrap items-center justify-start gap-3">
               <ButtonLink file={cancelLink} params={params} id="cancel-button" variant="alternative">
                 {t('form.cancel')}

--- a/frontend/app/routes/page-components/employees/validation.server.ts
+++ b/frontend/app/routes/page-components/employees/validation.server.ts
@@ -264,13 +264,6 @@ export async function createPersonalInformationSchema() {
       v.custom((val) => isValidPhone(val as string), 'app:personal-information.errors.personal-phone-invalid'),
       v.transform((val) => parsePhoneNumberWithError(val, 'CA').formatInternational().replace(/ /g, '')),
     ),
-    additionalComment: v.optional(
-      v.pipe(
-        v.string('app:personal-information.errors.additional-information-required'),
-        v.trim(),
-        v.maxLength(100, 'app:personal-information.errors.additional-information-max-length'),
-      ),
-    ),
   });
 }
 

--- a/frontend/tests/.server/domain/services/profile-service-default.test.ts
+++ b/frontend/tests/.server/domain/services/profile-service-default.test.ts
@@ -32,7 +32,6 @@ describe('ProfileServiceDefault', () => {
       content: [
         {
           id: 1,
-          additionalComment: 'Test comment',
           hasConsentedToPrivacyTerms: true,
           profileUser: { id: 1, firstName: 'John', lastName: 'Doe' },
           profileStatus: { id: 1, code: 'PENDING', nameEn: 'Pending', nameFr: 'En attente' },
@@ -280,7 +279,6 @@ describe('ProfileServiceDefault', () => {
   describe('getProfileById', () => {
     const mockProfile = {
       id: 42,
-      additionalComment: 'Detailed profile',
       hasConsentedToPrivacyTerms: true,
       hrAdvisorId: 5,
       profileUser: { id: 3, firstName: 'Jane', lastName: 'Smith' },
@@ -325,7 +323,6 @@ describe('ProfileServiceDefault', () => {
   describe('updateProfileById', () => {
     const mockUpdatedProfile = {
       id: 42,
-      additionalComment: 'Updated comment',
       hasConsentedToPrivacyTerms: true,
       personalEmailAddress: 'updated@example.com',
       lastModifiedDate: '2024-01-15T12:00:00Z',
@@ -337,7 +334,6 @@ describe('ProfileServiceDefault', () => {
 
       const profileId = 42;
       const updatedProfile: ProfilePutModel = {
-        additionalComment: 'Updated comment',
         hasConsentedToPrivacyTerms: true,
         personalEmailAddress: 'updated@example.com',
       };
@@ -356,7 +352,6 @@ describe('ProfileServiceDefault', () => {
       if (result.isOk()) {
         const profile = result.unwrap();
         expect(profile.id).toBe(42);
-        expect(profile.additionalComment).toBe('Updated comment');
         expect(profile.personalEmailAddress).toBe('updated@example.com');
       }
     });
@@ -366,7 +361,7 @@ describe('ProfileServiceDefault', () => {
       mockPut.mockResolvedValue(updateError);
 
       const profileId = 42;
-      const updatedProfile: ProfilePutModel = { additionalComment: 'Updated comment' };
+      const updatedProfile: ProfilePutModel = { personalEmailAddress: 'updated@example.com' };
       const accessToken = 'valid-token';
 
       const result = await defaultProfileService.updateProfileById(profileId, updatedProfile, accessToken);
@@ -488,7 +483,7 @@ describe('ProfileServiceDefault', () => {
       await defaultProfileService.getCurrentUserProfiles({}, accessToken);
       await defaultProfileService.registerProfile(accessToken);
       await defaultProfileService.getProfileById(1, accessToken);
-      await defaultProfileService.updateProfileById(1, { additionalComment: 'test' }, accessToken);
+      await defaultProfileService.updateProfileById(1, { personalEmailAddress: 'updated@example.com' }, accessToken);
       await defaultProfileService.updateProfileStatus(1, {}, accessToken);
       await defaultProfileService.findProfileById(1, accessToken);
 
@@ -500,7 +495,7 @@ describe('ProfileServiceDefault', () => {
       expect(mockPut).toHaveBeenCalledWith(
         '/profiles/1',
         'update profile with ID 1',
-        { additionalComment: 'test' },
+        { personalEmailAddress: 'updated@example.com' },
         accessToken,
       );
       expect(mockPut).toHaveBeenCalledWith('/profiles/1/status', 'update profile status for ID 1', {}, accessToken);

--- a/frontend/tests/.server/domain/services/profile-service-mock.test.ts
+++ b/frontend/tests/.server/domain/services/profile-service-mock.test.ts
@@ -210,7 +210,6 @@ describe('ProfileServiceMock', () => {
         expect(profile.hasConsentedToPrivacyTerms).toBe(false);
         expect(profile.personalEmailAddress).toBe('personal.email@example.com');
         expect(profile.personalPhoneNumber).toBe('613-938-0001');
-        expect(profile.additionalComment).toBe('Looking for opportunities in software development.');
       }
     });
   });
@@ -265,7 +264,6 @@ describe('ProfileServiceMock', () => {
     it('should update profile successfully', async () => {
       const profileId = 1;
       const updatedProfile: ProfilePutModel = {
-        additionalComment: 'Updated comment',
         hasConsentedToPrivacyTerms: true,
         isAvailableForReferral: false,
         personalEmailAddress: 'updated@example.com',
@@ -279,7 +277,6 @@ describe('ProfileServiceMock', () => {
       if (result.isOk()) {
         const profile = result.unwrap();
         expect(profile.id).toBe(profileId);
-        expect(profile.additionalComment).toBe('Updated comment');
         expect(profile.hasConsentedToPrivacyTerms).toBe(true);
         expect(profile.isAvailableForReferral).toBe(false);
         expect(profile.personalEmailAddress).toBe('updated@example.com');
@@ -292,7 +289,7 @@ describe('ProfileServiceMock', () => {
     it('should return error when profile not found', async () => {
       const profileId = 999;
       const updatedProfile: ProfilePutModel = {
-        additionalComment: 'Updated comment',
+        wfaEndDate: '',
       };
       const accessToken = 'valid-token';
 
@@ -309,7 +306,7 @@ describe('ProfileServiceMock', () => {
     it('should preserve existing fields when not provided', async () => {
       const profileId = 1;
       const partialUpdate: ProfilePutModel = {
-        additionalComment: 'Only updating comment',
+        wfaEndDate: '',
       };
       const accessToken = 'valid-token';
 
@@ -324,7 +321,7 @@ describe('ProfileServiceMock', () => {
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
         const updatedProfile = result.unwrap();
-        expect(updatedProfile.additionalComment).toBe('Only updating comment');
+        expect(updatedProfile.wfaEndDate).toBe('');
         // Other fields should be preserved
         expect(updatedProfile.profileUser).toEqual(originalProfile.profileUser);
         expect(updatedProfile.profileStatus).toEqual(originalProfile.profileStatus);
@@ -469,8 +466,8 @@ describe('ProfileServiceMock', () => {
           expect(typeof profile.id).toBe('number');
 
           // Optional fields that should have correct types when present
-          if (profile.additionalComment !== undefined) {
-            expect(typeof profile.additionalComment).toBe('string');
+          if (profile.wfaEndDate !== undefined) {
+            expect(typeof profile.wfaEndDate).toBe('string');
           }
           if (profile.hasConsentedToPrivacyTerms !== undefined) {
             expect(typeof profile.hasConsentedToPrivacyTerms).toBe('boolean');

--- a/frontend/tests/utils/profile-utils.test.ts
+++ b/frontend/tests/utils/profile-utils.test.ts
@@ -6,7 +6,6 @@ import { mapProfileToPutModel, mapProfileToPutModelWithOverrides } from '~/.serv
 describe('profile-utils', () => {
   const mockProfile: Profile = {
     id: 1,
-    additionalComment: 'Test comment',
     hasConsentedToPrivacyTerms: false,
     hrAdvisorId: 2,
     isAvailableForReferral: true,
@@ -80,7 +79,6 @@ describe('profile-utils', () => {
       const result = mapProfileToPutModel(mockProfile);
 
       expect(result).toEqual({
-        additionalComment: 'Test comment',
         cityId: 10,
         classificationId: 5,
         hasConsentedToPrivacyTerms: false,
@@ -117,7 +115,6 @@ describe('profile-utils', () => {
       const result = mapProfileToPutModel(minimalProfile);
 
       expect(result).toEqual({
-        additionalComment: undefined,
         cityId: undefined,
         classificationId: undefined,
         hasConsentedToPrivacyTerms: undefined,
@@ -166,7 +163,6 @@ describe('profile-utils', () => {
       const result = mapProfileToPutModelWithOverrides(mockProfile, overrides);
 
       expect(result).toEqual({
-        additionalComment: 'Test comment',
         cityId: 10,
         classificationId: 5,
         hasConsentedToPrivacyTerms: true, // overridden


### PR DESCRIPTION
## Summary

[AB#6975](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/6975)
Removed text box for additional information from personal information route, mocks, model, and updated tests

TODO: the rest of the changes for content change will be done in another pr

## Types of changes

What types of changes does this PR introduce?

- [x] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

<img width="491" height="839" alt="image" src="https://github.com/user-attachments/assets/dfae87be-6514-4276-98cf-2bb5981fd8df" />

Fr route:
<img width="486" height="238" alt="image" src="https://github.com/user-attachments/assets/c98fbc8f-ef6a-47e7-a4f3-aa6af62a1d82" />


Profile:
<img width="480" height="431" alt="image" src="https://github.com/user-attachments/assets/20ebee93-0a4e-434f-a265-bdbc1e1ba619" />



