### PR TITLE
fix(frontend): align styling and aria attributes between dialogs

### DIFF
--- a/frontend/app/routes/hiring-manager/request/index.tsx
+++ b/frontend/app/routes/hiring-manager/request/index.tsx
@@ -887,31 +887,21 @@ export default function EditRequest({ loaderData, params }: Route.ComponentProps
         </div>
       </div>
       <Dialog open={showDialog} onOpenChange={setShowDialog}>
-        <DialogContent aria-describedby={undefined} role="alertdialog">
+        <DialogContent aria-describedby="cancel-dialog-description" role="alertdialog">
           <DialogHeader>
             <DialogTitle id="cancel-dialog-title">{t('app:hiring-manager-referral-requests.request-cancel.title')}</DialogTitle>
           </DialogHeader>
-          <DialogDescription>{t('app:hiring-manager-referral-requests.request-cancel.content')}</DialogDescription>
+          <DialogDescription id="cancel-dialog-description">
+            {t('app:hiring-manager-referral-requests.request-cancel.content')}
+          </DialogDescription>
           <DialogFooter>
             <DialogClose asChild>
-              <Button
-                id="confirm-modal-back"
-                variant="alternative"
-                aria-describedby="cancel-dialog-description"
-                disabled={isSubmitting}
-              >
+              <Button id="confirm-modal-back" variant="alternative" disabled={isSubmitting}>
                 {t('app:hiring-manager-referral-requests.request-cancel.keep')}
               </Button>
             </DialogClose>
             <fetcher.Form method="post" noValidate>
-              <Button
-                id="cancel-request"
-                variant="primary"
-                name="_action"
-                value="cancel"
-                aria-describedby="cancel-dialog-description"
-                disabled={isSubmitting}
-              >
+              <Button id="cancel-request" variant="primary" name="_action" value="cancel" disabled={isSubmitting}>
                 {t('app:hiring-manager-referral-requests.request-cancel.cancel')}
               </Button>
             </fetcher.Form>

--- a/frontend/app/routes/hiring-manager/request/index.tsx
+++ b/frontend/app/routes/hiring-manager/request/index.tsx
@@ -887,19 +887,31 @@ export default function EditRequest({ loaderData, params }: Route.ComponentProps
         </div>
       </div>
       <Dialog open={showDialog} onOpenChange={setShowDialog}>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent aria-describedby={undefined} role="alertdialog">
           <DialogHeader>
-            <DialogTitle>{t('app:hiring-manager-referral-requests.request-cancel.title')}</DialogTitle>
+            <DialogTitle id="cancel-dialog-title">{t('app:hiring-manager-referral-requests.request-cancel.title')}</DialogTitle>
           </DialogHeader>
           <DialogDescription>{t('app:hiring-manager-referral-requests.request-cancel.content')}</DialogDescription>
           <DialogFooter>
             <DialogClose asChild>
-              <Button id="confirm-modal-back" variant="default" size="sm">
+              <Button
+                id="confirm-modal-back"
+                variant="alternative"
+                aria-describedby="cancel-dialog-description"
+                disabled={isSubmitting}
+              >
                 {t('app:hiring-manager-referral-requests.request-cancel.keep')}
               </Button>
             </DialogClose>
             <fetcher.Form method="post" noValidate>
-              <Button id="cancel-request" variant="primary" size="sm" name="_action" value="cancel" disabled={isSubmitting}>
+              <Button
+                id="cancel-request"
+                variant="primary"
+                name="_action"
+                value="cancel"
+                aria-describedby="cancel-dialog-description"
+                disabled={isSubmitting}
+              >
                 {t('app:hiring-manager-referral-requests.request-cancel.cancel')}
               </Button>
             </fetcher.Form>

--- a/frontend/app/routes/hr-advisor/employees.tsx
+++ b/frontend/app/routes/hr-advisor/employees.tsx
@@ -656,13 +656,13 @@ export default function EmployeeDashboard({ loaderData, params }: Route.Componen
             <DialogTitle id="archive-dialog-title">
               {t('app:hr-advisor-employees-table.archive-confirmation.title')}
             </DialogTitle>
-            <DialogDescription id="archive-dialog-description">
-              {selectedProfileForArchive &&
-                t('app:hr-advisor-employees-table.archive-confirmation.message', {
-                  profileUserName: `${selectedProfileForArchive.profileUser.firstName} ${selectedProfileForArchive.profileUser.lastName}`,
-                })}
-            </DialogDescription>
           </DialogHeader>
+          <DialogDescription>
+            {selectedProfileForArchive &&
+              t('app:hr-advisor-employees-table.archive-confirmation.message', {
+                profileUserName: `${selectedProfileForArchive.profileUser.firstName} ${selectedProfileForArchive.profileUser.lastName}`,
+              })}
+          </DialogDescription>
           <DialogFooter>
             <DialogClose asChild>
               <Button variant="alternative" aria-describedby="archive-dialog-description" disabled={isArchiving}>
@@ -673,7 +673,6 @@ export default function EmployeeDashboard({ loaderData, params }: Route.Componen
               variant="primary"
               onClick={confirmArchive}
               aria-describedby="archive-dialog-description"
-              className="focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
               disabled={isArchiving}
               loading={isArchiving}
             >

--- a/frontend/app/routes/hr-advisor/employees.tsx
+++ b/frontend/app/routes/hr-advisor/employees.tsx
@@ -651,13 +651,13 @@ export default function EmployeeDashboard({ loaderData, params }: Route.Componen
 
       {/* Archive Confirmation Dialog */}
       <Dialog open={showArchiveDialog} onOpenChange={setShowArchiveDialog}>
-        <DialogContent aria-describedby={undefined} role="alertdialog">
+        <DialogContent aria-describedby="archive-dialog-description" role="alertdialog">
           <DialogHeader>
             <DialogTitle id="archive-dialog-title">
               {t('app:hr-advisor-employees-table.archive-confirmation.title')}
             </DialogTitle>
           </DialogHeader>
-          <DialogDescription>
+          <DialogDescription id="archive-dialog-description">
             {selectedProfileForArchive &&
               t('app:hr-advisor-employees-table.archive-confirmation.message', {
                 profileUserName: `${selectedProfileForArchive.profileUser.firstName} ${selectedProfileForArchive.profileUser.lastName}`,
@@ -665,17 +665,11 @@ export default function EmployeeDashboard({ loaderData, params }: Route.Componen
           </DialogDescription>
           <DialogFooter>
             <DialogClose asChild>
-              <Button variant="alternative" aria-describedby="archive-dialog-description" disabled={isArchiving}>
+              <Button variant="alternative" disabled={isArchiving}>
                 {t('app:hr-advisor-employees-table.archive-confirmation.cancel')}
               </Button>
             </DialogClose>
-            <LoadingButton
-              variant="primary"
-              onClick={confirmArchive}
-              aria-describedby="archive-dialog-description"
-              disabled={isArchiving}
-              loading={isArchiving}
-            >
+            <LoadingButton variant="primary" onClick={confirmArchive} disabled={isArchiving} loading={isArchiving}>
               {t('app:hr-advisor-employees-table.archive-confirmation.confirm')}
             </LoadingButton>
           </DialogFooter>


### PR DESCRIPTION
This pull request improves accessibility and usability for dialog components in the hiring manager and HR advisor dashboards. The main changes ensure dialogs are properly described for screen readers and streamline button properties for consistency.

**Accessibility improvements:**

* Added `aria-describedby` and unique IDs to `DialogContent`, `DialogTitle`, and `DialogDescription` elements in both the hiring manager request cancel dialog (`frontend/app/routes/hiring-manager/request/index.tsx`) and the HR advisor employee archive confirmation dialog (`frontend/app/routes/hr-advisor/employees.tsx`). This helps screen readers announce dialog content correctly. [[1]](diffhunk://#diff-bffa633051e7d6d443233de33ba6816e81070b771f395f66854f2530c619efc0L890-R904) [[2]](diffhunk://#diff-c9e3632f5b380d7e64f31440fe26de52f5f8bf52b270c9f42e6ca754206ca755L654-R672)

**UI and code consistency:**

* Removed unnecessary `size="sm"` and `aria-describedby` props from dialog buttons, and ensured button variants are consistent across dialogs. [[1]](diffhunk://#diff-bffa633051e7d6d443233de33ba6816e81070b771f395f66854f2530c619efc0L890-R904) [[2]](diffhunk://#diff-c9e3632f5b380d7e64f31440fe26de52f5f8bf52b270c9f42e6ca754206ca755L654-R672)
* Disabled dialog buttons appropriately while submitting or archiving to prevent duplicate actions and improve user experience. [[1]](diffhunk://#diff-bffa633051e7d6d443233de33ba6816e81070b771f395f66854f2530c619efc0L890-R904) [[2]](diffhunk://#diff-c9e3632f5b380d7e64f31440fe26de52f5f8bf52b270c9f42e6ca754206ca755L654-R672)