### PR TITLE
feat(frontend): hiring-managers can delete draft requests

### DIFF
--- a/backend/src/main/java/ca/gov/dtsstn/vacman/api/security/OwnershipPermissionEvaluator.java
+++ b/backend/src/main/java/ca/gov/dtsstn/vacman/api/security/OwnershipPermissionEvaluator.java
@@ -17,8 +17,10 @@ import ca.gov.dtsstn.vacman.api.service.RequestService;
 import ca.gov.dtsstn.vacman.api.service.UserService;
 
 /**
- * A custom permission evaluator that checks if the current user is the owner of a given domain object.
- * This is used in conjunction with Spring Security's @PreAuthorize and @PostAuthorize annotations.
+ * A custom permission evaluator that checks if the current user is the owner of
+ * a given domain object.
+ * This is used in conjunction with Spring Security's @PreAuthorize
+ * and @PostAuthorize annotations.
  * <p>
  * It primarily evaluates permissions based on the target object's ID and type.
  */
@@ -33,33 +35,39 @@ public class OwnershipPermissionEvaluator implements PermissionEvaluator {
 
 	private final UserService userService;
 
-	public OwnershipPermissionEvaluator(ProfileService profileService, RequestService requestService, UserService userService) {
+	public OwnershipPermissionEvaluator(ProfileService profileService, RequestService requestService,
+			UserService userService) {
 		this.profileService = profileService;
 		this.requestService = requestService;
 		this.userService = userService;
 	}
 
 	/**
-	 * This implementation is not supported as we favor checking permissions before the object is fetched,
+	 * This implementation is not supported as we favor checking permissions before
+	 * the object is fetched,
 	 * using {@link #hasPermission(Authentication, Serializable, String, Object)}.
 	 */
 	@Override
 	public boolean hasPermission(Authentication authentication, Object targetDomainObject, Object permission) {
-		throw new UnsupportedOperationException("ID based permission evaluation is required. Use hasPermission(Authentication, Serializable, String, Object).");
+		throw new UnsupportedOperationException(
+				"ID based permission evaluation is required. Use hasPermission(Authentication, Serializable, String, Object).");
 	}
 
 	/**
-	 * Determines if a user has a given permission for a target resource, identified by its id and type.
-	 * The primary check is to verify if the authenticated user is the owner of the target entity.
+	 * Determines if a user has a given permission for a target resource, identified
+	 * by its id and type.
+	 * The primary check is to verify if the authenticated user is the owner of the
+	 * target entity.
 	 */
 	@Override
-	public boolean hasPermission(Authentication authentication, Serializable targetId, String targetType, Object permission) {
+	public boolean hasPermission(Authentication authentication, Serializable targetId, String targetType,
+			Object permission) {
 		final var currentUserId = userService.getUserByMicrosoftEntraId(authentication.getName()).map(UserEntity::getId);
 
 		if (currentUserId.isEmpty()) {
 			log.warn("Access denied: user not found; "
-				+ "permission=[{}], targetType=[{}], targetId=[{}]",
-				permission, targetType, targetId);
+					+ "permission=[{}], targetType=[{}], targetId=[{}]",
+					permission, targetType, targetId);
 			return false;
 		}
 
@@ -67,8 +75,8 @@ public class OwnershipPermissionEvaluator implements PermissionEvaluator {
 
 		if (targetResource.isEmpty()) {
 			log.warn("Access denied: resource does not exist; "
-				+ "permission=[{}], targetType=[{}], targetId=[{}], currentUserId=[{}]",
-				permission, targetType, targetId, currentUserId.get());
+					+ "permission=[{}], targetType=[{}], targetId=[{}], currentUserId=[{}]",
+					permission, targetType, targetId, currentUserId.get());
 			return false;
 		}
 
@@ -77,8 +85,8 @@ public class OwnershipPermissionEvaluator implements PermissionEvaluator {
 
 			if (ownerId.isEmpty()) {
 				log.warn("Access denied: resource does not have an owner; "
-					+ "permission=[{}], targetType=[{}], targetId=[{}], currentUserId=[{}]",
-					permission, targetType, targetId, currentUserId.get());
+						+ "permission=[{}], targetType=[{}], targetId=[{}], currentUserId=[{}]",
+						permission, targetType, targetId, currentUserId.get());
 				return false;
 			}
 
@@ -106,8 +114,8 @@ public class OwnershipPermissionEvaluator implements PermissionEvaluator {
 
 					default: {
 						log.warn("Access denied: user is a delegate but requested non-READ permission; "
-							+ "permission=[{}], targetType=[{}], targetId=[{}], currentUserId=[{}]",
-							permission, targetType, targetId, currentUserId.get());
+								+ "permission=[{}], targetType=[{}], targetId=[{}], currentUserId=[{}]",
+								permission, targetType, targetId, currentUserId.get());
 						return false;
 					}
 				}
@@ -115,8 +123,8 @@ public class OwnershipPermissionEvaluator implements PermissionEvaluator {
 		}
 
 		log.warn("Access denied: "
-			+ "permission=[{}], targetType=[{}], targetId=[{}], currentUserId=[{}]",
-			permission, targetType, targetId, currentUserId.get());
+				+ "permission=[{}], targetType=[{}], targetId=[{}], currentUserId=[{}]",
+				permission, targetType, targetId, currentUserId.get());
 		return false;
 	}
 

--- a/frontend/app/.server/domain/services/request-service-default.ts
+++ b/frontend/app/.server/domain/services/request-service-default.ts
@@ -169,7 +169,13 @@ export function getDefaultRequestService(): RequestService {
      * Deletes a request by its ID.
      */
     async deleteRequestById(requestId: number, accessToken: string): Promise<Result<void, AppError>> {
-      const result = await apiClient.delete(`/requests/${requestId}`, `delete request with ID ${requestId}`, accessToken);
+      console.log(accessToken);
+      const result = await apiClient.delete(
+        `/requests/${requestId}`,
+        `delete request with ID ${requestId}`,
+        undefined,
+        accessToken,
+      );
 
       if (result.isErr()) {
         const error = result.unwrapErr();

--- a/frontend/app/.server/domain/services/request-service-default.ts
+++ b/frontend/app/.server/domain/services/request-service-default.ts
@@ -169,7 +169,6 @@ export function getDefaultRequestService(): RequestService {
      * Deletes a request by its ID.
      */
     async deleteRequestById(requestId: number, accessToken: string): Promise<Result<void, AppError>> {
-      console.log(accessToken);
       const result = await apiClient.delete(
         `/requests/${requestId}`,
         `delete request with ID ${requestId}`,

--- a/frontend/app/.server/locales/app-en.ts
+++ b/frontend/app/.server/locales/app-en.ts
@@ -1,4 +1,5 @@
 export default {
+  'generic-error': 'Something went wrong. Try again later.',
   'index': {
     'about': 'The VacMan initiative!',
     'dashboard': 'Dashboard',
@@ -365,10 +366,12 @@ export default {
     'request-incomplete': 'Please complete all required fields before submitting request',
     'request-submitted': 'Request submitted successfully! An HR advisor will review it for approval',
     'delete-request': {
-      title: 'Delete this request?',
-      content: 'This will permanently delete this request. This action cannot be undone.',
-      keep: 'Keep request',
-      delete: 'Delete request',
+      'title': 'Delete this request?',
+      'content': 'This will permanently delete this request. This action cannot be undone.',
+      'keep': 'Keep request',
+      'delete': 'Delete request',
+      'not-allowed': 'Submitted requests can’t be deleted. Only drafts may be removed.',
+      'error-generic': 'Something went wrong while deleting the request. Try again later.',
     },
     'back': 'Back to requests',
   },

--- a/frontend/app/.server/locales/app-fr.ts
+++ b/frontend/app/.server/locales/app-fr.ts
@@ -1,6 +1,7 @@
 import type appEn from '~/.server/locales/app-en';
 
 export default {
+  'generic-error': 'Une erreur est survenue. Veuillez réessayer plus tard.',
   'index': {
     'about': "L'initiative VacMan!",
     'dashboard': 'Tableau de bord',
@@ -370,10 +371,12 @@ export default {
     'request-incomplete': 'Veuillez remplir tous les champs obligatoires avant de soumettre votre demande',
     'request-submitted': "Demande soumise avec succès! Un-e conseiller(ère) RH va l'examiner pour approbation",
     'delete-request': {
-      title: 'Supprimer cette demande?',
-      content: 'Cela supprimera définitivement la demande. Cette action est irréversible.',
-      keep: 'Conserver la demande',
-      delete: 'Supprimer la demande',
+      'title': 'Supprimer cette demande?',
+      'content': 'Cela supprimera définitivement la demande. Cette action est irréversible.',
+      'keep': 'Conserver la demande',
+      'delete': 'Supprimer la demande',
+      'not-allowed': 'Les demandes déjà soumises ne peuvent pas être supprimées. Seuls les brouillons peuvent être retirés.',
+      'error-generic': 'Une erreur est survenue lors de la suppression de la demande. Veuillez réessayer plus tard.',
     },
     'back': 'Retour aux demandes',
   },

--- a/frontend/app/routes/hiring-manager/request/index.tsx
+++ b/frontend/app/routes/hiring-manager/request/index.tsx
@@ -435,9 +435,6 @@ export default function EditRequest({ loaderData, params }: Route.ComponentProps
   }
   const alertConfig = getAlertConfig();
 
-  const isSubmitted =
-    loaderData.status?.code === REQUEST_STATUS_CODE.SUBMIT || loaderData.status?.code === REQUEST_STATUS_CODE.HR_REVIEW;
-
   type CityPreference = {
     province: string;
     city: string;

--- a/frontend/app/routes/hiring-manager/request/index.tsx
+++ b/frontend/app/routes/hiring-manager/request/index.tsx
@@ -418,19 +418,22 @@ export default function EditRequest({ loaderData, params }: Route.ComponentProps
     defaultValue: 'Something went wrong while deleting the request. Try again later.',
   });
 
-  const alertConfig = fetcher.data
-    ? isActionErrorResult(fetcher.data)
-      ? {
-          type: 'error' as const,
-          message: fetcher.data.errorMessage ?? defaultDeleteErrorMessage,
-        }
-      : {
-          type: loaderData.isRequestComplete ? ('success' as const) : ('error' as const),
-          message: loaderData.isRequestComplete
-            ? t('app:hiring-manager-referral-requests.request-submitted')
-            : t('app:hiring-manager-referral-requests.request-incomplete'),
-        }
-    : undefined;
+  function getAlertConfig() {
+    if (!fetcher.data) return undefined;
+    if (isActionErrorResult(fetcher.data)) {
+      return {
+        type: 'error' as const,
+        message: fetcher.data.errorMessage ?? defaultDeleteErrorMessage,
+      };
+    }
+    return {
+      type: loaderData.isRequestComplete ? ('success' as const) : ('error' as const),
+      message: loaderData.isRequestComplete
+        ? t('app:hiring-manager-referral-requests.request-submitted')
+        : t('app:hiring-manager-referral-requests.request-incomplete'),
+    };
+  }
+  const alertConfig = getAlertConfig();
 
   const isSubmitted =
     loaderData.status?.code === REQUEST_STATUS_CODE.SUBMIT || loaderData.status?.code === REQUEST_STATUS_CODE.HR_REVIEW;

--- a/frontend/app/routes/hiring-manager/request/index.tsx
+++ b/frontend/app/routes/hiring-manager/request/index.tsx
@@ -85,9 +85,7 @@ export async function action({ context, params, request }: Route.ActionArgs) {
     if (requestData.status?.code !== REQUEST_STATUS_CODE.DRAFT) {
       return {
         status: 'error',
-        errorMessage: t('app:hiring-manager-referral-requests.delete-request.not-allowed', {
-          defaultValue: 'Only draft requests can be deleted.',
-        }),
+        errorMessage: t('app:hiring-manager-referral-requests.delete-request.not-allowed'),
         errorCode: 'REQUEST_DELETE_NOT_ALLOWED',
       };
     }
@@ -414,9 +412,7 @@ export default function EditRequest({ loaderData, params }: Route.ComponentProps
     }
   }, [isDeleting, showDialog]);
 
-  const defaultDeleteErrorMessage = t('app:hiring-manager-referral-requests.delete-request.error-generic', {
-    defaultValue: 'Something went wrong while deleting the request. Try again later.',
-  });
+  const defaultDeleteErrorMessage = t('app:hiring-manager-referral-requests.delete-request.error-generic');
 
   function getAlertConfig() {
     if (!fetcher.data) return undefined;

--- a/frontend/app/routes/hiring-manager/request/index.tsx
+++ b/frontend/app/routes/hiring-manager/request/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
 import type { RouteHandle } from 'react-router';
 import { useFetcher } from 'react-router';
@@ -395,7 +395,6 @@ export default function EditRequest({ loaderData, params }: Route.ComponentProps
   const fetcher = useFetcher<typeof action>();
   const fetcherState = useFetcherState(fetcher);
   const isSubmitting = fetcherState.submitting;
-  const isDeleting = fetcherState.submitting && fetcherState.action === 'delete';
 
   const alertRef = useRef<HTMLDivElement>(null);
 
@@ -405,12 +404,6 @@ export default function EditRequest({ loaderData, params }: Route.ComponentProps
   }
 
   const [showDialog, setShowDialog] = useState(false);
-
-  useEffect(() => {
-    if (isDeleting && showDialog) {
-      setShowDialog(false);
-    }
-  }, [isDeleting, showDialog]);
 
   const defaultDeleteErrorMessage = t('app:hiring-manager-referral-requests.delete-request.error-generic');
 
@@ -884,7 +877,14 @@ export default function EditRequest({ loaderData, params }: Route.ComponentProps
               </Button>
             </DialogClose>
             <fetcher.Form method="post" noValidate>
-              <Button id="delete-request" variant="red" name="action" value="delete" disabled={isSubmitting}>
+              <Button
+                id="delete-request"
+                variant="red"
+                name="action"
+                value="delete"
+                disabled={isSubmitting}
+                onClick={() => setShowDialog(false)}
+              >
                 {t('app:hiring-manager-referral-requests.delete-request.delete')}
               </Button>
             </fetcher.Form>

--- a/frontend/app/routes/hiring-manager/request/index.tsx
+++ b/frontend/app/routes/hiring-manager/request/index.tsx
@@ -415,9 +415,7 @@ export default function EditRequest({ loaderData, params }: Route.ComponentProps
   }, [isDeleting, showDialog]);
 
   const defaultDeleteErrorMessage = t('app:hiring-manager-referral-requests.delete-request.error-generic', {
-    defaultValue: t('app:generic-error', {
-      defaultValue: 'Something went wrong while deleting the request. Try again later.',
-    }),
+    defaultValue: 'Something went wrong while deleting the request. Try again later.',
   });
 
   const alertConfig = fetcher.data

--- a/frontend/app/routes/hiring-manager/request/index.tsx
+++ b/frontend/app/routes/hiring-manager/request/index.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import type { RouteHandle } from 'react-router';
 import { useFetcher } from 'react-router';
@@ -395,6 +395,7 @@ export default function EditRequest({ loaderData, params }: Route.ComponentProps
   const fetcher = useFetcher<typeof action>();
   const fetcherState = useFetcherState(fetcher);
   const isSubmitting = fetcherState.submitting;
+  const isDeleting = fetcherState.submitting && fetcherState.action === 'delete';
 
   const alertRef = useRef<HTMLDivElement>(null);
 
@@ -404,6 +405,12 @@ export default function EditRequest({ loaderData, params }: Route.ComponentProps
   }
 
   const [showDialog, setShowDialog] = useState(false);
+
+  useEffect(() => {
+    if (isDeleting && showDialog) {
+      setShowDialog(false);
+    }
+  }, [isDeleting, showDialog]);
 
   const defaultDeleteErrorMessage = t('app:hiring-manager-referral-requests.delete-request.error-generic');
 
@@ -877,14 +884,7 @@ export default function EditRequest({ loaderData, params }: Route.ComponentProps
               </Button>
             </DialogClose>
             <fetcher.Form method="post" noValidate>
-              <Button
-                id="delete-request"
-                variant="red"
-                name="action"
-                value="delete"
-                disabled={isSubmitting}
-                onClick={() => setShowDialog(false)}
-              >
+              <Button id="delete-request" variant="red" name="action" value="delete" disabled={isSubmitting}>
                 {t('app:hiring-manager-referral-requests.delete-request.delete')}
               </Button>
             </fetcher.Form>


### PR DESCRIPTION
**Backend**

- `OwnershipPermissionEvaluator.java`
  - Improved code formatting and readability in comments and method signatures.


**Frontend**

- Request Service
  - Fixed the deleteRequestById method to correctly pass the accessToken as the fourth argument to the API client.

**Localization**

- Added generic error messages for both English and French.
- Expanded delete request error messages, including a specific message for when deletion is not allowed (submitted requests).


**Hiring Manager View Request Page**

  - Added type guard and error result type for action errors.
  - Updated the delete action to prevent deletion of non-draft requests, returning a localized error message if attempted.
  - Improved alert message logic:
    - Introduced a helper function (getAlertConfig) to determine alert type and message, replacing a nested ternary for better readability.
    - Alert now displays specific error messages from the action result, with a fallback to a generic error.
  - Added UI feedback for delete-in-progress state (closes dialog when deleting).
  - General code cleanup and improved maintainability.