### PR TITLE
fix(frontend) decorative banner in dashboard screens

### DIFF
--- a/frontend/app/routes/layout.tsx
+++ b/frontend/app/routes/layout.tsx
@@ -19,6 +19,7 @@ import { uselayoutHasDecorativeBackground } from '~/hooks/use-layout-has-backgro
 import { useRoute } from '~/hooks/use-route';
 import { getFixedT } from '~/i18n-config.server';
 import { getAltLanguage, getLanguage } from '~/utils/i18n-utils';
+import { cn } from '~/utils/tailwind-utils';
 
 export const handle = {
   i18nNamespace: ['gcweb', 'app'],
@@ -79,24 +80,35 @@ export default function Layout({ loaderData }: Route.ComponentProps) {
       </header>
 
       <main className="flex flex-grow flex-col">
-        <div className="container flex flex-grow flex-col print:w-full print:max-w-none">
+        <div
+          className={cn('flex flex-grow flex-col print:w-full print:max-w-none', !layoutHasDecorativeBackground && 'container')}
+        >
           {layoutHasDecorativeBackground ? (
-            <div className="grid flex-grow grid-cols-9 grid-rows-1 gap-4">
-              <div className="col-span-9 flex flex-col sm:col-span-5">
-                <Outlet />
-                <div className="mt-auto">
-                  <PageDetails buildDate={BUILD_DATE} buildVersion={BUILD_VERSION} pageId={pageId} />
+            <div className="relative flex flex-grow">
+              <div className="pointer-events-none absolute inset-0 hidden grid-cols-1 sm:grid sm:grid-cols-12">
+                <div className="sm:col-span-8"></div>
+                <div className="bg-[rgba(9,28,45,1)] sm:col-span-4">
+                  <div className="grid h-full grid-rows-2">
+                    <div
+                      role="presentation"
+                      className="row-start-1 h-full w-full bg-[url('/VacMan-design-element-07.svg')] bg-right-top bg-no-repeat"
+                    />
+                    <div
+                      role="presentation"
+                      className="row-start-2 h-full w-full bg-[url('/VacMan-design-element-06.svg')] bg-left-bottom bg-no-repeat"
+                    />
+                  </div>
                 </div>
               </div>
-              <div className="col-span-4 grid grid-rows-2 bg-[rgba(9,28,45,1)]">
-                <div
-                  role="presentation"
-                  className="row-start-1 h-full w-full place-self-start bg-[url('/VacMan-design-element-07.svg')] bg-right-top bg-no-repeat"
-                />
-                <div
-                  role="presentation"
-                  className="row-start-2 h-full w-full place-self-end bg-[url('/VacMan-design-element-06.svg')] bg-left-bottom bg-no-repeat"
-                />
+
+              <div className="relative z-10 container flex h-full">
+                <div className="flex flex-1 flex-col">
+                  <Outlet />
+                  <div className="mt-auto">
+                    <PageDetails buildDate={BUILD_DATE} buildVersion={BUILD_VERSION} pageId={pageId} />
+                  </div>
+                </div>
+                <div className="hidden w-4/12 sm:block"></div>
               </div>
             </div>
           ) : (


### PR DESCRIPTION
## Summary

The decorative banner in the dashboard screen now breaks out of the container to occupy the full width of the screen.  It is responsive and will be hidden when the view port is `<'sm'` (768px)

<img width="1916" height="856" alt="image" src="https://github.com/user-attachments/assets/9be73b53-02e7-4e75-8d11-6e43f1837ace" />

<img width="538" height="734" alt="image" src="https://github.com/user-attachments/assets/c654864a-1296-4891-9629-8bbd28d29f2a" />


