### PR TITLE
feat(frontend/backend): hiring manager request submission API integration

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/RequestService.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/service/RequestService.java
@@ -321,7 +321,7 @@ public class RequestService {
 		request.setRequestStatus(getRequestStatusByCode(requestStatuses.submitted()));
 
 		// Send notification
-		sendRequestCreatedNotification(request);
+		// sendRequestCreatedNotification(request);
 
 		return request;
 	}

--- a/frontend/app/.server/domain/models.ts
+++ b/frontend/app/.server/domain/models.ts
@@ -1,3 +1,5 @@
+import type { RequestEventType } from '~/domain/constants';
+
 // Generic base types for all lookup models
 export type LookupModel = Readonly<{
   id: number;
@@ -70,6 +72,10 @@ export type LocalizedProfileStatus = LocalizedLookupModel;
 
 export type RequestStatus = LookupModel;
 export type LocalizedRequestStatus = LocalizedLookupModel;
+
+export type RequestStatusUpdate = Readonly<{
+  eventType: RequestEventType;
+}>;
 
 export type SecurityClearance = LookupModel;
 export type LocalizedSecurityClearance = LocalizedLookupModel;

--- a/frontend/app/.server/domain/services/request-service-default.ts
+++ b/frontend/app/.server/domain/services/request-service-default.ts
@@ -8,6 +8,7 @@ import type {
   CollectionRequestResponse,
   RequestQueryParams,
   PagedProfileResponse,
+  RequestStatusUpdate,
 } from '~/.server/domain/models';
 import { apiClient } from '~/.server/domain/services/api-client';
 import type { RequestService } from '~/.server/domain/services/request-service';
@@ -136,11 +137,15 @@ export function getDefaultRequestService(): RequestService {
     /**
      * Updates a request's status.
      */
-    async updateRequestStatus(requestId: number, eventType: string, accessToken: string): Promise<Result<void, AppError>> {
-      const result = await apiClient.put<unknown, undefined>(
+    async updateRequestStatus(
+      requestId: number,
+      statusUpdate: RequestStatusUpdate,
+      accessToken: string,
+    ): Promise<Result<RequestReadModel, AppError>> {
+      const result = await apiClient.put<RequestStatusUpdate, RequestReadModel>(
         `/requests/${requestId}/status-change`,
         `update request status for ID ${requestId}`,
-        eventType,
+        statusUpdate,
         accessToken,
       );
 
@@ -157,7 +162,7 @@ export function getDefaultRequestService(): RequestService {
         );
       }
 
-      return Ok(undefined);
+      return Ok(result.unwrap());
     },
 
     /**

--- a/frontend/app/.server/domain/services/request-service.ts
+++ b/frontend/app/.server/domain/services/request-service.ts
@@ -7,6 +7,7 @@ import type {
   CollectionRequestResponse,
   RequestQueryParams,
   PagedProfileResponse,
+  RequestStatusUpdate,
 } from '~/.server/domain/models';
 import { getDefaultRequestService } from '~/.server/domain/services/request-service-default';
 import { getMockRequestService } from '~/.server/domain/services/request-service-mock';
@@ -34,7 +35,11 @@ export type RequestService = {
   ): Promise<Result<RequestReadModel, AppError>>;
 
   // PUT /api/v1/requests/{id}/status-change - Update request status
-  updateRequestStatus(requestId: number, eventType: string, accessToken: string): Promise<Result<void, AppError>>;
+  updateRequestStatus(
+    requestId: number,
+    statusUpdate: RequestStatusUpdate,
+    accessToken: string,
+  ): Promise<Result<RequestReadModel, AppError>>;
 
   // DELETE /api/v1/requests/{id} - Delete a request by ID
   deleteRequestById(requestId: number, accessToken: string): Promise<Result<void, AppError>>;

--- a/frontend/app/domain/constants.ts
+++ b/frontend/app/domain/constants.ts
@@ -289,4 +289,11 @@ export const SELECTION_PROCESS_TYPE = {
 export const REQUEST_EVENT_TYPE = {
   submitted: 'requestSubmitted',
   pickedUp: 'requestPickedUp',
-};
+  vmsNotRequired: 'vmsNotRequired',
+  submitFeedback: 'submitFeedback',
+  pscNotRequired: 'pscNotRequired',
+  pscRequired: 'pscRequired',
+  complete: 'complete',
+} as const;
+
+export type RequestEventType = (typeof REQUEST_EVENT_TYPE)[keyof typeof REQUEST_EVENT_TYPE];

--- a/frontend/app/routes/hiring-manager/request/index.tsx
+++ b/frontend/app/routes/hiring-manager/request/index.tsx
@@ -170,7 +170,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
 
   const submitResult = await getRequestService().updateRequestStatus(
     Number(params.requestId),
-    REQUEST_EVENT_TYPE.submitted,
+    { eventType: REQUEST_EVENT_TYPE.submitted },
     session.authState.accessToken,
   );
 
@@ -183,9 +183,11 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     };
   }
 
+  const updatedRequest = submitResult.unwrap();
+
   return {
     status: 'submitted',
-    requestStatus: submitResult.unwrap(),
+    requestStatus: updatedRequest.status,
   };
 }
 


### PR DESCRIPTION
This pull request refactors the request status update functionality across both the frontend and backend, improving type safety and extensibility. The main change is replacing the previous string-based status update with a new `RequestStatusUpdate` object, which uses an explicit event type. This update affects service interfaces, implementations, and related constants, and also expands the set of supported request event types.

**API and Service Layer Refactoring:**

* The `RequestService` interface and its implementations (`request-service-default.ts`, `request-service-mock.ts`) now use a `RequestStatusUpdate` object instead of a raw string for status changes. The return type is updated to provide the updated `RequestReadModel` instead of just `void`. [[1]](diffhunk://#diff-144b7fa2790d469ea80cdddbc808973dbea2ff393c00c89d6a2d7ccdd257546eL37-R42) [[2]](diffhunk://#diff-253e983259c8cff4afba14aba6ec7b97dec7e4280616f78afe620b45a35f61aeL139-R148) [[3]](diffhunk://#diff-1d538804021606ce2bc27811e3a124aad8ed0e91d8d034396d5ce1fb28737091L256-R261) [[4]](diffhunk://#diff-1d538804021606ce2bc27811e3a124aad8ed0e91d8d034396d5ce1fb28737091L283-R327)

* The mock service now maps all supported event types to their corresponding statuses, allowing more flexible and realistic status transitions for requests.

**Type and Constant Improvements:**

* The `RequestEventType` and `REQUEST_EVENT_TYPE` constant are expanded to include additional events, and a new type definition is added for better type safety throughout the codebase. [[1]](diffhunk://#diff-24a541d918524f04bae24fec428f211d8b74fc3347e970c4085ae9a81759064fL292-R299) [[2]](diffhunk://#diff-4125e7b7867b4c3b61c56b95639d0052e515ac7a8897b59171f5598a8bc0d0d0R1-R2) [[3]](diffhunk://#diff-4125e7b7867b4c3b61c56b95639d0052e515ac7a8897b59171f5598a8bc0d0d0R76-R79)

**Frontend Usage Updates:**

* All usages of the status update API, such as in the request submission route, are updated to use the new `RequestStatusUpdate` object and handle the updated response format. [[1]](diffhunk://#diff-bffa633051e7d6d443233de33ba6816e81070b771f395f66854f2530c619efc0L173-R173) [[2]](diffhunk://#diff-bffa633051e7d6d443233de33ba6816e81070b771f395f66854f2530c619efc0R186-R190)

**Backend Notification Change:**

* The backend temporarily disables the request created notification when handling a submitted request, as it throws an error due to a missing template, which prevents the status update from being applied.