### PR TITLE
chore(frontend): strategic runtime upgrade to Node.js v20.20.0

### DIFF
--- a/frontend/containerfile
+++ b/frontend/containerfile
@@ -32,7 +32,7 @@
 #   $ podman search --limit 25000 --list-tags docker.io/library/node \
 #         | grep 'slim' | awk '{print $2}' | sort --version-sort
 #
-FROM docker.io/library/node:22.19.0-trixie-slim AS base
+FROM docker.io/library/node:22.20.0-trixie-slim AS base
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
## Summary

Sit down, grab a coffee, and prepare yourselves for what is undoubtedly the most pivotal infrastructure upgrade of the fiscal year. After minutes of painstaking research, nonexistent whiteboard sessions, and at least one existential crisis in the cluster room, I am proposing that we upgrade our Node.js runtime from the now-archaic and frankly dangerous v20.19.0 to the glorious, enlightened, and paradigm-shifting **v20.20.0**.

I know what you're thinking: "*But it's just a point release!*" To which I say, that's what they said about the wheel, the printing press, and sliced bread. This is not merely an update; this is an **ascension**.

## The path forward
 
This is not a change to be taken lightly. The following rigorous testing protocol has been executed:

1. **Full test suite execution:** ran `npm test`.. once. It passed, I think.
1. **Manual sanity check:** verified that `true` is still, in fact, `true`. The results were positive.
1. **Haptic analysis:** started the application with v20.20.0 and placed my hand on my laptop. It vibrated at least 3% more.
1. **Astrological alignment:** consulted a star chart to ensure the merge window does not conflict with Mercury being in retrograde. We are clear for launch.

## Summary... a call to action
 
To merge this PR is to choose progress. It's to choose security and performance over whatever criteria we chose last time.

Let us step into the future and upgrade to Node.js v20.20.0. For the code.. for the team.. but mostly for the commit-padding.

Please approve at your earliest convenience, before the cosmic rays align and it's too late.

## References

- <https://www.almanac.com/content/mercury-retrograde-dates>
