### PR TITLE
fix(frontend): validation for future date check on projected end date

### DIFF
--- a/frontend/app/.server/locales/app-en.ts
+++ b/frontend/app/.server/locales/app-en.ts
@@ -258,6 +258,7 @@ export default {
       'projected-end-date': {
         'invalid': 'Projected end date is invalid',
         'invalid-before-start-date': 'Projected end date must be after the start date',
+        'invalid-future': 'Projected end date must be after today',
         'required-year': 'Year of Projected end date is required',
         'invalid-year': 'Year of Projected end date is invalid',
         'required-month': 'Month of Projected end date is required',

--- a/frontend/app/.server/locales/app-fr.ts
+++ b/frontend/app/.server/locales/app-fr.ts
@@ -261,6 +261,7 @@ export default {
       'projected-end-date': {
         'invalid': "La date de fin prévue n'est pas valide",
         'invalid-before-start-date': 'La date de fin prévue doit être postérieure à la date de début prévue',
+        'invalid-future': "La date de fin prévue doit être postérieure à aujourd'hui",
         'required-year': "L'année de la date de fin prévue est requise",
         'invalid-year': "L'année de la date de fin prévue n'est pas valide",
         'required-month': 'Le mois de la date de fin prévue est requis',

--- a/frontend/app/routes/page-components/requests/validation.server.ts
+++ b/frontend/app/routes/page-components/requests/validation.server.ts
@@ -9,10 +9,11 @@ import { getNonAdvertisedAppointmentService } from '~/.server/domain/services/no
 import { getProvinceService } from '~/.server/domain/services/province-service';
 import { getSelectionProcessTypeService } from '~/.server/domain/services/selection-process-type-service';
 import { getWorkUnitService } from '~/.server/domain/services/workunit-service';
+import { serverEnvironment } from '~/.server/environment';
 import { extractUniqueBranchesFromDirectoratesNonLocalized } from '~/.server/utils/directorate-utils';
 import { stringToIntegerSchema } from '~/.server/validation/string-to-integer-schema';
 import { EMPLOYMENT_TENURE, LANGUAGE_REQUIREMENT_CODES, REQUIRE_OPTIONS, SELECTION_PROCESS_TYPE } from '~/domain/constants';
-import { formatISODate, isValidDateString } from '~/utils/date-utils';
+import { formatISODate, isPastOrTodayInTimeZone, isValidDateString } from '~/utils/date-utils';
 import { formString } from '~/utils/string-utils';
 
 export type PositionInformationSchema = Awaited<ReturnType<typeof createPositionInformationSchema>>;
@@ -465,6 +466,10 @@ export async function createProcessInformationSchema() {
               v.custom(
                 (input) => isValidDateString(input as string),
                 'app:process-information.errors.projected-end-date.invalid',
+              ),
+              v.custom(
+                (input) => !isPastOrTodayInTimeZone(serverEnvironment.BASE_TIMEZONE, input as string),
+                'app:process-information.errors.projected-end-date.invalid-future',
               ),
             ),
           }),


### PR DESCRIPTION
## Summary

[AB#7202](https://dev.azure.com/DTS-STN/VacMan/_workitems/edit/7202)
Added validation for the projected end date in `process-information.tsx` to check if the date is after today.

## Types of changes

What types of changes does this PR introduce?
_(check all that apply by placing an `x` in the relevant boxes)_

- [ ] 🛠️ **refactoring** -- non-breaking change that improves code readability or structure
- [x] 🐛 **bugfix** -- non-breaking change that fixes an issue
- [ ] ✨ **new feature** -- non-breaking change that adds functionality
- [ ] 💥 **breaking change** -- change that causes existing functionality to no longer work as expected
- [ ] 📚 **documentation** -- changes to documentation only
- [ ] ⚙️ **build or tooling** -- ex: CI/CD, dependency upgrades

## Checklist

Before submitting this PR, ensure that you have completed the following. You can fill these out now, or after creating the PR.
_(check all that apply by placing an `x` in the relevant boxes)_

- [x] code has been linted and formatted locally
- [x] added or updated tests to verify the changes
- [x] added adequate logging for new or updated functionality
- [x] ensured metrics and/or tracing are in place for monitoring and debugging
- [x] documentation has been updated to reflect the changes (if applicable)
- [x] linked this PR to a related issue (if applicable)

<details>
  <summary>Linting and formatting</summary>

```shell
pnpm run lint:check
pnpm run format:check
```

</details>

<details>
  <summary>Unit and e2e tests</summary>

```shell
pnpm run test
pnpm run test:e2e
```

</details>

## Additional Notes

If this PR introduces significant changes, explain your reasoning and provide any necessary context here. Feel free to include diagrams, screenshots, or alternative approaches you considered.

## Screenshots (if applicable)

<img width="687" height="222" alt="image" src="https://github.com/user-attachments/assets/c0332088-a230-4e0c-afbb-402e5a979e6b" />
