### PR TITLE
fix(frontend) error-summary

### DIFF
--- a/frontend/app/components/error-summary.tsx
+++ b/frontend/app/components/error-summary.tsx
@@ -41,20 +41,14 @@ export interface ErrorSummaryProps extends OmitStrict<ComponentPropsWithoutRef<'
 export function ErrorSummary({ className, errors, ...rest }: ErrorSummaryProps): JSX.Element | null {
   const { t } = useTranslation(['gcweb']);
   const sectionRef = useRef<HTMLElement>(null);
-  const [hasAnnounced, setHasAnnounced] = useState(false);
 
   // Scroll and focus on the error summary when errors are updated.
   useEffect(() => {
-    if (errors.length > 0 && sectionRef.current && !hasAnnounced) {
-      requestAnimationFrame(() => {
-        sectionRef.current?.scrollIntoView({ behavior: 'smooth' });
-        sectionRef.current?.focus();
-        setHasAnnounced(true);
-      });
-    } else if (errors.length === 0) {
-      setHasAnnounced(false);
+    if (errors.length > 0 && sectionRef.current) {
+      sectionRef.current.scrollIntoView({ behavior: 'smooth' });
+      sectionRef.current.focus();
     }
-  }, [errors, hasAnnounced]);
+  }, [errors]);
 
   if (errors.length === 0) {
     return null;


### PR DESCRIPTION
## Summary

Reverting changes made in #867 

After testing, the error summary doesn't scroll into view on multiple form submissions (because of the `hasAnnounced` state).  NVDA still only reads the error summary once (not 2-3 times in succession like before), because of the `aria-live` vs `role=alert`, despite them being equivalent in this case, so we can keep the rest of the code and live happily.