### PR TITLE
feat(frontent): add request/response logging with correlation IDs

### DIFF
--- a/frontend/app/.server/utils/request-context.ts
+++ b/frontend/app/.server/utils/request-context.ts
@@ -1,0 +1,24 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export type RequestContext = {
+  reqId: string;
+};
+
+const storage = new AsyncLocalStorage<RequestContext>();
+
+export function runWithRequestContext<T>(ctx: RequestContext, fn: () => T): T {
+  return storage.run(ctx, fn);
+}
+
+export function getRequestContext(): RequestContext | undefined {
+  return storage.getStore();
+}
+
+// Expose a safe global accessor so non-server modules (that cannot import Node APIs)
+// can still retrieve the current correlation id if present. This avoids bundling
+// node:async_hooks into client code while allowing best-effort correlation.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const g: any = globalThis as any;
+if (typeof g === 'object' && g) {
+  g.__vacmanGetReqId = (): string | undefined => storage.getStore()?.reqId;
+}

--- a/frontend/app/utils/correlation.ts
+++ b/frontend/app/utils/correlation.ts
@@ -1,0 +1,11 @@
+import { randomString } from '~/utils/string-utils';
+
+/**
+ * Generate a correlation/request id.
+ * Kept identical to the previous implementation from AppError to avoid name/format drift.
+ */
+export function generateCorrelationId(): string {
+  const prefix = randomString(2).toUpperCase();
+  const suffix = randomString(6).toUpperCase();
+  return `${prefix}-${suffix}`;
+}


### PR DESCRIPTION
This pull request introduces a comprehensive upgrade to request correlation, logging, and error handling on the frontend. The main changes include adding request-scoped correlation IDs to API calls and error objects, enhancing logging with contextual information and redaction of sensitive data, and improving error propagation and traceability. These updates make it easier to trace requests through the system, debug issues, and ensure sensitive information is protected in logs.

**Request Correlation and Context Propagation**
- Introduced `AsyncLocalStorage`-based request context management in `request-context.ts`, allowing each request to carry a unique `reqId` (correlation ID) throughout its lifecycle. This context is attached to logs and error objects for improved traceability.
- Middleware now ensures every incoming request has a correlation ID, sets it on the response header, and propagates it through the request context for downstream usage. [[1]](diffhunk://#diff-f8d80bb45811d80ffb325251107ae47980d0665c622178a3bc6d2e89ac6f5df3R45-R56) [[2]](diffhunk://#diff-f8d80bb45811d80ffb325251107ae47980d0665c622178a3bc6d2e89ac6f5df3R189-R194)

**Logging Enhancements**
- Refactored logging to include new helpers: `getRequestLogger` (automatically attaches `reqId` from context), `getScoped` (attaches custom metadata), and redaction logic to sanitize sensitive fields (e.g., tokens, passwords) in log output. [[1]](diffhunk://#diff-3a15ce6d3177e16a6d7b37b4ec621d6849b1744525b93a739827b8a4f1ef1d3fR74-R91) [[2]](diffhunk://#diff-3a15ce6d3177e16a6d7b37b4ec621d6849b1744525b93a739827b8a4f1ef1d3fR140-R173)
- All service and API client methods now emit structured logs for request start, success, error, parsing, and cache hits/misses, with correlation IDs for easier debugging. [[1]](diffhunk://#diff-4e047e83b9d5c79cb603e49e6fb0f1843c42c81660062a5992da4cbe8b71e82dR33-R100) [[2]](diffhunk://#diff-4e047e83b9d5c79cb603e49e6fb0f1843c42c81660062a5992da4cbe8b71e82dR118-R128) [[3]](diffhunk://#diff-4e047e83b9d5c79cb603e49e6fb0f1843c42c81660062a5992da4cbe8b71e82dR156-R166) [[4]](diffhunk://#diff-4e047e83b9d5c79cb603e49e6fb0f1843c42c81660062a5992da4cbe8b71e82dR194) [[5]](diffhunk://#diff-4e047e83b9d5c79cb603e49e6fb0f1843c42c81660062a5992da4cbe8b71e82dR205-R212) [[6]](diffhunk://#diff-4e047e83b9d5c79cb603e49e6fb0f1843c42c81660062a5992da4cbe8b71e82dR241) [[7]](diffhunk://#diff-4e047e83b9d5c79cb603e49e6fb0f1843c42c81660062a5992da4cbe8b71e82dL199-R254) [[8]](diffhunk://#diff-7c6ce6bd74e00c867b374495016717eb3f491819f07aa6df6e6698478e9cfbbfR49-R67) [[9]](diffhunk://#diff-7c6ce6bd74e00c867b374495016717eb3f491819f07aa6df6e6698478e9cfbbfR81-R88) [[10]](diffhunk://#diff-7c6ce6bd74e00c867b374495016717eb3f491819f07aa6df6e6698478e9cfbbfR126-R132)

**Error Handling Improvements**
- `AppError` now uses request-scoped correlation IDs if available, falling back to a generated one, and includes this ID in error metadata for all thrown errors. [[1]](diffhunk://#diff-3587831b91e040597db3d598b2925f7b85e3ee22214b048084208e74483e3ee1L5-R10) [[2]](diffhunk://#diff-3587831b91e040597db3d598b2925f7b85e3ee22214b048084208e74483e3ee1L39-R47)
- Removed the old inlined correlation ID generator from `AppError` and moved it to a shared utility for consistency. [[1]](diffhunk://#diff-3587831b91e040597db3d598b2925f7b85e3ee22214b048084208e74483e3ee1L59-L67) [[2]](diffhunk://#diff-ee6db467905e81294d6a5d64ec3cde9da6b4fd662524e28667e5a281a0f41a57R1-R11)

**API Client Updates**
- All outgoing API requests now include the correlation ID in the `x-correlation-id` header, and all API client responses and errors are logged with contextual metadata and timing information. [[1]](diffhunk://#diff-4e047e83b9d5c79cb603e49e6fb0f1843c42c81660062a5992da4cbe8b71e82dR5-R12) [[2]](diffhunk://#diff-4e047e83b9d5c79cb603e49e6fb0f1843c42c81660062a5992da4cbe8b71e82dR33-R100)
- Improved error propagation and logging for all HTTP methods (GET, POST, PUT, DELETE) in the API client, making failures and parse errors easier to trace. [[1]](diffhunk://#diff-4e047e83b9d5c79cb603e49e6fb0f1843c42c81660062a5992da4cbe8b71e82dR118-R128) [[2]](diffhunk://#diff-4e047e83b9d5c79cb603e49e6fb0f1843c42c81660062a5992da4cbe8b71e82dR156-R166) [[3]](diffhunk://#diff-4e047e83b9d5c79cb603e49e6fb0f1843c42c81660062a5992da4cbe8b71e82dR194) [[4]](diffhunk://#diff-4e047e83b9d5c79cb603e49e6fb0f1843c42c81660062a5992da4cbe8b71e82dR205-R212) [[5]](diffhunk://#diff-4e047e83b9d5c79cb603e49e6fb0f1843c42c81660062a5992da4cbe8b71e82dR241) [[6]](diffhunk://#diff-4e047e83b9d5c79cb603e49e6fb0f1843c42c81660062a5992da4cbe8b71e82dL199-R254)

**Service Layer Logging**
- Lookup service implementation now logs cache hits, fetch starts, errors, and not-found cases with correlation IDs and entity metadata for better observability. [[1]](diffhunk://#diff-7c6ce6bd74e00c867b374495016717eb3f491819f07aa6df6e6698478e9cfbbfR6-R12) [[2]](diffhunk://#diff-7c6ce6bd74e00c867b374495016717eb3f491819f07aa6df6e6698478e9cfbbfR49-R67) [[3]](diffhunk://#diff-7c6ce6bd74e00c867b374495016717eb3f491819f07aa6df6e6698478e9cfbbfR81-R88) [[4]](diffhunk://#diff-7c6ce6bd74e00c867b374495016717eb3f491819f07aa6df6e6698478e9cfbbfR126-R132)

These improvements collectively enhance observability, traceability, and security for backend operations.