### PR TITLE
fix(deployments): update backend and frontend images to version 1.0.1-RC114 and 1.0.1-RC101 respectively

### DIFF
--- a/gitops/nonprod/overlays/uat/patches/deployments-backend.yaml
+++ b/gitops/nonprod/overlays/uat/patches/deployments-backend.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: vacman-backend
-          image: dtsrhpdevscedacr.azurecr.io/vacman/vacman-backend:1.0.1-RC112
+          image: dtsrhpdevscedacr.azurecr.io/vacman/vacman-backend:1.0.1-RC114
           envFrom:
             - secretRef:
                 name: vacman-backend-uat

--- a/gitops/nonprod/overlays/uat/patches/deployments-frontend.yaml
+++ b/gitops/nonprod/overlays/uat/patches/deployments-frontend.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: vacman-frontend
-          image: dtsrhpdevscedacr.azurecr.io/vacman/vacman-frontend:1.0.1-RC099
+          image: dtsrhpdevscedacr.azurecr.io/vacman/vacman-frontend:1.0.1-RC101
           envFrom:
             - configMapRef:
                 name: vacman-frontend-uat


### PR DESCRIPTION
This pull request updates the container image versions for both the backend and frontend deployments in the UAT environment. These changes ensure that the UAT environment uses the latest release candidates for both services.

**Deployment image updates:**

* Updated the backend deployment (`vacman-backend`) image to version `1.0.1-RC114` in `deployments-backend.yaml` to use the latest backend build.
* Updated the frontend deployment (`vacman-frontend`) image to version `1.0.1-RC101` in `deployments-frontend.yaml` to use the latest frontend build.