### PR TITLE
fix: remove selectionProcessNumber from required process fields

### DIFF
--- a/frontend/app/routes/hiring-manager/request/index.tsx
+++ b/frontend/app/routes/hiring-manager/request/index.tsx
@@ -107,7 +107,6 @@ export async function action({ context, params, request }: Route.ActionArgs) {
 
   // For process information from Request Model
   const requiredProcessFields = {
-    selectionProcessNumber: requestData.selectionProcessNumber,
     workforceMgmtApprovalRecvd: requestData.workforceMgmtApprovalRecvd,
     priorityEntitlement: requestData.priorityEntitlement,
     workSchedule: requestData.workSchedule,
@@ -228,7 +227,6 @@ export async function loader({ context, request, params }: Route.LoaderArgs) {
 
   // Process information from Request type
   const requiredProcessInformation = {
-    selectionProcessNumber: requestData.selectionProcessNumber,
     workforceMgmtApprovalRecvd: requestData.workforceMgmtApprovalRecvd,
     priorityEntitlement: requestData.priorityEntitlement,
     workSchedule: requestData.workSchedule,


### PR DESCRIPTION
This pull request makes a small change to the process information handling in the hiring manager request route. Specifically, it removes the `selectionProcessNumber` field from the required process fields in both the `action` and `loader` functions. This streamlines the required data for processing requests.