### PR TITLE
fix(frontend): selection process number no longer required

### DIFF
--- a/frontend/app/.server/locales/app-en.ts
+++ b/frontend/app/.server/locales/app-en.ts
@@ -238,7 +238,7 @@ export default {
     'yes': 'Yes',
     'no': 'No',
     'errors': {
-      'selection-process-number-required': 'Selection process number is required',
+      'selection-process-number-invalid': 'Selection process number is invalid',
       'approval-received-required': 'Approval received is required',
       'performed-duties-required': 'Performed duties is required',
       'priority-entitlement-rationale-required': 'Priority entitlement rationale is required',

--- a/frontend/app/.server/locales/app-fr.ts
+++ b/frontend/app/.server/locales/app-fr.ts
@@ -241,7 +241,7 @@ export default {
     'yes': 'Oui',
     'no': 'Non',
     'errors': {
-      'selection-process-number-required': 'Numéro du processus de sélection est requis',
+      'selection-process-number-invalid': 'Le numéro du processus de sélection est invalide',
       'approval-received-required': 'Approbation reçue est requise',
       'performed-duties-required': 'Exercé les mêmes fonctions est requis',
       'priority-entitlement-rationale-required': "Nomination d'un bénéficiaire de priorité est requise",

--- a/frontend/app/routes/page-components/requests/validation.server.ts
+++ b/frontend/app/routes/page-components/requests/validation.server.ts
@@ -334,10 +334,12 @@ export async function createProcessInformationSchema() {
   return v.pipe(
     v.intersect([
       v.object({
-        selectionProcessNumber: v.pipe(
-          v.string('app:process-information.errors.selection-process-number-required'),
-          v.trim(),
-          v.nonEmpty('app:process-information.errors.selection-process-number-required'),
+        selectionProcessNumber: v.optional(
+          v.pipe(
+            v.string('app:process-information.errors.selection-process-number-invalid'),
+            v.trim(),
+            v.nonEmpty('app:process-information.errors.selection-process-number-invalid'),
+          ),
         ),
         approvalReceived: v.pipe(v.boolean('app:process-information.errors.approval-received-required')),
         workSchedule: v.pipe(


### PR DESCRIPTION
This pull request updates the validation logic and error messaging for the selection process number field in both English and French locales, as well as in the form validation schema. The main focus is to provide a more accurate error message when the selection process number is invalid, rather than just missing, and to adjust the validation logic accordingly.

**Validation and error message improvements:**

* Changed the error message for the selection process number from "required" to "invalid" in both English (`app-en.ts`) and French (`app-fr.ts`) locale files to better reflect validation errors. [[1]](diffhunk://#diff-c66a209c5fef0d4d98edf70489cfdb2984a3ad3dd1644b6a7e7206f45c48a304L241-R241) [[2]](diffhunk://#diff-bfa4fd2b422d9379133c2ec7d691186e037bcc1bbbd45f60d83910a525d578eaL244-R244)
* Updated the validation schema in `validation.server.ts` to use the "invalid" error message and adjusted the logic to use `v.optional` for the `selectionProcessNumber` field, improving how missing and invalid values are handled.