### PR TITLE
feat(frontend): copy request

### DIFF
--- a/frontend/app/.server/locales/app-en.ts
+++ b/frontend/app/.server/locales/app-en.ts
@@ -505,6 +505,8 @@ export default {
     'action': 'Action',
     'view': 'View',
     'view-link': 'View request with ID {{requestId}}',
+    'copy': 'Copy',
+    'copy-link': 'Copy request with ID {{requestId}}',
     'next-page': 'Next',
   },
   'matches': {

--- a/frontend/app/.server/locales/app-fr.ts
+++ b/frontend/app/.server/locales/app-fr.ts
@@ -515,6 +515,8 @@ export default {
     'action': 'Action',
     'view': 'Affiché',
     'view-link': "Afficher la demande avec l'identifiant {{requestId}}",
+    'copy': 'Copier',
+    'copy-link': "Copier la demande avec l'identifiant {{requestId}}",
     'next-page': 'Suivant',
   },
   'matches': {

--- a/frontend/app/routes/page-components/requests/tables/requests-tables.tsx
+++ b/frontend/app/routes/page-components/requests/tables/requests-tables.tsx
@@ -114,16 +114,33 @@ export default function RequestsTables({
         cell: (info) => {
           const requestId = info.row.original.id.toString();
           return (
-            <InlineLink
-              className="text-sky-800 decoration-slate-400 decoration-2"
-              file={`routes/${view}/request/index.tsx`}
-              params={{ requestId }}
-              aria-label={t('requests-tables.view-link', {
-                requestId,
-              })}
-            >
-              {t('requests-tables.view')}
-            </InlineLink>
+            <div className="flex items-baseline gap-4">
+              <InlineLink
+                className="rounded-sm text-sky-800 underline hover:text-blue-700 focus:text-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none"
+                file={`routes/${view}/request/index.tsx`}
+                params={{ requestId }}
+                aria-label={t('requests-tables.view-link', {
+                  requestId,
+                })}
+              >
+                {t('requests-tables.view')}
+              </InlineLink>
+              {view === 'hiring-manager' && (
+                <fetcher.Form method="post" noValidate>
+                  <input type="hidden" name="requestId" value={requestId}></input>
+                  <LoadingButton
+                    name="action"
+                    variant="alternative"
+                    size="sm"
+                    disabled={isSubmitting}
+                    loading={isSubmitting}
+                    value="copy"
+                  >
+                    {t('requests-tables.copy')}
+                  </LoadingButton>
+                </fetcher.Form>
+              )}
+            </div>
           );
         },
       },
@@ -134,7 +151,14 @@ export default function RequestsTables({
     <div className="mb-8 space-y-4">
       {view === 'hiring-manager' && (
         <fetcher.Form method="post" noValidate className="mb-8">
-          <LoadingButton name="action" variant="primary" size="sm" disabled={isSubmitting} loading={isSubmitting}>
+          <LoadingButton
+            name="action"
+            variant="primary"
+            size="sm"
+            disabled={isSubmitting}
+            loading={isSubmitting}
+            value="create"
+          >
             {t('requests-tables.create-request')}
           </LoadingButton>
         </fetcher.Form>


### PR DESCRIPTION
## Summary

[AB#7181](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/7181/)
hiring manager can copy existing request to create a new one.
On copying a request, the user is redirected to the newly created request displaying copied data.
Current user is saved as the Submitter, while the information for hiring manager, hr advisor and sub delegated manager are not copied.

## Types of changes

What types of changes does this PR introduce?

- [x] ✨ **new feature** -- non-breaking change that adds functionality

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.

- [x] code has been linted and formatted locally
- [ ] added or updated tests to verify the changes


<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

Provide screenshots or screen-recordings to help reviewers understand the visual impact of your changes, if relevant.
<img width="827" height="474" alt="image" src="https://github.com/user-attachments/assets/be1d7bb0-e2c6-4e53-b8a6-5e0f811db23c" />
