### PR TITLE
fix(deployments-prod): update backend and frontend images to version 1.0.1

### DIFF
--- a/gitops/prod/deployments.yaml
+++ b/gitops/prod/deployments.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: vacman-backend
-          image: dtsrhpprodscedspokeacr.azurecr.io/vacman/vacman-backend:1.0.0
+          image: dtsrhpprodscedspokeacr.azurecr.io/vacman/vacman-backend:1.0.1-5454f682
           envFrom:
             - secretRef:
                 name: vacman-backend
@@ -83,7 +83,7 @@ spec:
     spec:
       containers:
         - name: vacman-frontend
-          image: dtsrhpprodscedspokeacr.azurecr.io/vacman/vacman-frontend:1.0.0
+          image: dtsrhpprodscedspokeacr.azurecr.io/vacman/vacman-frontend:1.0.1
           envFrom:
             - configMapRef:
                 name: vacman-frontend

--- a/gitops/prod/deployments.yaml
+++ b/gitops/prod/deployments.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: vacman-backend
-          image: dtsrhpprodscedspokeacr.azurecr.io/vacman/vacman-backend:1.0.1-5454f682
+          image: dtsrhpprodscedspokeacr.azurecr.io/vacman/vacman-backend:1.0.1
           envFrom:
             - secretRef:
                 name: vacman-backend


### PR DESCRIPTION
This pull request updates the container images for both the backend and frontend services in the production deployment configuration to newer versions.

Deployment image updates:

* Updated the `vacman-backend` container image to version `1.0.1-5454f682` in `gitops/prod/deployments.yaml`
* Updated the `vacman-frontend` container image to version `1.0.1` in `gitops/prod/deployments.yaml`