### PR TITLE
fix(frontend) profile index decorative banner

### DIFF
--- a/frontend/app/routes/employee/profile/index.tsx
+++ b/frontend/app/routes/employee/profile/index.tsx
@@ -378,29 +378,31 @@ export default function EditProfile({ loaderData, params }: Route.ComponentProps
 
   return (
     <div className="space-y-8">
-      <div className="space-y-4 py-8 text-white">
-        <StatusTag
-          status={{
-            code: loaderData.profileStatus.code,
-            name:
-              loaderData.profileStatus.code === PROFILE_STATUS.PENDING.code
-                ? t('app:profile.pending-status-employee')
-                : loaderData.profileStatus.name,
-          }}
-        />
-        <PageTitle className="after:w-14" containerClassName="my-6">
-          {loaderData.name}
-        </PageTitle>
-        {loaderData.email && <p className="mt-1">{loaderData.email}</p>}
-        <p className="font-normal text-[#9FA3AD]">
-          {t('app:profile.last-updated', { date: browserTZ, name: loaderData.lastUpdatedBy })}
-        </p>
+      <div className="absolute left-0 w-full space-y-4 bg-[rgba(9,28,45,1)] py-8 wrap-break-word text-white">
+        <div className="container">
+          <StatusTag
+            status={{
+              code: loaderData.profileStatus.code,
+              name:
+                loaderData.profileStatus.code === PROFILE_STATUS.PENDING.code
+                  ? t('app:profile.pending-status-employee')
+                  : loaderData.profileStatus.name,
+            }}
+          />
+          <PageTitle className="after:w-14" containerClassName="my-6">
+            {loaderData.name}
+          </PageTitle>
+          {loaderData.email && <p className="mt-1">{loaderData.email}</p>}
+          <p className="font-normal text-[#9FA3AD]">
+            {t('app:profile.last-updated', { date: browserTZ, name: loaderData.lastUpdatedBy })}
+          </p>
+        </div>
         <div
           role="presentation"
-          className="absolute top-25 left-0 -z-10 h-70 w-full scale-x-[-1] bg-[rgba(9,28,45,1)] bg-[url('/VacMan-design-element-06.svg')] bg-size-[450px] bg-left-bottom bg-no-repeat sm:h-60"
+          className="absolute bottom-0 left-0 h-40 w-full scale-x-[-1] bg-[url('/VacMan-design-element-06.svg')] bg-size-[30rem] bg-left-bottom bg-no-repeat"
         />
       </div>
-      <div className="justify-between md:grid md:grid-cols-2">
+      <div className="mt-110 justify-between sm:mt-70 md:grid md:grid-cols-2">
         <div className="max-w-prose">
           <p className="mt-12">
             {loaderData.profileStatus.code === PROFILE_STATUS.PENDING.code

--- a/frontend/app/routes/hr-advisor/employee-profile/index.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/index.tsx
@@ -269,23 +269,25 @@ export default function EditProfile({ loaderData, params }: Route.ComponentProps
 
   return (
     <div className="space-y-8">
-      <div className="space-y-4 py-8 text-white">
-        {loaderData.profileStatus && (
-          <StatusTag status={{ code: loaderData.profileStatus.code, name: loaderData.profileStatus.name }} />
-        )}
-        <PageTitle className="after:w-14" containerClassName="my-6">
-          {loaderData.name}
-        </PageTitle>
-        {loaderData.email && <p className="mt-1">{loaderData.email}</p>}
-        <p className="font-normal text-[#9FA3AD]">
-          {t('app:profile.last-updated', { date: browserTZ, name: loaderData.lastUpdatedBy })}
-        </p>
+      <div className="absolute left-0 w-full space-y-4 bg-[rgba(9,28,45,1)] py-8 wrap-break-word text-white">
+        <div className="container">
+          {loaderData.profileStatus && (
+            <StatusTag status={{ code: loaderData.profileStatus.code, name: loaderData.profileStatus.name }} />
+          )}
+          <PageTitle className="after:w-14" containerClassName="my-6">
+            {loaderData.name}
+          </PageTitle>
+          {loaderData.email && <p className="mt-1">{loaderData.email}</p>}
+          <p className="font-normal text-[#9FA3AD]">
+            {t('app:profile.last-updated', { date: browserTZ, name: loaderData.lastUpdatedBy })}
+          </p>
+        </div>
         <div
           role="presentation"
           className="absolute top-25 left-0 -z-10 h-70 w-full scale-x-[-1] bg-[rgba(9,28,45,1)] bg-[url('/VacMan-design-element-06.svg')] bg-size-[450px] bg-left-bottom bg-no-repeat sm:h-60"
         />
       </div>
-      <div className="justify-between md:grid md:grid-cols-2">
+      <div className="mt-110 justify-between sm:mt-70 md:grid md:grid-cols-2">
         <div className="max-w-prose">
           <InlineLink
             className="mt-6 block"


### PR DESCRIPTION
## Summary

One a11y issue that we received is low colour contrast between foreground and background, specifically in the profile index banner.  This happens because content overflows its container and white/gray text appears on a white background.  

The banner itself is hard to fix, due in part to it needing to break out of its container to occupy the full screen width, thus we've placed it `absolute`.  This has the unfortunate side-effect of taking it out of the document flow for styling, and anything below the banner will float up and underneath it.  

I think we should let the banner occupy the full height of its content (always), instead of just giving a fixed height to accommodate the decorative banner.  This will allow the banner to never overflow text.  Unfortunately, we have to give fixed margin/padding on top so the content underneath is visible.

after: 
<img width="1888" height="841" alt="image" src="https://github.com/user-attachments/assets/7ff8da8d-e4a7-4f64-ae36-6afa46f3bbf0" />

<img width="521" height="723" alt="image" src="https://github.com/user-attachments/assets/414661b6-cd82-439b-9dc7-b9164c9c3bc3" />

before:

<img width="883" height="847" alt="image" src="https://github.com/user-attachments/assets/889270b9-6f1f-4650-b23e-ab71afa0f8f8" />


