### PR TITLE
fix(frontend): fixed request pages allowing editing while the request isn't editable

### DIFF
--- a/frontend/app/routes/hiring-manager/request/process-information.tsx
+++ b/frontend/app/routes/hiring-manager/request/process-information.tsx
@@ -17,6 +17,7 @@ import { requireAuthentication } from '~/.server/utils/auth-utils';
 import { mapRequestToUpdateModelWithOverrides } from '~/.server/utils/request-utils';
 import { i18nRedirect } from '~/.server/utils/route-utils';
 import { BackLink } from '~/components/back-link';
+import { REQUEST_STATUS_CODE } from '~/domain/constants';
 import { HttpStatusCodes } from '~/errors/http-status-codes';
 import { getTranslation } from '~/i18n-config.server';
 import { handle as parentHandle } from '~/routes/layout';
@@ -54,6 +55,9 @@ export async function action({ context, params, request }: Route.ActionArgs) {
   }
 
   const requestData: RequestReadModel = requestResult.unwrap();
+  if (!requestData.status || requestData.status.code !== REQUEST_STATUS_CODE.DRAFT) {
+    throw new Response('Cannot edit request', { status: HttpStatusCodes.BAD_REQUEST });
+  }
 
   const requestPayload: RequestUpdateModel = mapRequestToUpdateModelWithOverrides(requestData, {
     selectionProcessNumber: parseResult.output.selectionProcessNumber,
@@ -90,6 +94,10 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 
   if (!requestData) {
     throw new Response('Request not found', { status: HttpStatusCodes.NOT_FOUND });
+  }
+
+  if (!requestData.status || requestData.status.code !== REQUEST_STATUS_CODE.DRAFT) {
+    throw new Response('Cannot edit request', { status: HttpStatusCodes.NOT_FOUND });
   }
 
   const { lang, t } = await getTranslation(request, handle.i18nNamespace);


### PR DESCRIPTION
## Summary

- `Process Information`, `Position Information`, `Submission Details` pages now check if the request is a `Draft` before allowing editing.
- Refactored the "check if the request is a `Draft`"  within the `action()` of `Statement of Merit` page

## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [x] added adequate logging for new or updated functionality
- [x] ensured metrics and/or tracing are in place for monitoring and debugging
- [x] documentation has been updated to reflect the changes (if applicable)
- [x] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

<img width="1520" height="428" alt="image" src="https://github.com/user-attachments/assets/5f0f2318-2acd-4548-945e-3dac85638ab7" />

<hr/>

> Trying to access `/en/hiring-manager/request/3/position-information`

<img width="1545" height="532" alt="image" src="https://github.com/user-attachments/assets/9c8e8534-8f88-422d-a0b0-86ee9e61cfe7" />