### PR TITLE
feat(frontend): incrementally adopt RRv7 middleware

### DIFF
--- a/frontend/app/.server/application-context.ts
+++ b/frontend/app/.server/application-context.ts
@@ -1,0 +1,14 @@
+/**
+ * React Router context for providing application-level data to loaders and actions.
+ * This is used by the server-side request handler to pass objects and data to the React application.
+ *
+ * @see https://reactrouter.com/how-to/middleware
+ */
+import { createContext } from 'react-router';
+
+export interface ApplicationContext {
+  readonly nonce: string;
+  readonly session: AppSession;
+}
+
+export const applicationContext = createContext<ApplicationContext>();

--- a/frontend/app/@types/react-router.ts
+++ b/frontend/app/@types/react-router.ts
@@ -2,11 +2,15 @@ import 'react-router';
 
 import type { Namespace } from 'i18next';
 
+import type { ApplicationContext } from '~/.server/application-context';
+
 declare module 'react-router' {
-  interface AppLoadContext {
-    nonce: string;
-    session: AppSession;
-  }
+  ///
+  /// TODO ::: GjB ::: overriding RouterContextProvider here facilitates an incremental adoption of RRv7 middleware
+  ///                  obviously, this should be removed once the full migration to RRv7 middleware is complete
+  ///                  see: https://reactrouter.com/how-to/middleware#migration-from-apploadcontext
+  ///
+  interface RouterContextProvider extends ApplicationContext {}
 
   /**
    * Route handles should export an i18n namespace, if necessary.

--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -2,7 +2,7 @@ import type { RenderToPipeableStreamOptions } from 'react-dom/server';
 import { renderToPipeableStream } from 'react-dom/server';
 
 import { createReadableStreamFromReadable } from '@react-router/node';
-import type { ActionFunctionArgs, AppLoadContext, EntryContext, LoaderFunctionArgs } from 'react-router';
+import type { ActionFunctionArgs, EntryContext, LoaderFunctionArgs, RouterContextProvider } from 'react-router';
 import { ServerRouter } from 'react-router';
 
 import { trace } from '@opentelemetry/api';
@@ -26,7 +26,7 @@ export default async function handleRequest(
   responseStatusCode: number,
   responseHeaders: Headers,
   routerContext: EntryContext,
-  loadContext: AppLoadContext,
+  loadContext: RouterContextProvider,
 ) {
   const language = getLanguage(request);
   const i18n = await initI18next(language);

--- a/frontend/react-router.config.ts
+++ b/frontend/react-router.config.ts
@@ -1,5 +1,9 @@
 import type { Config } from '@react-router/dev/config';
 
 export default {
+  future: {
+    // see: https://reactrouter.com/how-to/middleware
+    v8_middleware: true,
+  },
   serverBuildFile: 'app.js',
 } satisfies Config;

--- a/frontend/tests/.server/routes/index.test.ts
+++ b/frontend/tests/.server/routes/index.test.ts
@@ -1,11 +1,12 @@
 /**
  * Tests for index dashboard selection and routing flow.
  */
-import type { AppLoadContext } from 'react-router';
+import type { RouterContextProvider } from 'react-router';
 import { redirect } from 'react-router';
 
 import { None } from 'oxide.ts';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mock } from 'vitest-mock-extended';
 
 import { getProfileService } from '~/.server/domain/services/profile-service';
 import { getUserService } from '~/.server/domain/services/user-service';
@@ -14,7 +15,7 @@ import { loader as indexLoader } from '~/routes/index';
 
 // Type definitions for test compatibility
 type TestRouteArgs = {
-  context: AppLoadContext;
+  context: RouterContextProvider;
   request: Request;
   params: Record<string, string>;
 };
@@ -87,7 +88,7 @@ const mockProfileService = {
 vi.mocked(getProfileService).mockReturnValue(mockProfileService);
 
 // Helper to create mock context
-function createMockContext(activeDirectoryId: string, name?: string, roles: string[] = []): AppLoadContext {
+function createMockContext(activeDirectoryId: string, name?: string, roles: string[] = []): RouterContextProvider {
   const mockSession = {
     authState: {
       idTokenClaims: {
@@ -114,10 +115,10 @@ function createMockContext(activeDirectoryId: string, name?: string, roles: stri
     },
   } as unknown as AppSession;
 
-  return {
+  return mock({
     nonce: 'test-nonce',
     session: mockSession,
-  };
+  });
 }
 
 describe('Index Dashboard Selection Flow', () => {

--- a/frontend/tests/.server/utils/privacy-consent-utils.test.ts
+++ b/frontend/tests/.server/utils/privacy-consent-utils.test.ts
@@ -1,11 +1,12 @@
 /**
  * Tests for privacy consent utilities and flow.
  */
-import type { AppLoadContext } from 'react-router';
+import type { RouterContextProvider } from 'react-router';
 import { redirect } from 'react-router';
 
-import { None, Some, Ok } from 'oxide.ts';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { None, Ok, Some } from 'oxide.ts';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mock } from 'vitest-mock-extended';
 
 import { getProfileService } from '~/.server/domain/services/profile-service';
 import { getUserService } from '~/.server/domain/services/user-service';
@@ -15,7 +16,7 @@ import { loader as privacyLoader } from '~/routes/employee/profile/privacy-conse
 
 // Type definitions for test compatibility
 type TestRouteArgs = {
-  context: AppLoadContext;
+  context: RouterContextProvider;
   request: Request;
   params: Record<string, string>;
 };
@@ -102,7 +103,7 @@ const mockProfileService = {
 vi.mocked(getProfileService).mockReturnValue(mockProfileService);
 
 // Helper to create mock context
-function createMockContext(activeDirectoryId: string, name?: string, roles: string[] = []): AppLoadContext {
+function createMockContext(activeDirectoryId: string, name?: string, roles: string[] = []): RouterContextProvider {
   const mockSession = {
     authState: {
       idTokenClaims: {
@@ -129,10 +130,10 @@ function createMockContext(activeDirectoryId: string, name?: string, roles: stri
     },
   } as unknown as AppSession;
 
-  return {
+  return mock({
     nonce: 'test-nonce',
     session: mockSession,
-  };
+  });
 }
 
 describe('Privacy Consent Flow', () => {


### PR DESCRIPTION
## Summary

This PR *incrementally* adopts the new middleware pattern introduced in React Router v7. This is part of an effort to modernize the application's routing and data-loading mechanisms.

It will be the first PR of many that will eventually update all of the route loaders and actions.

- enabled the `v8_middleware` future flag in `react-router.config.ts`
- introduced a new `applicationContext` to provide application-level data (eg: `nonce`, `session`) to loaders and actions using the new middleware pattern
- updated the serverside request handler to use `RouterContextProvider` and the new `applicationContext`
- included a temporary compatibility shim to allow for a gradual migration from the old `AppLoadContext` to the new middleware pattern, as recommended in the React Router documentation (<https://reactrouter.com/how-to/middleware#migration-from-apploadcontext>)
- updated types and tests to align with the new `RouterContextProvider` and `applicationContext`

## Resources

- <https://reactrouter.com/how-to/middleware>