### PR TITLE
feat(frontend): add sanitizePositionNumber utility function and use it in PositionInformationForm

### DIFF
--- a/frontend/app/routes/page-components/requests/position-information/form.tsx
+++ b/frontend/app/routes/page-components/requests/position-information/form.tsx
@@ -34,6 +34,7 @@ import { PageTitle } from '~/components/page-title';
 import { LANGUAGE_LEVEL, LANGUAGE_REQUIREMENT_CODES } from '~/domain/constants';
 import type { I18nRouteFile } from '~/i18n-routes';
 import type { Errors } from '~/routes/page-components/requests/validation.server';
+import { sanitizePositionNumber } from '~/utils/request-utils';
 import { extractValidationKey } from '~/utils/validation-utils';
 
 interface PositionInformationFormProps {
@@ -61,6 +62,8 @@ export function PositionInformationForm({
 }: PositionInformationFormProps): JSX.Element {
   const { t: tApp } = useTranslation('app');
   const { t: tGcweb } = useTranslation('gcweb');
+
+  const defaultPositionNumber = sanitizePositionNumber(formValues?.positionNumber) ?? '';
 
   const [province, setProvince] = useState(
     formValues?.cities?.[0]?.provinceTerritory.id !== undefined ? String(formValues.cities[0].provinceTerritory.id) : undefined,
@@ -163,7 +166,7 @@ export function PositionInformationForm({
               id="position-number"
               name="positionNumber"
               label={tApp('position-information.position-number')}
-              defaultValue={formValues?.positionNumber}
+              defaultValue={defaultPositionNumber}
               errorMessage={tApp(extractValidationKey(formErrors?.positionNumber))}
               helpMessagePrimary={tApp('position-information.position-number-instruction')}
               required

--- a/frontend/app/utils/request-utils.ts
+++ b/frontend/app/utils/request-utils.ts
@@ -1,0 +1,16 @@
+export function sanitizePositionNumber(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+
+  if (trimmed.toLowerCase() === 'null') {
+    return undefined;
+  }
+
+  return trimmed;
+}

--- a/frontend/app/utils/request-utils.ts
+++ b/frontend/app/utils/request-utils.ts
@@ -1,3 +1,18 @@
+/**
+ * Sanitizes a position number value by converting it to a trimmed string or undefined.
+ *
+ * @param value - The input value to sanitize, can be of any type
+ * @returns The sanitized string value, or undefined if the input is invalid, empty, or "null"
+ *
+ * @example
+ * ```typescript
+ * sanitizePositionNumber("  123  ") // returns "123"
+ * sanitizePositionNumber("null") // returns undefined
+ * sanitizePositionNumber("") // returns undefined
+ * sanitizePositionNumber(123) // returns undefined
+ * sanitizePositionNumber("valid-position") // returns "valid-position"
+ * ```
+ */
 export function sanitizePositionNumber(value: unknown): string | undefined {
   if (typeof value !== 'string') {
     return undefined;


### PR DESCRIPTION
[Task 7191
](https://dev.azure.com/DTS-STN/VacMan/_boards/board/t/VacMan%20Team/Stories?System.IterationPath=VacMan%5CCurrent%20Work%2CVacMan%5CMVP%20Iteration%202&workitem=7191)

This pull request improves how the `positionNumber` field is handled in the position information form by ensuring that any invalid or placeholder values are sanitized before being displayed or processed. The main focus is on preventing empty strings or the string 'null' that we receive after saving partial updates from other sections, from appearing as default values in the form input.

Key changes:

**Form Data Sanitization**
- Added a new utility function `sanitizePositionNumber` in `request-utils.ts` to clean up the `positionNumber` value by trimming whitespace and filtering out empty strings or the string 'null'.

**Form Component Updates**
- Updated the `PositionInformationForm` component to use the sanitized `positionNumber` value as the default input, ensuring a cleaner user experience. [[1]](diffhunk://#diff-1c388e4c3bd4749a8afdc64d95a02c90023e48d303366e5d184c931b67a4eae8R37) [[2]](diffhunk://#diff-1c388e4c3bd4749a8afdc64d95a02c90023e48d303366e5d184c931b67a4eae8R66-R67) [[3]](diffhunk://#diff-1c388e4c3bd4749a8afdc64d95a02c90023e48d303366e5d184c931b67a4eae8L166-R169)