### PR TITLE
fix(frontend): fix updateProfileStatus calls to use currentProfile.id

### DIFF
--- a/frontend/app/routes/employee/profile/employment-information.tsx
+++ b/frontend/app/routes/employee/profile/employment-information.tsx
@@ -80,7 +80,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
   ) {
     // profile needs to be re-approved if and only if the current profile status is 'approved'
     await profileService.updateProfileStatus(
-      currentProfile.profileUser.id,
+      currentProfile.id,
       PROFILE_STATUS.PENDING,
       context.session.authState.accessToken,
     );

--- a/frontend/app/routes/employee/profile/employment-information.tsx
+++ b/frontend/app/routes/employee/profile/employment-information.tsx
@@ -79,11 +79,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     hasEmploymentDataChanged(currentProfile, parseResult.output)
   ) {
     // profile needs to be re-approved if and only if the current profile status is 'approved'
-    await profileService.updateProfileStatus(
-      currentProfile.id,
-      PROFILE_STATUS.PENDING,
-      context.session.authState.accessToken,
-    );
+    await profileService.updateProfileStatus(currentProfile.id, PROFILE_STATUS.PENDING, context.session.authState.accessToken);
     return i18nRedirect('routes/employee/profile/index.tsx', request, {
       params: { id: currentProfile.profileUser.id.toString() },
       search: new URLSearchParams({

--- a/frontend/app/routes/employee/profile/referral-preferences.tsx
+++ b/frontend/app/routes/employee/profile/referral-preferences.tsx
@@ -89,11 +89,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     hasReferralDataChanged(oldReferralData, newReferralData)
   ) {
     // profile needs to be re-approved if and only if the current profile status is 'approved'
-    await profileService.updateProfileStatus(
-      currentProfile.id,
-      PROFILE_STATUS.PENDING,
-      context.session.authState.accessToken,
-    );
+    await profileService.updateProfileStatus(currentProfile.id, PROFILE_STATUS.PENDING, context.session.authState.accessToken);
     return i18nRedirect('routes/employee/profile/index.tsx', request, {
       params: { id: currentProfile.profileUser.id.toString() },
       search: new URLSearchParams({

--- a/frontend/app/routes/employee/profile/referral-preferences.tsx
+++ b/frontend/app/routes/employee/profile/referral-preferences.tsx
@@ -90,7 +90,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
   ) {
     // profile needs to be re-approved if and only if the current profile status is 'approved'
     await profileService.updateProfileStatus(
-      currentProfile.profileUser.id,
+      currentProfile.id,
       PROFILE_STATUS.PENDING,
       context.session.authState.accessToken,
     );

--- a/frontend/app/routes/hr-advisor/employee-profile/index.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/index.tsx
@@ -15,12 +15,13 @@ import { serverEnvironment } from '~/.server/environment';
 import { requireAuthentication } from '~/.server/utils/auth-utils';
 import { getHrAdvisors } from '~/.server/utils/profile-utils';
 import { AlertMessage } from '~/components/alert-message';
+import { BackLink } from '~/components/back-link';
 import { DescriptionList, DescriptionListItem } from '~/components/description-list';
-import { InlineLink } from '~/components/links';
 import { LoadingButton } from '~/components/loading-button';
 import { PageTitle } from '~/components/page-title';
 import { ProfileCard } from '~/components/profile-card';
 import { ProfileStatusTag } from '~/components/status-tag';
+import { VacmanBackground } from '~/components/vacman-background';
 import { EMPLOYEE_WFA_STATUS, PROFILE_STATUS } from '~/domain/constants';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
 import { useFetcherState } from '~/hooks/use-fetcher-state';
@@ -52,7 +53,7 @@ export async function action({ context, request, params }: Route.ActionArgs) {
 
   // approve the profile
   const submitResult = await getProfileService().updateProfileStatus(
-    profileData.profileUser.id,
+    profileData.id,
     PROFILE_STATUS.APPROVED,
     context.session.authState.accessToken,
   );
@@ -238,35 +239,29 @@ export default function EditProfile({ loaderData, params }: Route.ComponentProps
 
   return (
     <div className="space-y-8">
-      <div className="absolute left-0 w-full space-y-4 bg-[rgba(9,28,45,1)] py-8 wrap-break-word text-white">
-        <div className="container">
+      <VacmanBackground variant="bottom-right" className="pb-12">
+        <div className="container space-y-4 py-8 wrap-break-word">
           {loaderData.profileStatus && (
             <ProfileStatusTag status={loaderData.profileStatus} lang={loaderData.lang} rounded view="hr-advisor" />
           )}
-          <PageTitle className="after:w-14" containerClassName="my-6">
+          <PageTitle className="after:w-14" variant="bottom" subTitle={loaderData.email} subTitleClassName="mt-3">
             {loaderData.name}
           </PageTitle>
-          {loaderData.email && <p className="mt-1">{loaderData.email}</p>}
           <p className="font-normal text-[#9FA3AD]">
             {t('app:profile.last-updated', { date: browserTZ, name: loaderData.lastUpdatedBy })}
           </p>
         </div>
-        <div
-          role="presentation"
-          className="absolute top-25 left-0 -z-10 h-70 w-full scale-x-[-1] bg-[rgba(9,28,45,1)] bg-[url('/VacMan-design-element-06.svg')] bg-size-[450px] bg-left-bottom bg-no-repeat sm:h-60"
-        />
-      </div>
-      <div className="mt-110 justify-between sm:mt-70 md:grid md:grid-cols-2">
+      </VacmanBackground>
+      <div className="justify-between md:grid md:grid-cols-2">
         <div className="max-w-prose">
-          <InlineLink
-            className="mt-6 block"
+          <BackLink
+            aria-label={t('app:employee-profile.back')}
             file="routes/hr-advisor/employees.tsx"
             params={params}
             search={`filter=${loaderData.backLinkFilter}`}
-            id="back-button"
           >
-            {`< ${t('app:employee-profile.back')}`}
-          </InlineLink>
+            {t('app:employee-profile.back')}
+          </BackLink>
           <p className="mt-12">{t('app:employee-profile.about-para-1')}</p>
         </div>
       </div>

--- a/frontend/app/routes/hr-advisor/employee-profile/index.tsx
+++ b/frontend/app/routes/hr-advisor/employee-profile/index.tsx
@@ -21,7 +21,6 @@ import { LoadingButton } from '~/components/loading-button';
 import { PageTitle } from '~/components/page-title';
 import { ProfileCard } from '~/components/profile-card';
 import { ProfileStatusTag } from '~/components/status-tag';
-import { VacmanBackground } from '~/components/vacman-background';
 import { EMPLOYEE_WFA_STATUS, PROFILE_STATUS } from '~/domain/constants';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
 import { useFetcherState } from '~/hooks/use-fetcher-state';
@@ -239,20 +238,25 @@ export default function EditProfile({ loaderData, params }: Route.ComponentProps
 
   return (
     <div className="space-y-8">
-      <VacmanBackground variant="bottom-right" className="pb-12">
-        <div className="container space-y-4 py-8 wrap-break-word">
+      <div className="absolute left-0 w-full space-y-4 bg-[rgba(9,28,45,1)] py-8 wrap-break-word text-white">
+        <div className="container">
           {loaderData.profileStatus && (
             <ProfileStatusTag status={loaderData.profileStatus} lang={loaderData.lang} rounded view="hr-advisor" />
           )}
-          <PageTitle className="after:w-14" variant="bottom" subTitle={loaderData.email} subTitleClassName="mt-3">
+          <PageTitle className="after:w-14" containerClassName="my-6">
             {loaderData.name}
           </PageTitle>
+          {loaderData.email && <p className="mt-1">{loaderData.email}</p>}
           <p className="font-normal text-[#9FA3AD]">
             {t('app:profile.last-updated', { date: browserTZ, name: loaderData.lastUpdatedBy })}
           </p>
         </div>
-      </VacmanBackground>
-      <div className="justify-between md:grid md:grid-cols-2">
+        <div
+          role="presentation"
+          className="absolute bottom-0 left-0 h-40 w-full scale-x-[-1] bg-[url('/VacMan-design-element-06.svg')] bg-size-[30rem] bg-left-bottom bg-no-repeat"
+        />
+      </div>
+      <div className="mt-110 justify-between sm:mt-70 md:grid md:grid-cols-2">
         <div className="max-w-prose">
           <BackLink
             aria-label={t('app:employee-profile.back')}


### PR DESCRIPTION
This pull request updates the logic for re-approving employee profiles in two routes by correcting the identifier used when updating profile status. The change ensures that the correct profile ID is passed to the `updateProfileStatus` service.

Profile status update fix:

* In both `employment-information.tsx` and `referral-preferences.tsx`, the call to `profileService.updateProfileStatus` now uses `currentProfile.id` instead of `currentProfile.profileUser.id` to correctly identify the profile being updated. [[1]](diffhunk://#diff-ba69a87dc77db29a07b93b48dabec7c6edf88c9acbf2279422228f5192c84c7dL83-R83) [[2]](diffhunk://#diff-7d92dd055cee605ad765f0b40f5c5490be9cfedc0b8ce20c4254002a2305eceeL93-R93)