### PR TITLE
fix(frontend): process-information labels should be clearer

### DIFF
--- a/frontend/app/.server/locales/app-en.ts
+++ b/frontend/app/.server/locales/app-en.ts
@@ -219,7 +219,7 @@ export default {
       'Approval received from the Workforce Management Committee (Non-EX positions) or the People Management Leadership Committee (EX positions) (required)',
     'priority-entitlement':
       'Would the appointment of a priority person result in a priority entitlement for another indeterminate employee?',
-    'priority-entitlement-rationale': 'Please provide the rationale',
+    'priority-entitlement-rationale': 'Please provide the rationale (required)',
     'rationale': 'Rationale',
     'selection-process-type': 'Selection process type',
     'performed-duties':

--- a/frontend/app/.server/locales/app-en.ts
+++ b/frontend/app/.server/locales/app-en.ts
@@ -219,7 +219,7 @@ export default {
       'Approval received from the Workforce Management Committee (Non-EX positions) or the People Management Leadership Committee (EX positions) (required)',
     'priority-entitlement':
       'Would the appointment of a priority person result in a priority entitlement for another indeterminate employee?',
-    'priority-entitlement-rationale': 'Please provide the rationale (required)',
+    'priority-entitlement-rationale': 'Please provide the rationale',
     'rationale': 'Rationale',
     'selection-process-type': 'Selection process type',
     'performed-duties':

--- a/frontend/app/.server/locales/app-en.ts
+++ b/frontend/app/.server/locales/app-en.ts
@@ -216,7 +216,7 @@ export default {
     'page-title': 'Process information',
     'selection-process-number': 'Selection process number (if applicable)',
     'approval-received':
-      'Approval received from the Workforce Management Committee (Non-EX positions) or the People Management Leadership Committee (EX positions)',
+      'Approval received from the Workforce Management Committee (Non-EX positions) or the People Management Leadership Committee (EX positions) (required)',
     'priority-entitlement':
       'Would the appointment of a priority person result in a priority entitlement for another indeterminate employee?',
     'priority-entitlement-rationale': 'Please provide the rationale',

--- a/frontend/app/.server/locales/app-fr.ts
+++ b/frontend/app/.server/locales/app-fr.ts
@@ -222,7 +222,7 @@ export default {
       'Approbation reçue du Comité de gestion des effectifs (postes non-EX) ou du Comité de gestion des personnes et du leadership (postes EX) (obligatoire)',
     'priority-entitlement':
       "Est-ce que la nomination d'un bénéficiaire de priorité aurait pour effet de conférer un droit de priorité à un-e autre fonctionnaire nommé-e pour une période indéterminée?",
-    'priority-entitlement-rationale': 'Veuillez fournir la justification (obligatoire)',
+    'priority-entitlement-rationale': 'Veuillez fournir la justification',
     'rationale': 'Justification',
     'selection-process-type': 'Type de processus de sélection',
     'performed-duties':

--- a/frontend/app/.server/locales/app-fr.ts
+++ b/frontend/app/.server/locales/app-fr.ts
@@ -219,7 +219,7 @@ export default {
     'page-title': 'Informations sur le processus',
     'selection-process-number': 'Numéro du processus de sélection (si applicable)',
     'approval-received':
-      'Approbation reçue du Comité de gestion des effectifs (postes non-EX) ou du Comité de gestion des personnes et du leadership (postes EX)',
+      'Approbation reçue du Comité de gestion des effectifs (postes non-EX) ou du Comité de gestion des personnes et du leadership (postes EX) (obligatoire)',
     'priority-entitlement':
       "Est-ce que la nomination d'un bénéficiaire de priorité aurait pour effet de conférer un droit de priorité à un-e autre fonctionnaire nommé-e pour une période indéterminée?",
     'priority-entitlement-rationale': 'Veuillez fournir la justification',

--- a/frontend/app/.server/locales/app-fr.ts
+++ b/frontend/app/.server/locales/app-fr.ts
@@ -222,7 +222,7 @@ export default {
       'Approbation reçue du Comité de gestion des effectifs (postes non-EX) ou du Comité de gestion des personnes et du leadership (postes EX) (obligatoire)',
     'priority-entitlement':
       "Est-ce que la nomination d'un bénéficiaire de priorité aurait pour effet de conférer un droit de priorité à un-e autre fonctionnaire nommé-e pour une période indéterminée?",
-    'priority-entitlement-rationale': 'Veuillez fournir la justification',
+    'priority-entitlement-rationale': 'Veuillez fournir la justification (obligatoire)',
     'rationale': 'Justification',
     'selection-process-type': 'Type de processus de sélection',
     'performed-duties':

--- a/frontend/app/routes/page-components/requests/process-information/form.tsx
+++ b/frontend/app/routes/page-components/requests/process-information/form.tsx
@@ -197,6 +197,7 @@ export function ProcessInformationForm({
               name="approvalReceived"
               defaultChecked={formValues?.approvalReceived}
               errorMessage={tApp(extractValidationKey(formErrors?.approvalReceived))}
+              required
             >
               {tApp('process-information.approval-received')}
             </InputCheckbox>

--- a/frontend/app/routes/page-components/requests/process-information/form.tsx
+++ b/frontend/app/routes/page-components/requests/process-information/form.tsx
@@ -217,6 +217,7 @@ export function ProcessInformationForm({
                 defaultValue={formValues?.priorityEntitlementRationale}
                 errorMessage={tApp(extractValidationKey(formErrors?.priorityEntitlementRationale))}
                 maxLength={100}
+                required
               />
             )}
             <InputSelect


### PR DESCRIPTION
This pull request introduces a small but important update to the process information form and its related translations. The main change is to clarify that approval from the relevant committee is required, and to enforce this requirement in the form.

**Form validation and translation improvements:**

* Marked the "approval received" field as required in both the English and French translation files to clarify that this information is mandatory. [[1]](diffhunk://#diff-c66a209c5fef0d4d98edf70489cfdb2984a3ad3dd1644b6a7e7206f45c48a304L219-R219) [[2]](diffhunk://#diff-bfa4fd2b422d9379133c2ec7d691186e037bcc1bbbd45f60d83910a525d578eaL222-R222)
* Added the `required` attribute to the `priorityEntitlementRationale` field in the `ProcessInformationForm` component to ensure users cannot submit the form without providing this information only if there is an affirmative priority entitlements.