### PR TITLE
feat(frontend): display selection count in DataTableColumnHeaderWithOptions

### DIFF
--- a/frontend/app/.server/locales/gcweb-en.ts
+++ b/frontend/app/.server/locales/gcweb-en.ts
@@ -86,6 +86,10 @@ export default {
   },
   'data-table': {
     'zero-records': 'No matching records found',
+    'filters': {
+      'header-aria_one': '{{title}}: {{count}} selected',
+      'header-aria_other': '{{title}}: {{count}} selected',
+    },
     'pagination': {
       'label': 'Pagination',
       'info_zero': 'Showing 0 to 0 of 0 entries',

--- a/frontend/app/.server/locales/gcweb-fr.ts
+++ b/frontend/app/.server/locales/gcweb-fr.ts
@@ -88,6 +88,10 @@ export default {
   },
   'data-table': {
     'zero-records': 'Aucune entrée correspondante trouvée',
+    'filters': {
+      'header-aria_one': '{{title}} : {{count}} sélectionné',
+      'header-aria_other': '{{title}} : {{count}} sélectionnés',
+    },
     'pagination': {
       'label': 'Pagination',
       'info_zero': 'Affichage de 0 à 0 sur 0 entrées',

--- a/frontend/app/components/data-table.tsx
+++ b/frontend/app/components/data-table.tsx
@@ -201,7 +201,7 @@ export function DataTableColumnHeaderWithOptions<TData, TValue>({
   selected: controlledSelected,
   onSelectionChange,
 }: DataTableColumnHeaderWithOptionsProps<TData, TValue>) {
-  const { t } = useTranslation(['gcweb', 'app']);
+  const { t } = useTranslation(['gcweb']);
   // Source of truth: controlled 'selected' if provided, else column filter state
   const selectedValues: string[] = controlledSelected ?? (column.getFilterValue() as string[] | undefined) ?? [];
 

--- a/frontend/app/components/data-table.tsx
+++ b/frontend/app/components/data-table.tsx
@@ -201,6 +201,7 @@ export function DataTableColumnHeaderWithOptions<TData, TValue>({
   selected: controlledSelected,
   onSelectionChange,
 }: DataTableColumnHeaderWithOptionsProps<TData, TValue>) {
+  const { t } = useTranslation(['gcweb', 'app']);
   // Source of truth: controlled 'selected' if provided, else column filter state
   const selectedValues: string[] = controlledSelected ?? (column.getFilterValue() as string[] | undefined) ?? [];
 
@@ -217,6 +218,16 @@ export function DataTableColumnHeaderWithOptions<TData, TValue>({
     setSelectedValues(next);
   };
 
+  const selectedCount = selectedValues.length;
+
+  const ariaLabel =
+    selectedCount > 0
+      ? t('gcweb:data-table.filters.header-aria', {
+          title,
+          count: selectedCount,
+        })
+      : title;
+
   return (
     <div className={cn('flex items-center space-x-2', className)}>
       <DropdownMenu>
@@ -226,8 +237,14 @@ export function DataTableColumnHeaderWithOptions<TData, TValue>({
             variant="ghost"
             size="sm"
             className="-ml-3 h-8 font-sans font-medium data-[state=open]:bg-neutral-100"
+            aria-label={ariaLabel}
           >
             {title}
+            {selectedCount > 0 && (
+              <span aria-hidden="true" className="ml-1 text-xs font-semibold text-[#0535D2]">
+                ({selectedCount})
+              </span>
+            )}
             <span className="ml-1 rounded-sm p-1 text-neutral-500 hover:bg-slate-300">
               <FontAwesomeIcon icon={faSortDown} />
             </span>


### PR DESCRIPTION
This pull request enhances the accessibility and user experience of the data table filters by adding localized ARIA labels and a visible indicator of selected filter options. The changes ensure that screen readers announce the number of selected filters, and users can visually see the count next to the filter title.

**Accessibility and Localization Improvements:**

* Added new localized ARIA label strings for filter headers in both English (`gcweb-en.ts`) and French (`gcweb-fr.ts`) locale files, supporting singular and plural forms. [[1]](diffhunk://#diff-3ff5c497124df65a907bf39e75c074666731ce4420420b5554b66cd8e86833bdR89-R92) [[2]](diffhunk://#diff-6abebf11f63fb7b28cb0190ede327b75e2edb81ed23000243c0f23ec9c8cb38bR91-R94)
* Integrated the translation hook (`useTranslation`) in the `DataTableColumnHeaderWithOptions` component to retrieve localized strings for ARIA labels.
* Computed a dynamic ARIA label for filter headers, which includes the filter title and the count of selected options when applicable, improving screen reader accessibility.
* Set the computed ARIA label on the filter dropdown button and added a visible count of selected options next to the filter title for better user feedback.

<img width="273" height="277" alt="image" src="https://github.com/user-attachments/assets/d93398c7-8d49-4497-ba6c-fdb4032d061b" />
