### PR TITLE
fix(frontend) add lang attribute to somc textareas

### DIFF
--- a/frontend/app/routes/page-components/requests/somc-conditions/form.tsx
+++ b/frontend/app/routes/page-components/requests/somc-conditions/form.tsx
@@ -46,6 +46,7 @@ export function SomcConditionsForm({ cancelLink, formValues, formErrors, params 
               defaultValue={formValues?.englishStatementOfMerit}
               errorMessage={t(extractValidationKey(formErrors?.englishStatementOfMerit))}
               required
+              lang="en"
             />
 
             <InputTextarea
@@ -57,6 +58,7 @@ export function SomcConditionsForm({ cancelLink, formValues, formErrors, params 
               defaultValue={formValues?.frenchStatementOfMerit}
               errorMessage={t(extractValidationKey(formErrors?.frenchStatementOfMerit))}
               required
+              lang="fr"
             />
             <div className="mt-8 flex flex-wrap items-center justify-start gap-3">
               <ButtonLink file={cancelLink} params={params} id="cancel-button" variant="alternative">


### PR DESCRIPTION
## Summary

The requests pages haven't been a11y audited yet, but they'' tell us to put lang attributes on these inputs since both english and french is displayed on the screen.