### PR TITLE
fix(deployments): update backend and frontend images to version 1.0.1-RC112 and 1.0.1-RC099 respectively

### DIFF
--- a/gitops/nonprod/overlays/uat/patches/deployments-backend.yaml
+++ b/gitops/nonprod/overlays/uat/patches/deployments-backend.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: vacman-backend
-          image: dtsrhpdevscedacr.azurecr.io/vacman/vacman-backend:0.0.0-432f3244-000c7
+          image: dtsrhpdevscedacr.azurecr.io/vacman/vacman-backend:1.0.1-RC112
           envFrom:
             - secretRef:
                 name: vacman-backend-uat

--- a/gitops/nonprod/overlays/uat/patches/deployments-frontend.yaml
+++ b/gitops/nonprod/overlays/uat/patches/deployments-frontend.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: vacman-frontend
-          image: dtsrhpdevscedacr.azurecr.io/vacman/vacman-frontend:0.0.0-1cfad340-00238
+          image: dtsrhpdevscedacr.azurecr.io/vacman/vacman-frontend:1.0.1-RC099
           envFrom:
             - configMapRef:
                 name: vacman-frontend-uat


### PR DESCRIPTION
This pull request updates the container image versions for both the backend and frontend deployments in the UAT environment to newer release candidate versions.

Deployment image updates:

* Updated the backend container image in `gitops/nonprod/overlays/uat/patches/deployments-backend.yaml` to `1.0.1-RC112` for the `vacman-backend` service.
* Updated the frontend container image in `gitops/nonprod/overlays/uat/patches/deployments-frontend.yaml` to `1.0.1-RC099` for the `vacman-frontend` service.