### PR TITLE
fix(frontend) showStatus submission-details card

### DIFF
--- a/frontend/app/routes/hiring-manager/request/index.tsx
+++ b/frontend/app/routes/hiring-manager/request/index.tsx
@@ -753,7 +753,7 @@ export default function EditRequest({ loaderData, params }: Route.ComponentProps
               params={params}
               required
               errorState={fetcher.data?.submissionInfoComplete === false}
-              showStatus
+              showStatus={loaderData.status?.code === REQUEST_STATUS_CODE.DRAFT}
             >
               {loaderData.isSubmissionNew ? (
                 <>{t('app:hiring-manager-referral-requests.submission-intro')}</>


### PR DESCRIPTION
## Summary

The status tag is only displayed when the status of the request is draft, same as the other cards
